### PR TITLE
sc2: Changing github workflows and addressing mypy/flake8 issues

### DIFF
--- a/.github/workflows/analyze-modified-files.yml
+++ b/.github/workflows/analyze-modified-files.yml
@@ -70,8 +70,11 @@ jobs:
       - name: "flake8: Lint modified files"
         continue-on-error: true
         if: env.diff != '' && matrix.task == 'flake8'
-        run: |
-          flake8 --count --max-complexity=14 --max-doc-length=120 --max-line-length=120 --statistics ${{ env.diff }}
+        # Todo(mm): Revert this when it is time to merge to main
+        run: >
+          flake8 --count --max-complexity=14 --max-doc-length=120 --max-line-length=120 --statistics ${{ env.diff }} 
+          --per-file-ignores='worlds/sc2/mission_tables.py:E227,E501,E221 worlds/sc2/*.py:E124,E128'
+          --ignore=C901,W503
 
       - name: "mypy: Type check modified files"
         continue-on-error: true

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -63,8 +63,10 @@ jobs:
         python ModuleUpdate.py --yes --force --append "WebHostLib/requirements.txt"
         python Launcher.py --update_settings  # make sure host.yaml exists for tests
     - name: Unittests
+      # Todo: Revert this commit when it is time to merge to main
+      # pytest -n auto
       run: |
-        pytest -n auto
+        python3 -m unittest discover worlds.sc2.test
 
   hosting:
     runs-on: ${{ matrix.os }}

--- a/worlds/sc2/mission_order/mission_pools.py
+++ b/worlds/sc2/mission_order/mission_pools.py
@@ -8,6 +8,7 @@ from worlds.AutoWorld import World
 if TYPE_CHECKING:
     from .nodes import SC2MOGenMission
 
+
 class Difficulty(IntEnum):
     RELATIVE = 0
     STARTER = 1
@@ -15,6 +16,7 @@ class Difficulty(IntEnum):
     MEDIUM = 3
     HARD = 4
     VERY_HARD = 5
+
 
 # TODO figure out an organic way to get these
 DEFAULT_DIFFICULTY_THRESHOLDS = {
@@ -26,6 +28,7 @@ DEFAULT_DIFFICULTY_THRESHOLDS = {
     Difficulty.VERY_HARD + 1: 100
 }
 
+
 STANDARD_DIFFICULTY_FILL_ORDER = (
     Difficulty.VERY_HARD,
     Difficulty.STARTER,
@@ -35,6 +38,7 @@ STANDARD_DIFFICULTY_FILL_ORDER = (
 )
 """Fill mission slots outer->inner difficulties,
 so if multiple pools get exhausted, they will tend to overflow towards the middle."""
+
 
 def modified_difficulty_thresholds(min_difficulty: Difficulty, max_difficulty: Difficulty) -> Dict[int, Difficulty]:
     if min_difficulty == Difficulty.RELATIVE:
@@ -49,6 +53,7 @@ def modified_difficulty_thresholds(min_difficulty: Difficulty, max_difficulty: D
         threshold *= 100 // total_thresh
         thresholds[threshold] = Difficulty(difficulty)
     return thresholds
+
 
 class SC2MOGenMissionPools:
     """
@@ -86,7 +91,7 @@ class SC2MOGenMissionPools:
 
     def exclude_mission(self, mission: SC2Mission) -> None:
         """Excludes a single mission unless it is unexcluded."""
-        if not mission in self._unexcluded_missions:
+        if mission not in self._unexcluded_missions:
             self.master_list.remove(mission.id)
             self.difficulty_pools[self.get_modified_mission_difficulty(mission)].remove(mission.id)
 
@@ -99,7 +104,7 @@ class SC2MOGenMissionPools:
             return len(used_files)
         else:
             return len(self.master_list)
-    
+
     def count_allowed_missions(self, campaign: SC2Campaign) -> int:
         allowed_missions = [
             mission_id
@@ -124,7 +129,7 @@ class SC2MOGenMissionPools:
     def get_pool_size(self, diff: Difficulty) -> int:
         """Returns the amount of missions of the given difficulty that are allowed to appear."""
         return len(self.difficulty_pools[diff])
-    
+
     def get_used_flags(self) -> Dict[MissionFlag, int]:
         """Returns a dictionary of all used flags and their appearance count within the mission order.
         Flags that don't appear in the mission order also don't appear in this dictionary."""
@@ -134,7 +139,9 @@ class SC2MOGenMissionPools:
         """Returns a set of all missions used in the mission order."""
         return self._used_missions
 
-    def set_flag_balances(self, flag_ratios: Dict[MissionFlag, int], flag_weights: Dict[MissionFlag, int]):
+    def set_flag_balances(
+        self, flag_ratios: Dict[MissionFlag, int], flag_weights: Dict[MissionFlag, int]
+    ) -> None:
         # Ensure the ratios are percentages
         ratio_sum = sum(ratio for ratio in flag_ratios.values())
         self._flag_ratios = {flag: ratio / ratio_sum for flag, ratio in flag_ratios.items()}
@@ -166,7 +173,7 @@ class SC2MOGenMissionPools:
             # Only keep the missions that create the best balance
             best_score = max(mission_scores)
             balanced_pool = [mission for idx, mission in enumerate(balanced_pool) if mission_scores[idx] == best_score]
-        
+
         balanced_weights = [1.0 for _ in balanced_pool]
         if len(self._flag_weights) > 0:
             relevant_used_flag_count = max(sum(self._used_flags.get(flag, 0) for flag in self._flag_weights), 1)
@@ -200,18 +207,18 @@ class SC2MOGenMissionPools:
                     self.difficulty_pools[diff].remove(mission.id)
                     break
         self._add_mission_stats(mission)
-    
+
     def _add_mission_stats(self, mission: SC2Mission) -> None:
         # Update used flag counts & missions
         # Done weirdly for Python <= 3.10 compatibility
         flag: MissionFlag
-        for flag in iter(MissionFlag):  # type: ignore
+        for flag in iter(MissionFlag):
             if flag & mission.flags == flag:
                 self._used_flags.setdefault(flag, 0)
                 self._used_flags[flag] += 1
-        
+
         # Exclude race swap variants
-        if self.exclude_mission_variants_on_pull and mission.flags & (MissionFlag.HasRaceSwap|MissionFlag.RaceSwap):
+        if self.exclude_mission_variants_on_pull and mission.flags & (MissionFlag.HasRaceSwap | MissionFlag.RaceSwap):
             variants = [
                 other_mission
                 for other_mission in self.master_list
@@ -222,10 +229,16 @@ class SC2MOGenMissionPools:
 
         self._used_missions.append(mission)
 
-    def pull_random_mission(self, world: World, slot: 'SC2MOGenMission', *, prefer_close_difficulty: bool = False) -> SC2Mission:
-        """Picks a random mission from the mission pool of the given slot and marks it as present in the mission order.
+    def pull_random_mission(
+        self, world: World, slot: 'SC2MOGenMission', *, prefer_close_difficulty: bool = False
+    ) -> SC2Mission:
+        """
+        Picks a random mission from the mission pool of the given slot
+        and marks it as present in the mission order.
 
-        With `prefer_close_difficulty = True` the mission is picked to be as close to the slot's desired difficulty as possible."""
+        With `prefer_close_difficulty = True`, the mission is picked to be
+        as close to the slot's desired difficulty as possible.
+        """
         pool = slot.option_mission_pool.intersection(self.master_list)
 
         difficulty_pools: Dict[int, List[int]] = {

--- a/worlds/sc2/mission_tables.py
+++ b/worlds/sc2/mission_tables.py
@@ -1,4 +1,4 @@
-from typing import NamedTuple, Dict, List, Set, Union, Literal, Iterable, Optional
+from typing import NamedTuple, Union, Literal, Iterable
 from enum import IntEnum, Enum, IntFlag, auto
 
 
@@ -8,11 +8,12 @@ class SC2Race(IntEnum):
     ZERG = 2
     PROTOSS = 3
 
-    def get_title(self):
+    def get_title(self) -> str:
         return self.name.lower().capitalize()
 
-    def get_mission_flag(self):
+    def get_mission_flag(self) -> 'MissionFlag':
         return MissionFlag.__getitem__(self.get_title())
+
 
 class MissionPools(IntEnum):
     STARTER = 0
@@ -66,19 +67,21 @@ class SC2CampaignGoalPriority(IntEnum):
 
 class SC2Campaign(Enum):
 
-    def __new__(cls, *args, **kwargs):
+    def __new__(cls, *args, **kwargs) -> 'SC2Campaign':
         value = len(cls.__members__) + 1
         obj = object.__new__(cls)
         obj._value_ = value
         return obj
 
-    def __init__(self, campaign_id: int, name: str, goal_priority: SC2CampaignGoalPriority,  race: SC2Race):
+    def __init__(
+        self, campaign_id: int, name: str, goal_priority: SC2CampaignGoalPriority, race: SC2Race
+    ) -> None:
         self.id = campaign_id
         self.campaign_name = name
         self.goal_priority = goal_priority
         self.race = race
 
-    def __lt__(self, other: "SC2Campaign"):
+    def __lt__(self, other: "SC2Campaign") -> bool:
         return self.id < other.id
 
     GLOBAL = 0, "Global", SC2CampaignGoalPriority.NONE, SC2Race.ANY
@@ -93,13 +96,23 @@ class SC2Campaign(Enum):
 
 class SC2Mission(Enum):
 
-    def __new__(cls, *args, **kwargs):
+    def __new__(cls, *args, **kwargs) -> 'SC2Mission':
         value = len(cls.__members__) + 1
         obj = object.__new__(cls)
         obj._value_ = value
         return obj
 
-    def __init__(self, mission_id: int, name: str, campaign: SC2Campaign, area: str, race: SC2Race, pool: MissionPools, map_file: str, flags: MissionFlag):
+    def __init__(
+        self,
+        mission_id: int,
+        name: str,
+        campaign: SC2Campaign,
+        area: str,
+        race: SC2Race,
+        pool: MissionPools,
+        map_file: str,
+        flags: MissionFlag,
+    ) -> None:
         self.id = mission_id
         self.mission_name = name
         self.campaign = campaign
@@ -109,7 +122,7 @@ class SC2Mission(Enum):
         self.map_file = map_file
         self.flags = flags
 
-    def get_short_name(self):
+    def get_short_name(self) -> str:
         if self.mission_name.find(' (') == -1:
             return self.mission_name
         else:
@@ -358,11 +371,11 @@ class MissionConnection:
     campaign: SC2Campaign
     connect_to: int  # -1 connects to Menu
 
-    def __init__(self, connect_to, campaign = SC2Campaign.GLOBAL):
+    def __init__(self, connect_to: int, campaign = SC2Campaign.GLOBAL) -> None:
         self.campaign = campaign
         self.connect_to = connect_to
 
-    def _asdict(self):
+    def _asdict(self) -> dict[Literal["campaign", "connect_to"], int]:
         return {
             "campaign": self.campaign.id,
             "connect_to": self.connect_to
@@ -371,7 +384,7 @@ class MissionConnection:
 
 class MissionInfo(NamedTuple):
     mission: SC2Mission
-    required_world: List[Union[MissionConnection, Dict[Literal["campaign", "connect_to"], int]]]
+    required_world: list[Union[MissionConnection, dict[Literal["campaign", "connect_to"], int]]]
     category: str
     number: int = 0  # number of worlds need beaten
     completion_critical: bool = False  # missions needed to beat game
@@ -380,11 +393,11 @@ class MissionInfo(NamedTuple):
 
 
 
-lookup_id_to_mission: Dict[int, SC2Mission] = {
+lookup_id_to_mission: dict[int, SC2Mission] = {
     mission.id: mission for mission in SC2Mission
 }
 
-lookup_name_to_mission: Dict[str, SC2Mission] = {
+lookup_name_to_mission: dict[str, SC2Mission] = {
     mission.mission_name: mission for mission in SC2Mission
 }
 for mission in SC2Mission:
@@ -393,19 +406,21 @@ for mission in SC2Mission:
         short_name = mission.get_short_name()
         lookup_name_to_mission[short_name] = mission
 
-lookup_id_to_campaign: Dict[int, SC2Campaign] = {
+lookup_id_to_campaign: dict[int, SC2Campaign] = {
     campaign.id: campaign for campaign in SC2Campaign
 }
 
 
-campaign_mission_table: Dict[SC2Campaign, Set[SC2Mission]] = {
+campaign_mission_table: dict[SC2Campaign, set[SC2Mission]] = {
     campaign: set() for campaign in SC2Campaign
 }
 for mission in SC2Mission:
     campaign_mission_table[mission.campaign].add(mission)
 
 
-def get_campaign_difficulty(campaign: SC2Campaign, excluded_missions: Iterable[SC2Mission] = ()) -> MissionPools:
+def get_campaign_difficulty(
+    campaign: SC2Campaign, excluded_missions: Iterable[SC2Mission] = ()
+) -> MissionPools:
     """
 
     :param campaign:
@@ -417,7 +432,9 @@ def get_campaign_difficulty(campaign: SC2Campaign, excluded_missions: Iterable[S
     return max([mission.pool for mission in included_missions])
 
 
-def get_campaign_goal_priority(campaign: SC2Campaign, excluded_missions: Iterable[SC2Mission] = ()) -> SC2CampaignGoalPriority:
+def get_campaign_goal_priority(
+    campaign: SC2Campaign, excluded_missions: Iterable[SC2Mission] = ()
+) -> SC2CampaignGoalPriority:
     """
     Gets a modified campaign goal priority.
     If all the campaign's goal missions are excluded, it's ineligible to have the goal
@@ -451,7 +468,7 @@ class SC2CampaignGoal(NamedTuple):
     location: str
 
 
-campaign_final_mission_locations: Dict[SC2Campaign, Optional[SC2CampaignGoal]] = {
+campaign_final_mission_locations: dict[SC2Campaign, SC2CampaignGoal | None] = {
     SC2Campaign.WOL: SC2CampaignGoal(SC2Mission.ALL_IN, f'{SC2Mission.ALL_IN.mission_name}: Victory'),
     SC2Campaign.PROPHECY: SC2CampaignGoal(SC2Mission.IN_UTTER_DARKNESS, f'{SC2Mission.IN_UTTER_DARKNESS.mission_name}: Defeat'),
     SC2Campaign.HOTS: SC2CampaignGoal(SC2Mission.THE_RECKONING, f'{SC2Mission.THE_RECKONING.mission_name}: Victory'),
@@ -461,7 +478,7 @@ campaign_final_mission_locations: Dict[SC2Campaign, Optional[SC2CampaignGoal]] =
     SC2Campaign.NCO: SC2CampaignGoal(SC2Mission.END_GAME, f'{SC2Mission.END_GAME.mission_name}: Victory'),
 }
 
-campaign_alt_final_mission_locations: Dict[SC2Campaign, Dict[SC2Mission, str]] = {
+campaign_alt_final_mission_locations: dict[SC2Campaign, dict[SC2Mission, str]] = {
     SC2Campaign.WOL: {
         SC2Mission.MAW_OF_THE_VOID: f'{SC2Mission.MAW_OF_THE_VOID.mission_name}: Victory',
         SC2Mission.ENGINE_OF_DESTRUCTION: f'{SC2Mission.ENGINE_OF_DESTRUCTION.mission_name}: Victory',
@@ -529,12 +546,12 @@ campaign_alt_final_mission_locations: Dict[SC2Campaign, Dict[SC2Mission, str]] =
     }
 }
 
-campaign_race_exceptions: Dict[SC2Mission, SC2Race] = {
+campaign_race_exceptions: dict[SC2Mission, SC2Race] = {
     SC2Mission.WITH_FRIENDS_LIKE_THESE: SC2Race.TERRAN
 }
 
 
-def get_goal_location(mission: SC2Mission) -> Union[str, None]:
+def get_goal_location(mission: SC2Mission) -> str | None:
     """
 
     :param mission:
@@ -555,13 +572,13 @@ def get_goal_location(mission: SC2Mission) -> Union[str, None]:
         else mission.mission_name + ": Victory"
 
 
-def get_campaign_potential_goal_missions(campaign: SC2Campaign) -> List[SC2Mission]:
+def get_campaign_potential_goal_missions(campaign: SC2Campaign) -> list[SC2Mission]:
     """
 
     :param campaign:
     :return: All missions that can be the campaign's goal
     """
-    missions: List[SC2Mission] = list()
+    missions: list[SC2Mission] = []
     primary_goal_mission = campaign_final_mission_locations[campaign]
     if primary_goal_mission is not None:
         missions.append(primary_goal_mission.mission)
@@ -573,5 +590,5 @@ def get_campaign_potential_goal_missions(campaign: SC2Campaign) -> List[SC2Missi
     return missions
 
 
-def get_missions_with_any_flags_in_list(flags: MissionFlag) -> List[SC2Mission]:
+def get_missions_with_any_flags_in_list(flags: MissionFlag) -> list[SC2Mission]:
     return [mission for mission in SC2Mission if flags & mission.flags]

--- a/worlds/sc2/mission_tables.py
+++ b/worlds/sc2/mission_tables.py
@@ -371,7 +371,7 @@ class MissionConnection:
     campaign: SC2Campaign
     connect_to: int  # -1 connects to Menu
 
-    def __init__(self, connect_to: int, campaign = SC2Campaign.GLOBAL) -> None:
+    def __init__(self, connect_to: int, campaign: SC2Campaign = SC2Campaign.GLOBAL) -> None:
         self.campaign = campaign
         self.connect_to = connect_to
 

--- a/worlds/sc2/options.py
+++ b/worlds/sc2/options.py
@@ -1,12 +1,12 @@
 import functools
 from dataclasses import fields, Field, dataclass
-from typing import *
+from typing import TYPE_CHECKING, Iterable, Any, Type, Iterator, Mapping
 from datetime import timedelta
 
 from Options import (
     Choice, Toggle, DefaultOnToggle, OptionSet, Range,
     PerGameCommonOptions, VerifyKeys, StartInventory,
-    is_iterable_except_str, OptionGroup, Visibility, ItemDict,
+    OptionGroup, ItemDict,
     OptionCounter,
 )
 from Utils import get_fuzzy_results
@@ -28,19 +28,15 @@ class Sc2MissionSet(OptionSet):
     """Option set made for handling missions and expanding mission groups"""
     valid_keys: Iterable[str] = [x.mission_name for x in SC2Mission]
 
-    @classmethod
-    def from_any(cls, data: Any):
-        if is_iterable_except_str(data):
-            return cls(data)
-        return cls.from_text(str(data))
-
     def verify(self, world: Type['World'], player_name: str, plando_options: PlandoOptions) -> None:
         """Overridden version of function from Options.VerifyKeys for a better error message"""
         new_value: set[str] = set()
         case_insensitive_group_mapping = {
             group_name.casefold(): group_value for group_name, group_value in mission_groups.items()
         }
-        case_insensitive_group_mapping.update({mission.mission_name.casefold(): [mission.mission_name] for mission in SC2Mission})
+        case_insensitive_group_mapping.update(
+            {mission.mission_name.casefold(): [mission.mission_name] for mission in SC2Mission}
+        )
         for group_name in self.value:
             item_names = case_insensitive_group_mapping.get(group_name.casefold(), {group_name})
             new_value.update(item_names)
@@ -68,7 +64,7 @@ class SelectedRaces(OptionSet):
     Pick which factions' missions and items can be shuffled into the world.
     """
     display_name = "Select Playable Races"
-    valid_keys = {race.get_title() for race in SC2Race if race != SC2Race.ANY}
+    valid_keys = frozenset(race.get_title() for race in SC2Race if race != SC2Race.ANY)
     default = valid_keys
 
 
@@ -126,12 +122,13 @@ class AllInMap(Choice):
     display_name = "All In Map"
     option_ground = 0
     option_air = 1
-    default = 'random'
+    default = 'random'  # type: ignore
 
 
 class MissionOrder(Choice):
     """
-    Determines the order the missions are played in.  The first three mission orders ignore the Maximum Campaign Size option.
+    Determines the order the missions are played in.
+    The first three mission orders ignore the Maximum Campaign Size option.
     Vanilla (83 total if all campaigns enabled): Keeps the standard mission order and branching from the vanilla Campaigns.
     Vanilla Shuffled (83 total if all campaigns enabled): Keeps same branching paths from the vanilla Campaigns but randomizes the order of missions within.
     Mini Campaign (47 total if all campaigns enabled): Shorter version of the campaign with randomized missions and optional branches.
@@ -172,7 +169,6 @@ class TwoStartPositions(Toggle):
     removes the first mission and allows both of the next two missions to be played from the start.
     """
     display_name = "Two start missions"
-    default = Toggle.option_false
 
 
 class KeyMode(Choice):
@@ -265,8 +261,8 @@ class EnabledCampaigns(OptionSet):
     - 'Nova Covert Ops'
     """
     display_name = "Enabled Campaigns"
-    valid_keys = {campaign.campaign_name for campaign in SC2Campaign if campaign != SC2Campaign.GLOBAL}
-    default = set((SC2Campaign.WOL.campaign_name,))
+    valid_keys = frozenset(campaign.campaign_name for campaign in SC2Campaign if campaign != SC2Campaign.GLOBAL)
+    default = frozenset((SC2Campaign.WOL.campaign_name,))
 
 
 class EnableRaceSwapVariants(Choice):
@@ -358,10 +354,11 @@ class RequiredTactics(Choice):
 
 class EnableVoidTrade(Toggle):
     """
-    Enables the Void Trade Wormhole to be built from the Advanced Construction tab of SCVs, Drones and Probes.  
-    This structure allows sending units to the Archipelago server, as well as buying random units from the server.  
-    
-    Note: Always disabled if there is no other Starcraft II world with Void Trade enabled in the multiworld.  You cannot receive units that you send.
+    Enables the Void Trade Wormhole to be built from the Advanced Construction tab of SCVs, Drones and Probes.
+    This structure allows sending units to the Archipelago server, as well as buying random units from the server.
+
+    Note: Always disabled if there is no other Starcraft II world with Void Trade enabled in the multiworld.
+    You cannot receive units that you send.
     """
     display_name = "Enable Void Trade"
 
@@ -417,7 +414,7 @@ class GenericUpgradeMissions(Range):
     """
     display_name = "Generic Upgrade Missions"
     range_start = 0
-    range_end = 100 # Higher values lead to fails often
+    range_end = 100  # Higher values lead to fails often
     default = 0
 
 
@@ -583,7 +580,8 @@ class KerriganLevelsPerMissionCompleted(Range):
 
 class KerriganLevelsPerMissionCompletedCap(Range):
     """
-    Limits how many total levels Kerrigan can gain from beating missions.  This does not affect levels gained from items.  
+    Limits how many total levels Kerrigan can gain from beating missions.
+    This does not affect levels gained from items.
     Set to -1 to disable this limit.
 
     NOTE: The following missions have these level requirements:
@@ -599,7 +597,8 @@ class KerriganLevelsPerMissionCompletedCap(Range):
 
 class KerriganLevelItemSum(Range):
     """
-    Determines the sum of the level items in the world.  This does not affect levels gained from beating missions.
+    Determines the sum of the level items in the world.
+    This does not affect levels gained from beating missions.
 
     NOTE: The following missions have these level requirements:
     Supreme: 35
@@ -619,17 +618,18 @@ class KerriganLevelItemDistribution(Choice):
     This entails 32 individual levels and 6 packs of varying sizes.
     This distribution always adds up to 70, ignoring the Level Item Sum setting.
     Smooth:  Uses a custom, condensed distribution of 10 items between sizes 4 and 10,
-    intended to fit more levels into settings with little room for filler while keeping some variance in level gains.
+      intended to fit more levels into settings with little room for filler
+      while keeping some variance in level gains.
     This distribution always adds up to 70, ignoring the Level Item Sum setting.
-    Size 70:  Uses items worth 70 levels each.
-    Size 35:  Uses items worth 35 levels each.
-    Size 14:  Uses items worth 14 levels each.
-    Size 10:  Uses items worth 10 levels each.
+    Size 70: Uses items worth 70 levels each.
+    Size 35: Uses items worth 35 levels each.
+    Size 14: Uses items worth 14 levels each.
+    Size 10: Uses items worth 10 levels each.
     Size 7:  Uses items worth 7 levels each.
     Size 5:  Uses items worth 5 levels each.
     Size 2:  Uses items worth 2 level eachs.
-    Size 1:  Uses individual levels.  As there are not enough locations in the game for this distribution,
-    this will result in a greatly reduced total level, and is likely to remove many other items."""
+    Size 1:  Uses individual levels. As there are not enough locations in the game for this distribution,
+      this will result in a greatly reduced total level, and is likely to remove many other items."""
     display_name = "Kerrigan Level Item Distribution"
     option_vanilla = 0
     option_smooth = 1
@@ -816,7 +816,10 @@ class SpearOfAdunMaxActiveAbilities(Range):
     """
     display_name = "Spear of Adun Maximum Active Abilities"
     range_start = 0
-    range_end = sum([item.quantity for item_name, item in item_tables.get_full_item_list().items() if item_name in item_tables.spear_of_adun_calldowns])
+    range_end = sum([
+        item_tables.item_table[item_name].quantity
+        for item_name in item_tables.spear_of_adun_calldowns
+    ])
     default = range_end
 
 
@@ -828,7 +831,10 @@ class SpearOfAdunMaxAutocastAbilities(Range):
     """
     display_name = "Spear of Adun Maximum Passive Abilities"
     range_start = 0
-    range_end = sum(item_tables.item_table[item_name].quantity for item_name in item_groups.spear_of_adun_passives)
+    range_end = sum(
+        item_tables.item_table[item_name].quantity
+        for item_name in item_groups.spear_of_adun_passives
+    )
     default = range_end
 
 
@@ -945,7 +951,7 @@ class Sc2ItemDict(OptionCounter, VerifyKeys, Mapping[str, int]):
     valid_keys = set(item_tables.item_table) | set(item_groups.item_name_groups)
 
     def __init__(self, value: dict[str, int]):
-        self.value = {key: val for key, val in value.items()}
+        self.value: dict[str, int] = {key: val for key, val in value.items()}
 
     @classmethod
     def from_any(cls, data: list[str] | dict[str, int]) -> 'Sc2ItemDict':
@@ -999,7 +1005,8 @@ class Sc2ItemDict(OptionCounter, VerifyKeys, Mapping[str, int]):
                     f"Did you mean '{picks[0][0]}' ({picks[0][1]}% sure)"
                 )
 
-    def get_option_name(self, value):
+    @classmethod
+    def get_option_name(cls, value: dict[str, int]) -> str:
         return ", ".join(f"{key}: {v}" for key, v in value.items())
 
     def __getitem__(self, item: str) -> int:
@@ -1072,7 +1079,7 @@ class ExcludeVeryHardMissions(Choice):
     option_false = 2
 
     @classmethod
-    def get_option_name(cls, value):
+    def get_option_name(cls, value: int) -> str:
         return ["Default", "Yes", "No"][int(value)]
 
 
@@ -1313,6 +1320,7 @@ class LowestMaximumSupply(Range):
     range_end = 200
     default = 180
 
+
 class ResearchCostReductionPerItem(Range):
     """
     Controls how much weapon/armor research cost is cut per research cost filler item.
@@ -1345,7 +1353,7 @@ class FillerItemsDistribution(ItemDict):
     valid_keys = default.keys()
     display_name = "Filler Items Distribution"
 
-    def __init__(self, value: Dict[str, int]):
+    def __init__(self, value: dict[str, int]):
         # Allow zeros that the parent class doesn't allow
         if any(item_count < 0 for item_count in value.values()):
             raise Exception("Cannot have negative item weight.")
@@ -1442,6 +1450,7 @@ class Starcraft2Options(PerGameCommonOptions):
     mission_order_scouting: MissionOrderScouting
 
     custom_mission_order: CustomMissionOrder
+
 
 option_groups = [
     OptionGroup("Difficulty Settings", [
@@ -1556,7 +1565,8 @@ option_groups = [
     ])
 ]
 
-def get_option_value(world: Union['SC2World', None], name: str) -> int:
+
+def get_option_value(world: 'SC2World | None', name: str) -> Any:
     """
     You should basically never use this unless `world` can be `None`.
     Use `world.options.<option_name>.value` instead for better typing, autocomplete, and error messages.
@@ -1575,12 +1585,16 @@ def get_option_value(world: Union['SC2World', None], name: str) -> int:
     return player_option.value
 
 
-def get_enabled_races(world: Optional['SC2World']) -> Set[SC2Race]:
-    race_names = world.options.selected_races.value if world and len(world.options.selected_races.value) > 0 else SelectedRaces.valid_keys
+def get_enabled_races(world: 'SC2World | None') -> set[SC2Race]:
+    race_names = (
+        world.options.selected_races.value
+        if world and len(world.options.selected_races.value) > 0
+        else SelectedRaces.valid_keys
+    )
     return {race for race in SC2Race if race.get_title() in race_names}
 
 
-def get_enabled_campaigns(world: Optional['SC2World']) -> Set[SC2Campaign]:
+def get_enabled_campaigns(world: 'SC2World | None') -> set[SC2Campaign]:
     if world is None:
         return {campaign for campaign in SC2Campaign if campaign.campaign_name in EnabledCampaigns.default}
     campaign_names = world.options.enabled_campaigns
@@ -1596,7 +1610,7 @@ def get_enabled_campaigns(world: Optional['SC2World']) -> Set[SC2Campaign]:
     return campaigns
 
 
-def get_disabled_campaigns(world: 'SC2World') -> Set[SC2Campaign]:
+def get_disabled_campaigns(world: 'SC2World') -> set[SC2Campaign]:
     all_campaigns = set(SC2Campaign)
     enabled_campaigns = get_enabled_campaigns(world)
     disabled_campaigns = all_campaigns.difference(enabled_campaigns)
@@ -1621,29 +1635,29 @@ def get_disabled_flags(world: 'SC2World') -> MissionFlag:
     return MissionFlag(excluded)
 
 
-def get_excluded_missions(world: 'SC2World') -> Set[SC2Mission]:
+def get_excluded_missions(world: 'SC2World') -> set[SC2Mission]:
     mission_order_type = world.options.mission_order.value
     excluded_mission_names = world.options.excluded_missions.value
     disabled_campaigns = get_disabled_campaigns(world)
     disabled_flags = get_disabled_flags(world)
 
-    excluded_missions: Set[SC2Mission] = set([lookup_name_to_mission[name] for name in excluded_mission_names])
+    excluded_missions: set[SC2Mission] = set([lookup_name_to_mission[name] for name in excluded_mission_names])
 
     # Excluding Very Hard missions depending on options
     if (mission_order_type != MissionOrder.option_vanilla and
-            (
-                    world.options.exclude_very_hard_missions == ExcludeVeryHardMissions.option_true
-                    or (
-                            world.options.exclude_very_hard_missions == ExcludeVeryHardMissions.option_default
-                            and (
-                                    (
-                                            mission_order_type in dynamic_mission_orders
-                                            and world.options.maximum_campaign_size < 20
-                                    )
-                                    or mission_order_type == MissionOrder.option_mini_campaign
-                            )
+        (
+            world.options.exclude_very_hard_missions == ExcludeVeryHardMissions.option_true
+            or (
+                world.options.exclude_very_hard_missions == ExcludeVeryHardMissions.option_default
+                and (
+                    (
+                        mission_order_type in dynamic_mission_orders
+                        and world.options.maximum_campaign_size < 20
                     )
+                    or mission_order_type == MissionOrder.option_mini_campaign
+                )
             )
+        )
     ):
         excluded_missions = excluded_missions.union(
             [mission for mission in SC2Mission if
@@ -1684,7 +1698,6 @@ def is_mission_in_soa_presence(
     )
 
 
-
 static_mission_orders = [
     MissionOrder.option_vanilla,
     MissionOrder.option_vanilla_shuffled,
@@ -1706,7 +1719,7 @@ kerrigan_unit_available = [
 ]
 
 # Names of upgrades to be included for different options
-upgrade_included_names: Dict[int, Set[str]] = {
+upgrade_included_names: dict[int, set[str]] = {
     GenericUpgradeItems.option_individual_items: {
         item_names.PROGRESSIVE_TERRAN_INFANTRY_WEAPON,
         item_names.PROGRESSIVE_TERRAN_INFANTRY_ARMOR,
@@ -1750,14 +1763,14 @@ upgrade_included_names: Dict[int, Set[str]] = {
 }
 
 # Mapping trade age limit options to their millisecond equivalents
-void_trade_age_limits_ms: Dict[int, int] = {
-    VoidTradeAgeLimit.option_5_minutes: 1000 * int(timedelta(minutes = 5).total_seconds()),
-    VoidTradeAgeLimit.option_30_minutes: 1000 * int(timedelta(minutes = 30).total_seconds()),
-    VoidTradeAgeLimit.option_1_hour: 1000 * int(timedelta(hours = 1).total_seconds()),
-    VoidTradeAgeLimit.option_2_hours: 1000 * int(timedelta(hours = 2).total_seconds()),
-    VoidTradeAgeLimit.option_4_hours: 1000 * int(timedelta(hours = 4).total_seconds()),
-    VoidTradeAgeLimit.option_1_day: 1000 * int(timedelta(days = 1).total_seconds()),
-    VoidTradeAgeLimit.option_1_week: 1000 * int(timedelta(weeks = 1).total_seconds()),
+void_trade_age_limits_ms: dict[int, int] = {
+    VoidTradeAgeLimit.option_5_minutes: 1000 * int(timedelta(minutes=5).total_seconds()),
+    VoidTradeAgeLimit.option_30_minutes: 1000 * int(timedelta(minutes=30).total_seconds()),
+    VoidTradeAgeLimit.option_1_hour: 1000 * int(timedelta(hours=1).total_seconds()),
+    VoidTradeAgeLimit.option_2_hours: 1000 * int(timedelta(hours=2).total_seconds()),
+    VoidTradeAgeLimit.option_4_hours: 1000 * int(timedelta(hours=4).total_seconds()),
+    VoidTradeAgeLimit.option_1_day: 1000 * int(timedelta(days=1).total_seconds()),
+    VoidTradeAgeLimit.option_1_week: 1000 * int(timedelta(weeks=1).total_seconds()),
 }
 
 # Store the names of all options

--- a/worlds/sc2/regions.py
+++ b/worlds/sc2/regions.py
@@ -1,7 +1,8 @@
 from typing import TYPE_CHECKING, List, Dict, Any, Tuple, Optional
 
 from Options import OptionError
-from .locations import LocationData, Location
+from BaseClasses import Location
+from .locations import LocationData
 from .mission_tables import (
     SC2Mission, SC2Campaign, MissionFlag, get_campaign_goal_priority,
     campaign_final_mission_locations, campaign_alt_final_mission_locations
@@ -15,9 +16,16 @@ from .options import (
 )
 from .mission_order.options import CustomMissionOrder
 from .mission_order import SC2MissionOrder
-from .mission_order.nodes import SC2MOGenMissionOrder, Difficulty
-from .mission_order.mission_pools import SC2MOGenMissionPools
-from .mission_order.generation import resolve_unlocks, fill_depths, resolve_difficulties, fill_missions, make_connections, resolve_generic_keys
+from .mission_order.nodes import SC2MOGenMissionOrder
+from .mission_order.mission_pools import SC2MOGenMissionPools, Difficulty
+from .mission_order.generation import (
+    resolve_unlocks,
+    fill_depths,
+    resolve_difficulties,
+    fill_missions,
+    make_connections,
+    resolve_generic_keys,
+)
 
 if TYPE_CHECKING:
     from . import SC2World
@@ -25,7 +33,7 @@ if TYPE_CHECKING:
 
 def create_mission_order(
     world: 'SC2World', locations: Tuple[LocationData, ...], location_cache: List[Location]
-):
+) -> SC2MissionOrder:
     # 'locations' contains both actual game locations and beat event locations for all mission regions
     # When a region (mission) is accessible, all its locations are potentially accessible
     # Accessible in this context always means "its access rule evaluates to True"
@@ -36,9 +44,11 @@ def create_mission_order(
     # whenever the event location becomes accessible
 
     # Set up mission pools
-    race_swap_pick_one = world.options.enable_race_swap.value in [EnableRaceSwapVariants.option_pick_one, EnableRaceSwapVariants.option_pick_one_non_vanilla]
+    race_swap_pick_one = world.options.enable_race_swap.value in (
+        EnableRaceSwapVariants.option_pick_one, EnableRaceSwapVariants.option_pick_one_non_vanilla
+    )
     mission_pools = SC2MOGenMissionPools(race_swap_pick_one)
-    mission_pools.set_exclusions(get_excluded_missions(world), []) # TODO set unexcluded
+    mission_pools.set_exclusions(get_excluded_missions(world), [])  # TODO set unexcluded
     adjust_mission_pools(world, mission_pools)
     setup_mission_pool_balancing(world, mission_pools)
 
@@ -56,21 +66,22 @@ def create_mission_order(
 
     # Set up requirements for individual parts of the mission order
     resolve_unlocks(mission_order)
-    
+
     # Ensure total accessibilty and resolve relative difficulties
     fill_depths(mission_order)
     resolve_difficulties(mission_order)
-    
+
     # Build the mission order
-    fill_missions(mission_order, mission_pools, world, [], locations, location_cache) # TODO set locked missions
+    fill_missions(mission_order, mission_pools, world, [], locations, location_cache)  # TODO set locked missions
     make_connections(mission_order, world)
 
     # Fill in Key requirements now that missions are placed
     resolve_generic_keys(mission_order)
-    
+
     return SC2MissionOrder(mission_order, mission_pools)
 
-def adjust_mission_pools(world: 'SC2World', pools: SC2MOGenMissionPools):
+
+def adjust_mission_pools(world: 'SC2World', pools: SC2MOGenMissionPools) -> None:  # noqa: C901
     # Mission pool changes
     mission_order_type = world.options.mission_order.value
     enabled_campaigns = get_enabled_campaigns(world)
@@ -153,17 +164,21 @@ def adjust_mission_pools(world: 'SC2World', pools: SC2MOGenMissionPools):
         # Flashpoint needs just a few items at start but competent comp at the end
         pools.move_mission(SC2Mission.FLASHPOINT, Difficulty.HARD, Difficulty.EASY)
 
-def setup_mission_pool_balancing(world: 'SC2World', pools: SC2MOGenMissionPools):
+
+def setup_mission_pool_balancing(world: 'SC2World', pools: SC2MOGenMissionPools) -> None:
     race_mission_balance = world.options.mission_race_balancing.value
     flag_ratios: Dict[MissionFlag, int] = {}
     flag_weights: Dict[MissionFlag, int] = {}
     if race_mission_balance == EnableMissionRaceBalancing.option_semi_balanced:
-        flag_weights = { MissionFlag.Terran: 1, MissionFlag.Zerg: 1, MissionFlag.Protoss: 1 }
+        flag_weights = {MissionFlag.Terran: 1, MissionFlag.Zerg: 1, MissionFlag.Protoss: 1}
     elif race_mission_balance == EnableMissionRaceBalancing.option_fully_balanced:
-        flag_ratios = { MissionFlag.Terran: 1, MissionFlag.Zerg: 1, MissionFlag.Protoss: 1 }
+        flag_ratios = {MissionFlag.Terran: 1, MissionFlag.Zerg: 1, MissionFlag.Protoss: 1}
     pools.set_flag_balances(flag_ratios, flag_weights)
 
-def create_regular_mission_order(world: 'SC2World', mission_pools: SC2MOGenMissionPools) -> Dict[str, Dict[str, Any]]:
+
+def create_regular_mission_order(
+    world: 'SC2World', mission_pools: SC2MOGenMissionPools
+) -> dict[str, dict[str, Any]]:
     mission_order_type = world.options.mission_order.value
 
     if mission_order_type in static_mission_orders:
@@ -171,7 +186,10 @@ def create_regular_mission_order(world: 'SC2World', mission_pools: SC2MOGenMissi
     else:
         return create_dynamic_mission_order(world, mission_order_type, mission_pools)
 
-def create_static_mission_order(world: 'SC2World', mission_order_type: int, mission_pools: SC2MOGenMissionPools) -> Dict[str, Dict[str, Any]]:
+
+def create_static_mission_order(
+    world: 'SC2World', mission_order_type: int, mission_pools: SC2MOGenMissionPools
+) -> dict[str, dict[str, Any]]:
     mission_order: Dict[str, Dict[str, Any]] = {}
 
     enabled_campaigns = get_enabled_campaigns(world)
@@ -181,7 +199,7 @@ def create_static_mission_order(world: 'SC2World', mission_order_type: int, miss
         missions = "random"
     else:
         missions = "vanilla_shuffled"
-    
+
     if world.options.enable_race_swap.value == EnableRaceSwapVariants.option_disabled:
         shuffle_raceswaps = False
     else:
@@ -201,24 +219,24 @@ def create_static_mission_order(world: 'SC2World', mission_order_type: int, miss
         keys = "progressive_per_layout"
     else:
         keys = "none"
-    
+
     if mission_order_type == MissionOrder.option_mini_campaign:
         prefix = "mini "
     else:
         prefix = ""
 
-    def mission_order_preset(name: str) -> Dict[str, str]:
+    def mission_order_preset(name: str) -> dict[str, str | bool]:
         return {
             "preset": prefix + name,
             "missions": missions,
             "shuffle_raceswaps": shuffle_raceswaps,
-            "keys": keys
+            "keys": keys,
         }
 
     prophecy_enabled = SC2Campaign.PROPHECY in enabled_campaigns
     wol_enabled = SC2Campaign.WOL in enabled_campaigns
     if wol_enabled:
-        mission_order[SC2Campaign.WOL.campaign_name] = mission_order_preset("wol") 
+        mission_order[SC2Campaign.WOL.campaign_name] = mission_order_preset("wol")
 
     if prophecy_enabled:
         mission_order[SC2Campaign.PROPHECY.campaign_name] = mission_order_preset("prophecy")
@@ -236,11 +254,11 @@ def create_static_mission_order(world: 'SC2World', mission_order_type: int, miss
         mission_order[SC2Campaign.EPILOGUE.campaign_name] = mission_order_preset("epilogue")
         entry_rules = []
         if SC2Campaign.WOL in enabled_campaigns:
-            entry_rules.append({ "scope": SC2Campaign.WOL.campaign_name })
+            entry_rules.append({"scope": SC2Campaign.WOL.campaign_name})
         if SC2Campaign.HOTS in enabled_campaigns:
-            entry_rules.append({ "scope": SC2Campaign.HOTS.campaign_name })
+            entry_rules.append({"scope": SC2Campaign.HOTS.campaign_name})
         if SC2Campaign.LOTV in enabled_campaigns:
-            entry_rules.append({ "scope": SC2Campaign.LOTV.campaign_name })
+            entry_rules.append({"scope": SC2Campaign.LOTV.campaign_name})
         mission_order[SC2Campaign.EPILOGUE.campaign_name]["entry_rules"] = entry_rules
 
     if SC2Campaign.NCO in enabled_campaigns:
@@ -249,11 +267,13 @@ def create_static_mission_order(world: 'SC2World', mission_order_type: int, miss
     # Resolve immediately so the layout updates are simpler
     mission_order = CustomMissionOrder(mission_order).value
 
-    # WoL requirements should count missions from Prophecy if both are enabled, and Prophecy should require a WoL mission
-    # There is a preset that already does this, but special-casing this way is easier to work with for other code
+    # WoL requirements should count missions from Prophecy if both are enabled,
+    # and Prophecy should require a WoL mission.
+    # There is a preset that already does this,
+    # but special-casing this way is easier to work with for other code.
     if wol_enabled and prophecy_enabled:
         fix_wol_prophecy_entry_rules(mission_order)
-    
+
     # Vanilla Shuffled is allowed to drop some slots
     if mission_order_type == MissionOrder.option_vanilla_shuffled:
         remove_missions(world, mission_order, mission_pools)
@@ -264,18 +284,18 @@ def create_static_mission_order(world: 'SC2World', mission_order_type: int, miss
     return mission_order
 
 
-def fix_wol_prophecy_entry_rules(mission_order: Dict[str, Dict[str, Any]]):
+def fix_wol_prophecy_entry_rules(mission_order: dict[str, dict[str, Any]]) -> None:
     prophecy_name = SC2Campaign.PROPHECY.campaign_name
 
     # Make the mission count entry rules in WoL also count Prophecy
-    def fix_entry_rule(entry_rule: Dict[str, Any], local_campaign_scope: str):
+    def fix_entry_rule(entry_rule: dict[str, Any], local_campaign_scope: str) -> None:
         # This appends Prophecy to any scope that points at the local campaign (WoL)
         if "scope" in entry_rule:
             if entry_rule["scope"] == local_campaign_scope:
                 entry_rule["scope"] = [local_campaign_scope, prophecy_name]
             elif isinstance(entry_rule["scope"], list) and local_campaign_scope in entry_rule["scope"]:
                 entry_rule["scope"] = entry_rule["scope"] + [prophecy_name]
-    
+
     for layout_dict in mission_order[SC2Campaign.WOL.campaign_name].values():
         if not isinstance(layout_dict, dict):
             continue
@@ -287,20 +307,31 @@ def fix_wol_prophecy_entry_rules(mission_order: Dict[str, Dict[str, Any]]):
                 if "entry_rules" in mission_dict:
                     for entry_rule in mission_dict["entry_rules"]:
                         fix_entry_rule(entry_rule, "../..")
-    
+
     # Make Prophecy require Artifact's second mission
-    mission_order[prophecy_name][prophecy_name]["entry_rules"] = [{ "scope": [f"{SC2Campaign.WOL.campaign_name}/Artifact/1"]}]
+    mission_order[prophecy_name][prophecy_name]["entry_rules"] = [
+        {"scope": [f"{SC2Campaign.WOL.campaign_name}/Artifact/1"]}
+    ]
 
 
-def force_final_missions(world: 'SC2World', mission_order: Dict[str, Dict[str, Any]], mission_order_type: int):
+def force_final_missions(
+    world: 'SC2World', mission_order: Dict[str, Dict[str, Any]], mission_order_type: int
+) -> None:
     goal_mission: Optional[SC2Mission] = None
     excluded_missions = get_excluded_missions(world)
     enabled_campaigns = get_enabled_campaigns(world)
     raceswap_variants = [mission for mission in SC2Mission if mission.flags & MissionFlag.RaceSwap]
     # Prefer long campaigns over shorter ones and harder missions over easier ones
-    goal_priorities = {campaign: get_campaign_goal_priority(campaign, excluded_missions) for campaign in enabled_campaigns}
+    goal_priorities = {
+        campaign: get_campaign_goal_priority(campaign, excluded_missions)
+        for campaign in enabled_campaigns
+    }
     goal_level = max(goal_priorities.values())
-    candidate_campaigns: List[SC2Campaign] = [campaign for campaign, goal_priority in goal_priorities.items() if goal_priority == goal_level]
+    candidate_campaigns: List[SC2Campaign] = [
+        campaign
+        for campaign, goal_priority in goal_priorities.items()
+        if goal_priority == goal_level
+    ]
     candidate_campaigns.sort(key=lambda it: it.id)
 
     # Vanilla Shuffled & Mini Campaign get a curated final mission
@@ -311,8 +342,14 @@ def force_final_missions(world: 'SC2World', mission_order: Dict[str, Dict[str, A
                 # No primary goal or its mission is excluded
                 candidate_missions = list(campaign_alt_final_mission_locations[goal_campaign].keys())
                 # Also allow raceswaps of curated final missions, provided they're not excluded
-                for candidate_with_raceswaps in [mission for mission in candidate_missions if mission.flags & MissionFlag.HasRaceSwap]:
-                    raceswap_candidates = [mission for mission in raceswap_variants if mission.map_file == candidate_with_raceswaps.map_file]
+                for candidate_with_raceswaps in candidate_missions:
+                    if not candidate_with_raceswaps.flags & MissionFlag.HasRaceSwap:
+                        continue
+                    raceswap_candidates = [
+                        mission
+                        for mission in raceswap_variants
+                        if mission.map_file == candidate_with_raceswaps.map_file
+                    ]
                     candidate_missions.extend(raceswap_candidates)
                 candidate_missions = [mission for mission in candidate_missions if mission not in excluded_missions]
                 if len(candidate_missions) == 0:
@@ -320,7 +357,7 @@ def force_final_missions(world: 'SC2World', mission_order: Dict[str, Dict[str, A
                 goal_mission = world.random.choice(candidate_missions)
             else:
                 goal_mission = primary_goal.mission
-            
+
             # The goal layout for static presets is the layout corresponding to the last key
             goal_layout = list(mission_order[goal_campaign.campaign_name].keys())[-1]
             goal_index = mission_order[goal_campaign.campaign_name][goal_layout]["size"] - 1
@@ -334,12 +371,19 @@ def force_final_missions(world: 'SC2World', mission_order: Dict[str, Dict[str, A
         if campaign not in candidate_campaigns:
             mission_order[campaign.campaign_name]["goal"] = False
 
-def remove_missions(world: 'SC2World', mission_order: Dict[str, Dict[str, Any]], mission_pools: SC2MOGenMissionPools):
+
+def remove_missions(
+    world: 'SC2World', mission_order: Dict[str, Dict[str, Any]], mission_pools: SC2MOGenMissionPools
+) -> None:
     enabled_campaigns = get_enabled_campaigns(world)
     removed_counts: Dict[SC2Campaign, Dict[str, int]] = {}
     for campaign in enabled_campaigns:
         # Count missing missions for each campaign individually
-        campaign_size = sum(layout["size"] for layout in mission_order[campaign.campaign_name].values() if type(layout) == dict)
+        campaign_size = sum(
+            layout["size"]
+            for layout in mission_order[campaign.campaign_name].values()
+            if isinstance(layout, dict)
+        )
         allowed_missions = mission_pools.count_allowed_missions(campaign)
         removal_count = campaign_size - allowed_missions
         if removal_count > len(removal_priorities[campaign]):
@@ -370,6 +414,7 @@ def remove_missions(world: 'SC2World', mission_order: Dict[str, Dict[str, Any]],
         # Remove the whole last layout if its size is 0
         if "Mission Pack 3" in removed_counts[SC2Campaign.NCO] and removed_counts[SC2Campaign.NCO]["Mission Pack 3"] == 3:
             mission_order[SC2Campaign.NCO.campaign_name].pop("Mission Pack 3")
+
 
 removal_priorities: Dict[SC2Campaign, List[str]] = {
     SC2Campaign.WOL: [
@@ -419,6 +464,7 @@ removal_priorities: Dict[SC2Campaign, List[str]] = {
     ]
 }
 
+
 def make_grid(world: 'SC2World', size: int) -> Dict[str, Dict[str, Any]]:
     mission_order = {
         "grid": {
@@ -429,6 +475,7 @@ def make_grid(world: 'SC2World', size: int) -> Dict[str, Dict[str, Any]]:
         }
     }
     return mission_order
+
 
 def make_golden_path(world: 'SC2World', size: int) -> Dict[str, Dict[str, Any]]:
     key_mode = world.options.key_mode.value
@@ -444,7 +491,7 @@ def make_golden_path(world: 'SC2World', size: int) -> Dict[str, Dict[str, Any]]:
         keys = "progressive_per_layout"
     else:
         keys = "none"
-    
+
     mission_order = {
         "golden path": {
             "display_name": "",
@@ -456,7 +503,8 @@ def make_golden_path(world: 'SC2World', size: int) -> Dict[str, Dict[str, Any]]:
     }
     return mission_order
 
-def make_gauntlet(size: int) -> Dict[str, Dict[str, Any]]:
+
+def make_gauntlet(size: int) -> dict[str, dict[str, Any]]:
     mission_order = {
         "gauntlet": {
             "display_name": "",
@@ -466,7 +514,8 @@ def make_gauntlet(size: int) -> Dict[str, Dict[str, Any]]:
     }
     return mission_order
 
-def make_blitz(size: int) -> Dict[str, Dict[str, Any]]:
+
+def make_blitz(size: int) -> dict[str, dict[str, Any]]:
     mission_order = {
         "blitz": {
             "display_name": "",
@@ -476,7 +525,8 @@ def make_blitz(size: int) -> Dict[str, Dict[str, Any]]:
     }
     return mission_order
 
-def make_hopscotch(world: 'SC2World', size: int) -> Dict[str, Dict[str, Any]]:
+
+def make_hopscotch(world: 'SC2World', size: int) -> dict[str, dict[str, Any]]:
     mission_order = {
         "hopscotch": {
             "display_name": "",
@@ -487,12 +537,15 @@ def make_hopscotch(world: 'SC2World', size: int) -> Dict[str, Dict[str, Any]]:
     }
     return mission_order
 
-def create_dynamic_mission_order(world: 'SC2World', mission_order_type: int, mission_pools: SC2MOGenMissionPools) -> Dict[str, Dict[str, Any]]:
+
+def create_dynamic_mission_order(
+    world: 'SC2World', mission_order_type: int, mission_pools: SC2MOGenMissionPools
+) -> dict[str, dict[str, Any]]:
     num_missions = min(mission_pools.get_allowed_mission_count(), world.options.maximum_campaign_size.value)
     num_missions = max(1, num_missions)
     if mission_order_type == MissionOrder.option_golden_path:
         return make_golden_path(world, num_missions)
-    
+
     if mission_order_type == MissionOrder.option_grid:
         mission_order = make_grid(world, num_missions)
     elif mission_order_type == MissionOrder.option_gauntlet:
@@ -503,20 +556,19 @@ def create_dynamic_mission_order(world: 'SC2World', mission_order_type: int, mis
         mission_order = make_hopscotch(world, num_missions)
     else:
         raise ValueError("Received unknown Mission Order type")
-    
+
     # Optionally add key requirements
     # This only works for layout types that don't define their own entry rules (which is currently all of them)
     # Golden Path handles Key Mode on its own
     key_mode = world.options.key_mode.value
     if key_mode == KeyMode.option_missions:
         mission_order[list(mission_order.keys())[0]]["missions"] = [
-            { "index": "all", "entry_rules": [{ "items": { "Key": 1 }}] },
-            { "index": "entrances", "entry_rules": [] }
+            {"index": "all", "entry_rules": [{"items": {"Key": 1}}]},
+            {"index": "entrances", "entry_rules": []}
         ]
     elif key_mode == KeyMode.option_progressive_missions:
         mission_order[list(mission_order.keys())[0]]["missions"] = [
-            { "index": "all", "entry_rules": [{ "items": { "Progressive Key": 1 }}] },
-            { "index": "entrances", "entry_rules": [] }
+            {"index": "all", "entry_rules": [{"items": {"Progressive Key": 1}}]},
+            {"index": "entrances", "entry_rules": []}
         ]
-    
     return mission_order


### PR DESCRIPTION
## What is this fixing or adding?
While investigating what github action workflows we wanted to leave on for the dev branch, I checked the mypy and flake8 logs for [PR #5538](https://github.com/ArchipelagoMW/Archipelago/pull/5538) and went through and fixed a bunch.

Note commit [5731ac0](https://github.com/archipelago-sc2/Archipelago/pull/7/commits/5731ac0cb9601bcf96d15626aab5009ee8584068) changes the github workflow files -- this will have to be reverted before merging to main. The changes are:
* Only run sc2 unit tests; this should mean less spurious failures from other apworlds
* Globally ignoring some warnings that are just useless:
  * C901: "function too complex" -- this one just seems to trigger if you have too many if statements
  * W503: "newline before binary operator" -- PEP8 actually changed and now recommends this, flake8 is just out-of-date
* Ignoring some flake8 exclusions around parenthesis alignment and spacing in mission_tables.py
  * I deemed these issues as something we're unlikely to ever address; my hope is that this leaves the log a little bit clearer for people to take a peek at and actually get actionable code format issues flagged
  * [E227](https://www.flake8rules.com/rules/E227.html): "Missing whitespace around bitwise or shift operator" -- it wants spaces around `|` in `flag | flag`
  * [E501](https://www.flake8rules.com/rules/E501.html): "Line too long" (> 120 characters)
  * [E221](https://www.flake8rules.com/rules/E221.html): "multiple spaces before operator" -- this is complaining about aligning `=` in some places
* Ignoring some warnings for all sc2 files, as I figure these are part of our style at this point
  * [E124](https://www.flake8rules.com/rules/E124.html): "closing bracket does not match visual indentation"
    * Basically saying that if you want a multi-line `if (<long expression>):` either a newline has to be added before `<long expression>` or `):` will get indented to match `(`, which is very visually unclear. I consider this a minor bug on flake8's part
  * [E128](https://www.flake8rules.com/rules/E128.html): "Continuation line under-indented for visual indent" -- basically same as E124, but for `or (` and `and (`, which come up pretty often in rules.py

## How was this tested?
Activated the github actions for the repo and we will see how the log looks.

* The flake8 report is about 175 lines shorter (~250 lines -> ~75).
  * Most of the remaining issues are just too long lines in option descriptions
* The mypy report is down to just 4 lines lines shorter (56 -> 4)

## If this makes graphical changes, please attach screenshots.
None