### PR TITLE
sc2: Moving pulsars to advanced logic only in protoss basic anti-air

### DIFF
--- a/worlds/sc2/rules.py
+++ b/worlds/sc2/rules.py
@@ -1346,16 +1346,22 @@ class SC2Logic:
                     item_names.MISTWING,
                     item_names.CALADRIUS,
                     item_names.OPPRESSOR,
-                    item_names.PULSAR,
                     item_names.DRAGOON,
                 },
                 self.player,
             )
-            or state.has_all({item_names.TRIREME, item_names.TRIREME_SOLAR_BEAM}, self.player)
-            or state.has_all({item_names.WRATHWALKER, item_names.WRATHWALKER_AERIAL_TRACKING}, self.player)
-            or state.has_all({item_names.WARP_PRISM, item_names.WARP_PRISM_PHASE_BLASTER}, self.player)
-            or self.advanced_tactics
-            and state.has_any({item_names.HIGH_TEMPLAR, item_names.SIGNIFIER, item_names.SENTRY, item_names.ENERGIZER}, self.player)
+            or state.has_all((item_names.TRIREME, item_names.TRIREME_SOLAR_BEAM), self.player)
+            or state.has_all((item_names.WRATHWALKER, item_names.WRATHWALKER_AERIAL_TRACKING), self.player)
+            or state.has_all((item_names.WARP_PRISM, item_names.WARP_PRISM_PHASE_BLASTER), self.player)
+            or (self.advanced_tactics
+                and state.has_any((
+                    item_names.HIGH_TEMPLAR,
+                    item_names.SIGNIFIER,
+                    item_names.SENTRY,
+                    item_names.ENERGIZER,
+                    item_names.PULSAR,
+                ), self.player)
+            )
             or self.protoss_can_merge_archon(state)
             or self.protoss_can_merge_dark_archon(state)
         )


### PR DESCRIPTION
## What is this fixing or adding?
Brought up by Shirasho today in the discord that they thought they were required to beat Spear of Adun.

> They are my logical unit for protoss, and they simply dont do enough damage or have enough health to survive. They also cost too much for what they bring.
> 17 of them took 6 seconds to kill a simple overlord in Spear of Adun

https://discordapp.com/channels/731205301247803413/980554570075873300/1437528947481907261

They turned out to not be the logically required unit on standard, but investigating showed that they could be a "basic anti-air" unit for protoss on standard. Given the troubles, that seemed incorrect and Envy agreed they should be moved to advanced tactics only for basic anti-air.

## How was this tested?
Ran unit tests.

## If this makes graphical changes, please attach screenshots.
None