### PR TITLE
sc2: Incrementing generator and API version number to 5; updating mod download URL

### DIFF
--- a/worlds/sc2/__init__.py
+++ b/worlds/sc2/__init__.py
@@ -223,7 +223,7 @@ class SC2World(World):
             slot_data["use_nova_wol_fallback"] = True
         slot_data["final_mission_ids"] = self.custom_mission_order.get_final_mission_ids()
         slot_data["custom_mission_order"] = self.custom_mission_order.get_slot_data()
-        slot_data["version"] = 4
+        slot_data["version"] = 5
 
         if SC2Campaign.HOTS not in enabled_campaigns:
             slot_data["kerrigan_presence"] = KerriganPresence.option_not_present

--- a/worlds/sc2/client.py
+++ b/worlds/sc2/client.py
@@ -21,7 +21,6 @@ import random
 import concurrent.futures
 import time
 import uuid
-import argparse
 from pathlib import Path
 
 # CommonClient import first to trigger ModuleUpdater
@@ -82,9 +81,9 @@ nest_asyncio.apply(loop)
 MAX_BONUS: int = 28
 
 # GitHub repo where the Map/mod data is hosted for /download_data command
-DATA_REPO_OWNER = "Ziktofel"
+DATA_REPO_OWNER = "archipelago-sc2"
 DATA_REPO_NAME = "Archipelago-SC2-data"
-DATA_API_VERSION = "API4"
+DATA_API_VERSION = "API5"
 
 # Bot controller
 CONTROLLER_HEALTH: int = 38281


### PR DESCRIPTION
## What is this fixing or adding?
Incrementing the version numbers and such to start version 5 in earnest.

I manually made the API5 release on the Archipelago-SC2-Data repository: https://github.com/archipelago-sc2/Archipelago-SC2-data/releases/tag/API5. The build script on that repository isn't updated yet, so it will not auto-upload.

## How was this tested?
Did a local gen and started the client. Ran `/download_data`. The download succeeded, and the log output seemed to indicate it was pulling from the correct location:
```
Starting new HTTPS connection (1): api.github.com:443
https://api.github.com:443 "GET /repos/archipelago-sc2/Archipelago-SC2-data/releases/tags/API5 HTTP/1.1" 200 942
Attempting to download latest version of API version API5 of Archipelago-SC2-data.
Starting new HTTPS connection (1): github.com:443
https://github.com:443 "GET /archipelago-sc2/Archipelago-SC2-data/releases/download/API5/Archipelago-SC2Data.zip HTTP/1.1" 302 0
Starting new HTTPS connection (1): release-assets.githubusercontent.com:443
https://release-assets.githubusercontent.com:443 "GET /github-production-release-asset/1092101226/[CUT FOR BREVITY] HTTP/1.1" 200 401372156
Successfully downloaded Archipelago-SC2-data.zip. Installing...
Download complete. Package installed.
```

## If this makes graphical changes, please attach screenshots.
None