### PR TITLE
[SC2] Replace Chat system + AP Controller Unit with Banks

### DIFF
--- a/worlds/sc2/banks.py
+++ b/worlds/sc2/banks.py
@@ -74,10 +74,8 @@ def get_bank_folder() -> str:
     return result
 
 
-class SC2Bank():
+class SC2Bank:
     # Has the same structure as bank files provided by SC2
-    file_name = "NewBank"
-    sections = {}
     def __init__(self, name: str) -> None:
         self.file_name = name
         self.sections: typing.Dict[str, typing.Dict[str, str]] = {}

--- a/worlds/sc2/banks.py
+++ b/worlds/sc2/banks.py
@@ -1,9 +1,9 @@
 from pathlib import Path
 from glob import glob
-from typing import Dict, List
 import queue
 import os.path
 import re
+import logging
 
 # Banks are XML files used to communicate with Starcraft 2
 # file names, section names and key names have to match the SC2 trigger implementation
@@ -62,6 +62,8 @@ BANK_TRADE_SEND_KEY_RECEIVE_COUNT = "Count"
 # Limit for how many backup banks are saved per bank file
 BANK_BACKUP_FILE_LIMIT = 100
 
+logger = logging.getLogger("Starcraft2")
+
 # file path to bank folder.
 def get_bank_folder() -> str:
     # handle documents folder backed up by cloud service (OneDrive)
@@ -78,7 +80,7 @@ class SC2Bank:
     # Has the same structure as bank files provided by SC2
     def __init__(self, name: str) -> None:
         self.file_name: str = name
-        self.sections: Dict[str, Dict[str, str]] = {}
+        self.sections: dict[str, dict[str, str]] = {}
 
     def __str__(self) -> str:
         result: list[str] = []
@@ -178,7 +180,7 @@ class SC2Bank:
                 return
         # only the messages bank has any chance to hit this
         # at current limits, this would be attempting to send 5000 messages in a single iteration
-        # sc2_logger.info(f"Too many bank backups, cannot write:\n{self}")
+        logger.info(f"Too many bank backups, cannot write:\n{self}")
 
     def remove_entry_from_file(self, key: str) -> None:
         # Remove one Key/Value pair from a bank file
@@ -294,7 +296,7 @@ def send_ap_messages_from_queue(message_queue: queue.Queue):
         send_ap_message(messages)
 
 
-def send_ap_message(messages: List[str]):
+def send_ap_message(messages: list[str]):
     # message list is expected to not contain more than KEY_LIMIT messages
     bank = SC2Bank(BANK_MESSAGES_FILE_NAME)
     if messages:

--- a/worlds/sc2/banks.py
+++ b/worlds/sc2/banks.py
@@ -1,0 +1,322 @@
+from pathlib import Path
+import typing
+import os.path
+import re
+
+# Banks are XML files used to communicate with Starcraft 2
+# file names, section names and key names have to match the SC2 trigger implementation
+#
+# Client -> SC2
+# Core Options
+BANK_CORE_OPTIONS_FILE_NAME = "ArchipelagoCoreOptions" # .SC2Bank
+BANK_CORE_OPTIONS_SECTION_CORE_OPTIONS = "CoreOptions"
+BANK_CORE_OPTIONS_KEY_STARTING_RESOURCES = "StartingResources"
+BANK_CORE_OPTIONS_KEY_FACTION_COLORS = "FactionColors"
+BANK_CORE_OPTIONS_KEY_UNCOLLECTED_LOCATIONS = "UncollectedLocations"
+BANK_CORE_OPTIONS_KEY_LOAD_FINISHED = "LoadFinished"
+
+# Options
+# 2 types of options because they are handled in different mod files by SC2
+BANK_OPTIONS_FILE_NAME = "ArchipelagoOptions" # .SC2Bank
+BANK_OPTIONS_SECTION_OPTIONS = "GameOptions"
+BANK_OPTIONS_KEY_OPTIONS = "Options"
+
+# Items
+BANK_ITEMS_FILE_NAME = "ArchipelagoItems" # .SC2Bank
+BANK_ITEMS_SECTION_ITEMS = "Items"
+BANK_ITEMS_KEY_TERRAN_ITEMS = "TerranItems"
+BANK_ITEMS_KEY_ZERG_ITEMS = "ZergItems"
+BANK_ITEMS_KEY_PROTOSS_ITEMS = "ProtossItems"
+BANK_ITEMS_KEY_MISC_ITEMS = "MiscItems"
+
+# Messages
+BANK_MESSAGES_FILE_NAME = "ArchipelagoMessages" # .SC2Bank
+BANK_MESSAGES_SECTION_MESSAGES = "Messages"
+BANK_MESSAGES_KEY_MESSAGE = "Message" # Appends message number 'Message1' 'Message2' ...
+BANK_MESSAGES_KEY_LIMIT = 50 # Limit for messages per bank
+
+# Void Trade Receive (messages received by SC2)
+BANK_TRADE_RECEIVE_FILE_NAME = "ArchipelagoVoidTradeReceive" # .SC2Bank
+BANK_TRADE_RECEIVE_SECTION_TRADE = "VoidTrade"
+BANK_TRADE_RECEIVE_KEY_TRADE_RESPONSE = "TradeResponse"
+
+# SC2 -> Client
+# Locations 
+BANK_LOCATIONS_FILE_NAME = "ArchipelagoLocations" # .SC2Bank
+BANK_LOCATIONS_SECTION_LOCATIONS = "Locations"
+BANK_LOCATIONS_KEY_GAME_STATE = "GameState"
+
+# Update
+# Doesn't need sections or keys. The existence of the file is used as an update prompt for now
+BANK_UPDATE_NAME = "ArchipelagoUpdate" #.SC2Bank
+
+# Void Trade Send (messages sent by SC2)
+BANK_TRADE_SEND_FILE_NAME = "ArchipelagoVoidTradeSend"
+BANK_TRADE_SEND_SECTION_UNITS = "VoidTradeUnits"
+BANK_TRADE_SEND_KEY_UNIT_TYPES = "UnitTypes"
+BANK_TRADE_SEND_SECTION_RECEIVE_REQUEST = "VoidTradeReceiveRequest"
+BANK_TRADE_SEND_KEY_RECEIVE_COUNT = "Count"
+
+# file path to bank folder.
+def get_bank_folder() -> str:
+    return os.path.expanduser("~/Documents/StarCraft II/Banks")
+
+
+class SC2Bank():
+    # Banks are XML files used to handle communication between SC2 and the AP Client
+    file_name = "NewBank"
+    sections = {}
+    def __init__(self, name: str) -> None:
+        self.file_name = name
+        self.sections: typing.Dict[str, typing.Dict[str, str]] = {}
+    
+    def __str__(self) -> str:
+        result = []
+        result.append(f'{self.file_name}.SC2Bank:')
+        for name, section in self.sections.items():
+            result.append(f'Section {name}:')
+            for key, value in section.items():
+                result.append(f'  Key {key}:')
+                result.append(f'    Value: {value}')
+        return ('\n'.join(result))
+        
+    def add_section(self, section: str) -> None:
+        self.sections[section] = {}
+
+    def add_entry(self, section: str, key: str, value: str) -> None:
+        if not section in self.sections:
+            self.add_section(section)
+        self.sections[section][key] = value 
+    
+    def get_value(self, section: str, key: str) -> str:
+        result = ""
+        if section in self.sections:
+            if key in self.sections[section]:
+                result = self.sections[section][key]
+        return result
+
+    def read_file(self, path: str = None) -> None:
+        # Read a bank file provided by SC2 and convert it into an SC2Bank object
+        # Assumes bank files to follow the structure provided by the game
+        # Asserts catch malformed files, should never happen unless the player manually edits the files
+        if not path:
+            path = f"{get_bank_folder()}/{self.file_name}.SC2Bank"
+        if not os.path.isfile(path):
+            return
+        with open(path, "r") as f:
+            SECTION_PATTERN = re.compile(r'<Section name="(\w+)">')
+            KEY_PATTERN = re.compile(r'<Key name="(\w+)">')
+            VALUE_PATTERN = re.compile(r'<Value string="([^"]+)"/>')
+            END_KEY_PATTERN = '</Key>'
+            END_SECTION_PATTERN = '</Section>'
+            section = '' # Use the presence of a section/key as the state variable
+            key = ''     # empty string is not present
+            lines = f.readlines()
+            for line in lines:
+                line_content = line.strip()
+                if (m := SECTION_PATTERN.match(line_content)):
+                    assert not section, f"Encountered section {m.group(1)} while already inside section {section}"
+                    section = m.group(1)
+                    self.add_section(section)
+                    assert section not in self.sections.items(), f"Duplicate section definition for section {section}"
+                elif (m := KEY_PATTERN.match(line_content)):
+                    assert section, "Encountered a key while not in a section"
+                    assert not key, f"Encountered key {m.group(1)} while already inside key {key}"
+                    key = m.group(1)
+                    assert key not in self.sections[section].items(), f"Duplicate key definition for key {key}"
+                elif (m := VALUE_PATTERN.match(line_content)):
+                    assert section, "Encountered a value while not in a section"
+                    assert key, "Encountered a value while not in a key"
+                    value = m.group(1)
+                    self.add_entry(section, key, value)
+                elif line_content == END_KEY_PATTERN:
+                    assert key, "Closing a key while not already in a key"
+                    key = ''
+                elif line_content == END_SECTION_PATTERN:
+                    assert section, "Closing a section while not already in a section"
+                    section = ''
+                else:
+                    pass
+
+    def write_file(self) -> None:
+        # Write a bank file with the formatting expected from SC2
+        # SC2 reads data by restoring a bank from a backup
+        # so we write the new backup file here
+        dir = f"{get_bank_folder()}/Backup"
+        lines = []
+        lines.append(         f'<?xml version="1.0" encoding="utf-8"?>')
+        lines.append(         f'<Bank version="1">')
+        for name, section in self.sections.items():
+            lines.append(     f'    <Section name="{name}">')
+            for key, value in section.items():
+                lines.append( f'        <Key name="{key}">')
+                lines.append( f'            <Value string="{value}"/>')
+                lines.append( f'        </Key>')
+            lines.append(     f'    </Section>')
+        lines.append(         f'</Bank>')
+        Path(dir).mkdir(parents=True, exist_ok=True)
+        # TODO: Handle multiple backups in the same step (if needed)
+        with open(f"{dir}/{self.file_name}_backup_1.SC2Bank", "w") as f:
+            f.write('\n'.join(lines))
+        
+    def remove_entry_from_file(self, key: str) -> None:
+        # Remove one Key/Value pair from a bank file
+        path = f"{get_bank_folder()}/{self.file_name}"
+        with open(path, "r") as f:
+            lines = f.readlines()
+        with open(path, "w") as f:
+            deleting = False
+            for line in lines:
+                line_content = line.strip()
+                # Just find the key tag
+                if line_content == f'<Key name="{key}">':
+                    deleting = True
+                # and delete all lines until finding the closing tag
+                elif line_content == '</Key>':
+                    deleting = False
+                elif not deleting:
+                    f.write(line)         
+            
+
+def file_cleanup() -> None:
+    # Use at the start of a mission to delete old bank files
+    # Locations needs cleanup, others are optional
+    Path(f"{get_bank_folder()}/{BANK_LOCATIONS_FILE_NAME}.SC2Bank").unlink(missing_ok=True)
+
+def send_options(msg: str) -> None:
+    bank = SC2Bank(BANK_OPTIONS_FILE_NAME)
+    bank.add_entry(
+        BANK_OPTIONS_SECTION_OPTIONS, 
+        BANK_OPTIONS_KEY_OPTIONS, 
+        msg
+    )
+    bank.write_file()
+
+def send_core_options(
+        start_resources: str, 
+        colors: str, 
+        uncollected_objectives: str = None, 
+        finished_loading: str = None
+    ) -> None:
+    bank = SC2Bank(BANK_CORE_OPTIONS_FILE_NAME)
+    bank.add_entry(
+        BANK_CORE_OPTIONS_SECTION_CORE_OPTIONS, 
+        BANK_CORE_OPTIONS_KEY_STARTING_RESOURCES, 
+        start_resources
+    )
+    bank.add_entry(
+        BANK_CORE_OPTIONS_SECTION_CORE_OPTIONS,
+        BANK_CORE_OPTIONS_KEY_FACTION_COLORS,
+        colors
+    )
+    if uncollected_objectives:
+        bank.add_entry(
+            BANK_CORE_OPTIONS_SECTION_CORE_OPTIONS,
+            BANK_CORE_OPTIONS_KEY_UNCOLLECTED_LOCATIONS,
+            uncollected_objectives
+        )
+    if finished_loading:
+        bank.add_entry(
+            BANK_CORE_OPTIONS_SECTION_CORE_OPTIONS,
+            BANK_CORE_OPTIONS_KEY_LOAD_FINISHED,
+            finished_loading
+        )
+    bank.write_file()
+
+def send_items(
+        terran_items: str,
+        zerg_items: str,
+        protoss_items: str,
+        misc_items: str, 
+    ) -> None:
+    bank = SC2Bank(BANK_ITEMS_FILE_NAME)
+    bank.add_entry(
+        BANK_ITEMS_SECTION_ITEMS, 
+        BANK_ITEMS_KEY_TERRAN_ITEMS, 
+        terran_items
+    )
+    bank.add_entry(
+        BANK_ITEMS_SECTION_ITEMS, 
+        BANK_ITEMS_KEY_ZERG_ITEMS, 
+        zerg_items
+    )
+    bank.add_entry(
+        BANK_ITEMS_SECTION_ITEMS, 
+        BANK_ITEMS_KEY_PROTOSS_ITEMS, 
+        protoss_items
+    )
+    bank.add_entry(
+        BANK_ITEMS_SECTION_ITEMS, 
+        BANK_ITEMS_KEY_MISC_ITEMS, 
+        misc_items
+    )
+    bank.write_file()
+
+def clean_ap_message(message: str) -> str:
+    return message.replace('<','&lt;').replace('>','&gt;').replace('"','&quot;')
+
+def send_ap_message(messages: typing.List[str]):
+    bank = SC2Bank(BANK_MESSAGES_FILE_NAME)
+    if messages:
+        i = 0
+        for msg in messages:
+            if msg:
+                # TODO: Check for limits/staggering
+                i+=1
+                bank.add_entry(
+                    BANK_MESSAGES_SECTION_MESSAGES,
+                    f"{BANK_MESSAGES_KEY_MESSAGE}{str(i)}", 
+                    clean_ap_message(msg)
+                )
+        if i > 0:
+            bank.write_file()
+
+def update_prompt() -> bool:
+    result = False
+    path =f"{get_bank_folder()}/{BANK_UPDATE_NAME}.SC2Bank"
+    if os.path.isfile(path):
+        # if bank exists, we want an update prompt. No need to check the values
+        os.remove(path)
+        result = True
+    return result
+
+def read_locations() -> str:
+    bank = SC2Bank(BANK_LOCATIONS_FILE_NAME)
+    bank.read_file()
+    result = bank.get_value(
+        BANK_LOCATIONS_SECTION_LOCATIONS,
+        BANK_LOCATIONS_KEY_GAME_STATE
+    )
+    return result
+
+# Void Trade
+def send_trade_received(msg: str) -> None:
+    bank = SC2Bank(BANK_TRADE_RECEIVE_FILE_NAME)
+    bank.add_entry(
+        BANK_TRADE_RECEIVE_SECTION_TRADE, 
+        BANK_TRADE_RECEIVE_KEY_TRADE_RESPONSE, 
+        msg
+    )
+    bank.write_file()
+
+def read_trade_units() -> str:
+    bank = SC2Bank(BANK_TRADE_SEND_FILE_NAME)
+    bank.read_file()
+    result = bank.get_value(
+        BANK_TRADE_SEND_SECTION_UNITS,
+        BANK_TRADE_SEND_KEY_UNIT_TYPES
+    )
+    if result:
+        bank.remove_entry_from_file(BANK_TRADE_SEND_KEY_UNIT_TYPES)
+    return result
+
+def read_trade_receive_request() -> str:
+    bank = SC2Bank(BANK_TRADE_SEND_FILE_NAME)
+    bank.read_file()
+    result = bank.get_value(
+        BANK_TRADE_SEND_SECTION_RECEIVE_REQUEST,
+        BANK_TRADE_SEND_KEY_RECEIVE_COUNT
+    )
+    if result:
+        bank.remove_entry_from_file(BANK_TRADE_SEND_KEY_RECEIVE_COUNT)
+    return result

--- a/worlds/sc2/banks.py
+++ b/worlds/sc2/banks.py
@@ -61,11 +61,13 @@ BANK_TRADE_SEND_KEY_RECEIVE_COUNT = "Count"
 # file path to bank folder.
 def get_bank_folder() -> str:
     # handle documents folder backed up by cloud service (OneDrive)
-    banks_folder = glob(os.path.expanduser("~\\*\\Documents\\StarCraft II\\Banks"))
-    if len(banks_folder) == 0:
-        banks_folder = os.path.expanduser("~\\Documents\\StarCraft II\\Banks")
-    assert len(banks_folder) > 0, "Banks folder not found" 
-    return banks_folder
+    banks_folders = glob(os.path.expanduser("~\\*\\Documents\\StarCraft II\\Banks"))
+    if len(banks_folders) > 0:
+        result = banks_folders[0]
+    else:
+        result = os.path.expanduser("~\\Documents\\StarCraft II\\Banks")
+    assert len(result) > 0, "Banks folder not found" 
+    return result
 
 
 class SC2Bank():

--- a/worlds/sc2/banks.py
+++ b/worlds/sc2/banks.py
@@ -49,7 +49,7 @@ BANK_LOCATIONS_KEY_GAME_STATE = "GameState"
 
 # Update
 # Doesn't need sections or keys. The existence of the file is used as an update prompt for now
-BANK_UPDATE_NAME = "ArchipelagoUpdate" #.SC2Bank
+BANK_UPDATE_FILE_NAME = "ArchipelagoUpdate" #.SC2Bank
 
 # Void Trade Send (messages sent by SC2)
 BANK_TRADE_SEND_FILE_NAME = "ArchipelagoVoidTradeSend"
@@ -281,7 +281,7 @@ def send_ap_message(messages: typing.List[str]):
 
 def update_prompt() -> bool:
     result = False
-    path =f"{get_bank_folder()}\\{BANK_UPDATE_NAME}.SC2Bank"
+    path =f"{get_bank_folder()}\\{BANK_UPDATE_FILE_NAME}.SC2Bank"
     if os.path.isfile(path):
         # if bank exists, we want an update prompt. No need to check the values
         os.remove(path)

--- a/worlds/sc2/banks.py
+++ b/worlds/sc2/banks.py
@@ -150,7 +150,7 @@ class SC2Bank():
         # Write a bank file with the formatting expected from SC2
         # SC2 reads data by restoring a bank from a backup
         # so we write the new backup file here
-        dir = f"{get_bank_folder()}/Backup"
+        dir = f"{get_bank_folder()}\\Backup"
         lines = []
         lines.append(         f'<?xml version="1.0" encoding="utf-8"?>')
         lines.append(         f'<Bank version="1">')
@@ -164,12 +164,12 @@ class SC2Bank():
         lines.append(         f'</Bank>')
         Path(dir).mkdir(parents=True, exist_ok=True)
         # TODO: Handle multiple backups in the same step (if needed)
-        with open(f"{dir}/{self.file_name}_backup_1.SC2Bank", "w") as f:
+        with open(f"{dir}\\{self.file_name}_backup_1.SC2Bank", "w") as f:
             f.write('\n'.join(lines))
         
     def remove_entry_from_file(self, key: str) -> None:
         # Remove one Key/Value pair from a bank file
-        path = f"{get_bank_folder()}/{self.file_name}"
+        path = f"{get_bank_folder()}\\{self.file_name}.SC2Bank"
         with open(path, "r") as f:
             lines = f.readlines()
         with open(path, "w") as f:
@@ -189,7 +189,7 @@ class SC2Bank():
 def file_cleanup() -> None:
     # Use at the start of a mission to delete old bank files
     # Locations needs cleanup, others are optional
-    Path(f"{get_bank_folder()}/{BANK_LOCATIONS_FILE_NAME}.SC2Bank").unlink(missing_ok=True)
+    Path(f"{get_bank_folder()}\\{BANK_LOCATIONS_FILE_NAME}.SC2Bank").unlink(missing_ok=True)
 
 def send_options(msg: str) -> None:
     bank = SC2Bank(BANK_OPTIONS_FILE_NAME)
@@ -281,7 +281,7 @@ def send_ap_message(messages: typing.List[str]):
 
 def update_prompt() -> bool:
     result = False
-    path =f"{get_bank_folder()}/{BANK_UPDATE_NAME}.SC2Bank"
+    path =f"{get_bank_folder()}\\{BANK_UPDATE_NAME}.SC2Bank"
     if os.path.isfile(path):
         # if bank exists, we want an update prompt. No need to check the values
         os.remove(path)

--- a/worlds/sc2/banks.py
+++ b/worlds/sc2/banks.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+from glob import glob
 import typing
 import os.path
 import re
@@ -59,11 +60,16 @@ BANK_TRADE_SEND_KEY_RECEIVE_COUNT = "Count"
 
 # file path to bank folder.
 def get_bank_folder() -> str:
-    return os.path.expanduser("~/Documents/StarCraft II/Banks")
+    # handle documents folder backed up by cloud service (OneDrive)
+    banks_folder = glob(os.path.expanduser("~\\*\\Documents\\StarCraft II\\Banks"))
+    if len(banks_folder) == 0:
+        banks_folder = os.path.expanduser("~\\Documents\\StarCraft II\\Banks")
+    assert len(banks_folder) > 0, "Banks folder not found" 
+    return banks_folder
 
 
 class SC2Bank():
-    # Banks are XML files used to handle communication between SC2 and the AP Client
+    # Has the same structure as bank files provided by SC2
     file_name = "NewBank"
     sections = {}
     def __init__(self, name: str) -> None:

--- a/worlds/sc2/banks.py
+++ b/worlds/sc2/banks.py
@@ -1,6 +1,6 @@
 from pathlib import Path
 from glob import glob
-import typing
+from typing import Dict, List
 import queue
 import os.path
 import re
@@ -43,7 +43,7 @@ BANK_TRADE_RECEIVE_SECTION_TRADE = "VoidTrade"
 BANK_TRADE_RECEIVE_KEY_TRADE_RESPONSE = "TradeResponse"
 
 # SC2 -> Client
-# Locations 
+# Locations
 BANK_LOCATIONS_FILE_NAME = "ArchipelagoLocations" # .SC2Bank
 BANK_LOCATIONS_SECTION_LOCATIONS = "Locations"
 BANK_LOCATIONS_KEY_GAME_STATE = "GameState"
@@ -65,23 +65,23 @@ BANK_BACKUP_FILE_LIMIT = 100
 # file path to bank folder.
 def get_bank_folder() -> str:
     # handle documents folder backed up by cloud service (OneDrive)
-    banks_folders = glob(os.path.expanduser("~\\*\\Documents\\StarCraft II\\Banks"))
+    banks_folders = glob(os.path.expanduser("~/*/Documents/StarCraft II/Banks"))
     if len(banks_folders) > 0:
         result = banks_folders[0]
     else:
-        result = os.path.expanduser("~\\Documents\\StarCraft II\\Banks")
-    assert os.path.isdir(result), "Banks folder not found" 
+        result = os.path.expanduser("~/Documents/StarCraft II/Banks")
+    assert os.path.isdir(result), "Banks folder not found"
     return result
 
 
 class SC2Bank:
     # Has the same structure as bank files provided by SC2
     def __init__(self, name: str) -> None:
-        self.file_name = name
-        self.sections: typing.Dict[str, typing.Dict[str, str]] = {}
-    
+        self.file_name: str = name
+        self.sections: Dict[str, Dict[str, str]] = {}
+
     def __str__(self) -> str:
-        result = []
+        result: list[str] = []
         result.append(f'{self.file_name}.SC2Bank:')
         for name, section in self.sections.items():
             result.append(f'Section {name}:')
@@ -89,15 +89,15 @@ class SC2Bank:
                 result.append(f'  Key {key}:')
                 result.append(f'    Value: {value}')
         return ('\n'.join(result))
-        
+
     def add_section(self, section: str) -> None:
         self.sections[section] = {}
 
     def add_entry(self, section: str, key: str, value: str) -> None:
-        if not section in self.sections:
+        if section not in self.sections:
             self.add_section(section)
-        self.sections[section][key] = value 
-    
+        self.sections[section][key] = value
+
     def get_value(self, section: str, key: str) -> str:
         result = ""
         if section in self.sections:
@@ -106,11 +106,13 @@ class SC2Bank:
         return result
 
     def read_file(self, path: str = None) -> None:
-        # Read a bank file provided by SC2 and convert it into an SC2Bank object
-        # Assumes bank files to follow the structure provided by the game
-        # Asserts catch malformed files, should never happen unless the player manually edits the files
+        """
+        Reads a bank file provided by SC2 and converts it into an SC2Bank object.
+        Assumes bank files follow the structure provided by the game.
+        Asserts catch malformed files, which should never happen unless the player manually edits the files.
+        """
         if not path:
-            path = f"{get_bank_folder()}\\{self.file_name}.SC2Bank"
+            path = f"{get_bank_folder()}/{self.file_name}.SC2Bank"
         if not os.path.isfile(path):
             return
         with open(path, "r") as f:
@@ -152,8 +154,8 @@ class SC2Bank:
         # Write a bank file with the formatting expected from SC2
         # SC2 reads data by restoring a bank from a backup
         # so we write the new backup file here
-        dir = f"{get_bank_folder()}\\Backup"
-        lines = []
+        dir = f"{get_bank_folder()}/Backup"
+        lines: list[str] = []
         lines.append(         f'<?xml version="1.0" encoding="utf-8"?>')
         lines.append(         f'<Bank version="1">')
         for name, section in self.sections.items():
@@ -167,21 +169,20 @@ class SC2Bank:
         Path(dir).mkdir(parents=True, exist_ok=True)
         # The game deletes a backup after reading. If a backup exists already, the game didn't read it yet
         # In that case, just make a second backup, the game will read them in sequence
-        for i in range (1,BANK_BACKUP_FILE_LIMIT + 1):
+        for i in range (1, BANK_BACKUP_FILE_LIMIT + 1):
             # start at 1, makes handling in SC2 easier
-            path = f"{dir}\\{self.file_name}_backup_{i}.SC2Bank" 
+            path = f"{dir}/{self.file_name}_backup_{i}.SC2Bank"
             if not os.path.isfile(path):
                 with open(path, "w") as f:
                     f.write('\n'.join(lines))
                 return
         # only the messages bank has any chance to hit this
         # at current limits, this would be attempting to send 5000 messages in a single iteration
-        print("Too many bank backups, cannot write:")
-        print(self)
+        # sc2_logger.info(f"Too many bank backups, cannot write:\n{self}")
 
     def remove_entry_from_file(self, key: str) -> None:
         # Remove one Key/Value pair from a bank file
-        path = f"{get_bank_folder()}\\{self.file_name}.SC2Bank"
+        path = f"{get_bank_folder()}/{self.file_name}.SC2Bank"
         with open(path, "r") as f:
             lines = f.readlines()
         with open(path, "w") as f:
@@ -195,33 +196,35 @@ class SC2Bank:
                 elif line_content == '</Key>':
                     deleting = False
                 elif not deleting:
-                    f.write(line)         
-            
+                    f.write(line)
+
 
 def file_cleanup() -> None:
     # Use at the start of a mission to delete old bank files
     # Locations needs cleanup, others are optional
-    Path(f"{get_bank_folder()}\\{BANK_LOCATIONS_FILE_NAME}.SC2Bank").unlink(missing_ok=True)
+    Path(f"{get_bank_folder()}/{BANK_LOCATIONS_FILE_NAME}.SC2Bank").unlink(missing_ok=True)
+
 
 def send_options(msg: str) -> None:
     bank = SC2Bank(BANK_OPTIONS_FILE_NAME)
     bank.add_entry(
-        BANK_OPTIONS_SECTION_OPTIONS, 
-        BANK_OPTIONS_KEY_OPTIONS, 
+        BANK_OPTIONS_SECTION_OPTIONS,
+        BANK_OPTIONS_KEY_OPTIONS,
         msg
     )
     bank.write_file()
 
+
 def send_core_options(
-        start_resources: str, 
-        colors: str, 
-        uncollected_objectives: str = None, 
-        finished_loading: str = None
-    ) -> None:
+    start_resources: str,
+    colors: str,
+    uncollected_objectives: str = None,
+    finished_loading: str = None
+) -> None:
     bank = SC2Bank(BANK_CORE_OPTIONS_FILE_NAME)
     bank.add_entry(
-        BANK_CORE_OPTIONS_SECTION_CORE_OPTIONS, 
-        BANK_CORE_OPTIONS_KEY_STARTING_RESOURCES, 
+        BANK_CORE_OPTIONS_SECTION_CORE_OPTIONS,
+        BANK_CORE_OPTIONS_KEY_STARTING_RESOURCES,
         start_resources
     )
     bank.add_entry(
@@ -243,74 +246,80 @@ def send_core_options(
         )
     bank.write_file()
 
+
 def send_items(
         terran_items: str,
         zerg_items: str,
         protoss_items: str,
-        misc_items: str, 
+        misc_items: str,
     ) -> None:
     bank = SC2Bank(BANK_ITEMS_FILE_NAME)
     bank.add_entry(
-        BANK_ITEMS_SECTION_ITEMS, 
-        BANK_ITEMS_KEY_TERRAN_ITEMS, 
+        BANK_ITEMS_SECTION_ITEMS,
+        BANK_ITEMS_KEY_TERRAN_ITEMS,
         terran_items
     )
     bank.add_entry(
-        BANK_ITEMS_SECTION_ITEMS, 
-        BANK_ITEMS_KEY_ZERG_ITEMS, 
+        BANK_ITEMS_SECTION_ITEMS,
+        BANK_ITEMS_KEY_ZERG_ITEMS,
         zerg_items
     )
     bank.add_entry(
-        BANK_ITEMS_SECTION_ITEMS, 
-        BANK_ITEMS_KEY_PROTOSS_ITEMS, 
+        BANK_ITEMS_SECTION_ITEMS,
+        BANK_ITEMS_KEY_PROTOSS_ITEMS,
         protoss_items
     )
     bank.add_entry(
-        BANK_ITEMS_SECTION_ITEMS, 
-        BANK_ITEMS_KEY_MISC_ITEMS, 
+        BANK_ITEMS_SECTION_ITEMS,
+        BANK_ITEMS_KEY_MISC_ITEMS,
         misc_items
     )
     bank.write_file()
 
-def clean_ap_message(message: str) -> str:
-    return message.replace('<','&lt;').replace('>','&gt;').replace('"','&quot;')
 
-def send_ap_messages_from_queue(messageQueue: queue.Queue):
+def escape_ap_message(message: str) -> str:
+    return message.replace('&', '&amp;').replace('<', '&lt;').replace('>', '&gt;').replace('"', '&quot;')
+
+
+def send_ap_messages_from_queue(message_queue: queue.Queue):
     messages = []
     for i in range(BANK_MESSAGES_KEY_LIMIT):
         # send up to KEY_LIMIT messages in a single bank file
-        if not messageQueue.empty(): 
-            messages.append(messageQueue.get_nowait())
-            messageQueue.task_done()
+        if not message_queue.empty():
+            messages.append(message_queue.get_nowait())
+            message_queue.task_done()
         else:
             break
     if messages:
         send_ap_message(messages)
 
-def send_ap_message(messages: typing.List[str]):
+
+def send_ap_message(messages: List[str]):
     # message list is expected to not contain more than KEY_LIMIT messages
     bank = SC2Bank(BANK_MESSAGES_FILE_NAME)
     if messages:
         i = 0
         for msg in messages:
             if msg and i < BANK_MESSAGES_KEY_LIMIT:
-                i+=1
+                i += 1
                 bank.add_entry(
                     BANK_MESSAGES_SECTION_MESSAGES,
-                    f"{BANK_MESSAGES_KEY_MESSAGE}{str(i)}", 
-                    clean_ap_message(msg)
+                    f"{BANK_MESSAGES_KEY_MESSAGE}{str(i)}",
+                    escape_ap_message(msg)
                 )
         if i > 0:
             bank.write_file()
 
+
 def update_prompt() -> bool:
     result = False
-    path =f"{get_bank_folder()}\\{BANK_UPDATE_FILE_NAME}.SC2Bank"
+    path = f"{get_bank_folder()}/{BANK_UPDATE_FILE_NAME}.SC2Bank"
     if os.path.isfile(path):
         # if bank exists, we want an update prompt. No need to check the values
         os.remove(path)
         result = True
     return result
+
 
 def read_locations() -> str:
     bank = SC2Bank(BANK_LOCATIONS_FILE_NAME)
@@ -321,15 +330,17 @@ def read_locations() -> str:
     )
     return result
 
+
 # Void Trade
 def send_trade_received(msg: str) -> None:
     bank = SC2Bank(BANK_TRADE_RECEIVE_FILE_NAME)
     bank.add_entry(
-        BANK_TRADE_RECEIVE_SECTION_TRADE, 
-        BANK_TRADE_RECEIVE_KEY_TRADE_RESPONSE, 
+        BANK_TRADE_RECEIVE_SECTION_TRADE,
+        BANK_TRADE_RECEIVE_KEY_TRADE_RESPONSE,
         msg
     )
     bank.write_file()
+
 
 def read_trade_units() -> str:
     bank = SC2Bank(BANK_TRADE_SEND_FILE_NAME)
@@ -341,6 +352,7 @@ def read_trade_units() -> str:
     if result:
         bank.remove_entry_from_file(BANK_TRADE_SEND_KEY_UNIT_TYPES)
     return result
+
 
 def read_trade_receive_request() -> str:
     bank = SC2Bank(BANK_TRADE_SEND_FILE_NAME)

--- a/worlds/sc2/banks.py
+++ b/worlds/sc2/banks.py
@@ -248,11 +248,11 @@ def send_core_options(
 
 
 def send_items(
-        terran_items: str,
-        zerg_items: str,
-        protoss_items: str,
-        misc_items: str,
-    ) -> None:
+    terran_items: str,
+    zerg_items: str,
+    protoss_items: str,
+    misc_items: str,
+) -> None:
     bank = SC2Bank(BANK_ITEMS_FILE_NAME)
     bank.add_entry(
         BANK_ITEMS_SECTION_ITEMS,

--- a/worlds/sc2/banks.py
+++ b/worlds/sc2/banks.py
@@ -66,7 +66,7 @@ def get_bank_folder() -> str:
         result = banks_folders[0]
     else:
         result = os.path.expanduser("~\\Documents\\StarCraft II\\Banks")
-    assert len(result) > 0, "Banks folder not found" 
+    assert os.path.isdir(result), "Banks folder not found" 
     return result
 
 
@@ -108,7 +108,7 @@ class SC2Bank():
         # Assumes bank files to follow the structure provided by the game
         # Asserts catch malformed files, should never happen unless the player manually edits the files
         if not path:
-            path = f"{get_bank_folder()}/{self.file_name}.SC2Bank"
+            path = f"{get_bank_folder()}\\{self.file_name}.SC2Bank"
         if not os.path.isfile(path):
             return
         with open(path, "r") as f:

--- a/worlds/sc2/banks.py
+++ b/worlds/sc2/banks.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 from glob import glob
 import typing
+import queue
 import os.path
 import re
 
@@ -57,6 +58,9 @@ BANK_TRADE_SEND_SECTION_UNITS = "VoidTradeUnits"
 BANK_TRADE_SEND_KEY_UNIT_TYPES = "UnitTypes"
 BANK_TRADE_SEND_SECTION_RECEIVE_REQUEST = "VoidTradeReceiveRequest"
 BANK_TRADE_SEND_KEY_RECEIVE_COUNT = "Count"
+
+# Limit for how many backup banks are saved per bank file
+BANK_BACKUP_FILE_LIMIT = 100
 
 # file path to bank folder.
 def get_bank_folder() -> str:
@@ -163,10 +167,20 @@ class SC2Bank():
             lines.append(     f'    </Section>')
         lines.append(         f'</Bank>')
         Path(dir).mkdir(parents=True, exist_ok=True)
-        # TODO: Handle multiple backups in the same step (if needed)
-        with open(f"{dir}\\{self.file_name}_backup_1.SC2Bank", "w") as f:
-            f.write('\n'.join(lines))
-        
+        # The game deletes a backup after reading. If a backup exists already, the game didn't read it yet
+        # In that case, just make a second backup, the game will read them in sequence
+        for i in range (1,BANK_BACKUP_FILE_LIMIT + 1):
+            # start at 1, makes handling in SC2 easier
+            path = f"{dir}\\{self.file_name}_backup_{i}.SC2Bank" 
+            if not os.path.isfile(path):
+                with open(path, "w") as f:
+                    f.write('\n'.join(lines))
+                return
+        # only the messages bank has any chance to hit this
+        # at current limits, this would be attempting to send 5000 messages in a single iteration
+        print("Too many bank backups, cannot write:")
+        print(self)
+
     def remove_entry_from_file(self, key: str) -> None:
         # Remove one Key/Value pair from a bank file
         path = f"{get_bank_folder()}\\{self.file_name}.SC2Bank"
@@ -263,13 +277,25 @@ def send_items(
 def clean_ap_message(message: str) -> str:
     return message.replace('<','&lt;').replace('>','&gt;').replace('"','&quot;')
 
+def send_ap_messages_from_queue(messageQueue: queue.Queue):
+    messages = []
+    for i in range(BANK_MESSAGES_KEY_LIMIT):
+        # send up to KEY_LIMIT messages in a single bank file
+        if not messageQueue.empty(): 
+            messages.append(messageQueue.get_nowait())
+            messageQueue.task_done()
+        else:
+            break
+    if messages:
+        send_ap_message(messages)
+
 def send_ap_message(messages: typing.List[str]):
+    # message list is expected to not contain more than KEY_LIMIT messages
     bank = SC2Bank(BANK_MESSAGES_FILE_NAME)
     if messages:
         i = 0
         for msg in messages:
-            if msg:
-                # TODO: Check for limits/staggering
+            if msg and i < BANK_MESSAGES_KEY_LIMIT:
                 i+=1
                 bank.add_entry(
                     BANK_MESSAGES_SECTION_MESSAGES,

--- a/worlds/sc2/client.py
+++ b/worlds/sc2/client.py
@@ -10,7 +10,6 @@ import inspect
 import logging
 import multiprocessing
 import os.path
-import re
 import sys
 import tempfile
 import typing
@@ -130,7 +129,7 @@ class ConfigurableOptionInfo(typing.NamedTuple):
 
 class ColouredMessage:
     def __init__(self, text: str = '', *, keep_markup: bool = False) -> None:
-        self.parts: typing.List[dict] = []
+        self.parts: list[dict] = []
         if text:
             self(text, keep_markup=keep_markup)
     def __call__(self, text: str, *, keep_markup: bool = False) -> 'ColouredMessage':
@@ -235,7 +234,7 @@ class StarcraftClientProcessor(ClientCommandProcessor):
             self.output("To change the game speed, add the name of the speed after the command,"
                         " or Default to select based on difficulty.")
             return False
-    
+
     @mark_raw
     def _cmd_received(self, filter_search: str = "") -> bool:
         """List received items.
@@ -268,9 +267,9 @@ class StarcraftClientProcessor(ClientCommandProcessor):
             return False
 
         items = get_full_item_list()
-        categorized_items: typing.Dict[SC2Race, typing.List[typing.Union[int, str]]] = {}
-        parent_to_child: typing.Dict[typing.Union[int, str], typing.List[int]] = {}
-        items_received: typing.Dict[int, typing.List[NetworkItem]] = {}
+        categorized_items: dict[SC2Race, list[typing.Union[int, str]]] = {}
+        parent_to_child: dict[typing.Union[int, str], list[int]] = {}
+        items_received: dict[int, list[NetworkItem]] = {}
         for item in self.ctx.items_received:
             items_received.setdefault(item.item, []).append(item)
         items_received_set = set(items_received)
@@ -577,7 +576,7 @@ class SC2JSONtoTextParser(JSONtoTextParser):
         codes = node["color"].split(";")
         buffer = "".join(self.color_code(code) for code in codes if code in self.color_codes)
         return buffer + self._handle_text(node) + '</c>'
-    
+
     def _handle_item_name(self, node: JSONMessagePart) -> str:
         if self.ctx.slot_info[node["player"]].game == STARCRAFT2:
             annotation = ITEM_NAME_ANNOTATIONS.get(node["text"])
@@ -614,10 +613,10 @@ class SC2Context(CommonContext):
         self.kerrigan_presence: int = KerriganPresence.default
         self.kerrigan_primal_status = 0
         self.enable_morphling = EnableMorphling.default
-        self.custom_mission_order: typing.List[CampaignSlotData] = []
-        self.mission_id_to_entry_rules: typing.Dict[int, MissionEntryRules]
-        self.final_mission_ids: typing.List[int] = [29]
-        self.final_locations: typing.List[int] = []
+        self.custom_mission_order: list[CampaignSlotData] = []
+        self.mission_id_to_entry_rules: dict[int, MissionEntryRules]
+        self.final_mission_ids: list[int] = [29]
+        self.final_locations: list[int] = []
         self.announcements: queue.Queue = queue.Queue()
         self.sc2_run_task: typing.Optional[asyncio.Task] = None
         self.missions_unlocked: bool = False  # allow launching missions ignoring requirements
@@ -626,12 +625,12 @@ class SC2Context(CommonContext):
         self.generic_upgrade_research = 0
         self.generic_upgrade_research_speedup: int = GenericUpgradeResearchSpeedup.default
         self.generic_upgrade_items = 0
-        self.location_inclusions: typing.Dict[LocationType, int] = {}
-        self.location_inclusions_by_flag: typing.Dict[LocationFlag, int] = {}
-        self.plando_locations: typing.List[str] = []
+        self.location_inclusions: dict[LocationType, int] = {}
+        self.location_inclusions_by_flag: dict[LocationFlag, int] = {}
+        self.plando_locations: list[str] = []
         self.difficulty_override = -1
         self.game_speed_override = -1
-        self.mission_id_to_location_ids: typing.Dict[int, typing.List[int]] = {}
+        self.mission_id_to_location_ids: dict[int, list[int]] = {}
         self.last_bot: typing.Optional[ArchipelagoBot] = None
         self.slot_data_version = 2
         self.required_tactics: int = RequiredTactics.default
@@ -649,7 +648,7 @@ class SC2Context(CommonContext):
         self.maximum_supply_reduction_per_item: int = options.MaximumSupplyReductionPerItem.default
         self.lowest_maximum_supply: int = options.LowestMaximumSupply.default
         self.research_cost_reduction_per_item: int = options.ResearchCostReductionPerItem.default
-        self.nova_presence: typing.List[str] = NovaPresence.default
+        self.nova_presence: list[str] = NovaPresence.default
         self.mercenary_highlanders: bool = False
         self.kerrigan_levels_per_mission_completed = 0
         self.trade_enabled: int = EnableVoidTrade.default
@@ -663,7 +662,7 @@ class SC2Context(CommonContext):
         self.trade_response: typing.Optional[str] = None
         self.difficulty_damage_modifier: int = DifficultyDamageModifier.default
         self.mission_order_scouting = MissionOrderScouting.option_none
-        self.mission_item_classification: typing.Optional[typing.Dict[str, int]] = None
+        self.mission_item_classification: typing.Optional[dict[str, int]] = None
         self.war_council_nerfs: bool = False
 
     async def server_auth(self, password_requested: bool = False) -> None:
@@ -688,10 +687,10 @@ class SC2Context(CommonContext):
 
     def trade_storage_team(self) -> str:
         return f"{TRADE_DATASTORAGE_TEAM}{self.team}"
-    
+
     def trade_storage_slot(self) -> str:
         return f"{TRADE_DATASTORAGE_SLOT}{self.slot}"
-    
+
     def _apply_host_settings_to_options(self) -> None:
         if str(SC2World.settings.game_difficulty).casefold() == 'casual':
             self.difficulty = GameDifficulty.option_casual
@@ -769,9 +768,9 @@ class SC2Context(CommonContext):
                             for mission, mission_info in slot_req_table.items()
                         }
                     }
-                
+
                 self.custom_mission_order = self.parse_mission_req_table(mission_req_table)
-                
+
             if self.slot_data_version >= 4:
                 self.custom_mission_order = [
                     CampaignSlotData(
@@ -798,7 +797,7 @@ class SC2Context(CommonContext):
                 for campaign in self.custom_mission_order for layout in campaign.layouts
                 for column in layout.missions for mission in column
             }
-                
+
             self.mission_order = args["slot_data"].get("mission_order", MissionOrder.option_vanilla)
             if self.slot_data_version < 4:
                 self.final_mission_ids = [args["slot_data"].get("final_mission", SC2Mission.ALL_IN.id)]
@@ -919,9 +918,9 @@ class SC2Context(CommonContext):
                     (" to install.")
                 ).send(self)
                 self.data_out_of_date = True
-            
+
             ColouredMessage("[b]Check the Launcher tab to start playing.[/b]", keep_markup=True).send(self)
-        
+
         elif cmd == "SetReply":
             # Currently can only be Void Trade reply
             self.trade_latest_reply = args
@@ -937,24 +936,24 @@ class SC2Context(CommonContext):
         return MissionInfo(
             **{field: value for field, value in mission_info.items() if field in MissionInfo._fields}
         )
-    
+
     @staticmethod
-    def parse_mission_req_table(mission_req_table: typing.Dict[SC2Campaign, typing.Dict[typing.Any, MissionInfo]]) -> typing.List[CampaignSlotData]:
-        campaigns: typing.List[typing.Tuple[int, CampaignSlotData]] = []
+    def parse_mission_req_table(mission_req_table: dict[SC2Campaign, dict[typing.Any, MissionInfo]]) -> list[CampaignSlotData]:
+        campaigns: list[typing.Tuple[int, CampaignSlotData]] = []
         rolling_rule_id = 0
         for (campaign, campaign_data) in mission_req_table.items():
             if campaign.campaign_name == "Global":
                 campaign_name = ""
             else:
                 campaign_name = campaign.campaign_name
-            
-            categories: typing.Dict[str, typing.List[MissionSlotData]] = {}
+
+            categories: dict[str, list[MissionSlotData]] = {}
             for mission in campaign_data.values():
                 if mission.category not in categories:
                     categories[mission.category] = []
                 mission_id = mission.mission.id
-                sub_rules: typing.List[CountMissionsRuleData] = []
-                missions: typing.List[int]
+                sub_rules: list[CountMissionsRuleData] = []
+                missions: list[int]
                 if mission.number:
                     amount = mission.number
                     missions = [
@@ -962,7 +961,7 @@ class SC2Context(CommonContext):
                         for mission in mission_req_table[campaign].values()
                     ]
                     sub_rules.append(CountMissionsRuleData(missions, amount, [campaign_name]))
-                prev_missions: typing.List[int] = []
+                prev_missions: list[int] = []
                 if len(mission.required_world) > 0:
                     missions = []
                     for connection in mission.required_world:
@@ -989,7 +988,7 @@ class SC2Context(CommonContext):
                 rolling_rule_id += 1
                 categories[mission.category].append(MissionSlotData.legacy(mission_id, prev_missions, entry_rule))
 
-            layouts: typing.List[LayoutSlotData] = []
+            layouts: list[LayoutSlotData] = []
             for (layout, mission_slots) in categories.items():
                 if layout.startswith("_"):
                     layout_name = ""
@@ -1053,7 +1052,7 @@ class SC2Context(CommonContext):
             return False
 
     def build_location_to_mission_mapping(self) -> None:
-        mission_id_to_location_ids: typing.Dict[int, typing.Set[int]] = {
+        mission_id_to_location_ids: dict[int, typing.Set[int]] = {
             mission.mission_id: set()
             for campaign in self.custom_mission_order for layout in campaign.layouts
             for column in layout.missions for mission in column
@@ -1077,7 +1076,7 @@ class SC2Context(CommonContext):
         objectives = self.mission_id_to_location_ids[mission_id]
         for objective in objectives:
             yield get_location_id(mission_id, objective)
-    
+
     def locations_for_mission_id(self, mission_id: int) -> typing.Iterable[int]:
         objectives = self.mission_id_to_location_ids[mission_id]
         for objective in objectives:
@@ -1090,8 +1089,8 @@ class SC2Context(CommonContext):
 
     def is_mission_completed(self, mission_id: int) -> bool:
         return get_location_id(mission_id, 0) in self.checked_locations
-    
-        
+
+
     async def trade_acquire_storage(self, keep_trying: bool = False) -> typing.Optional[dict]:
         # This function was largely taken from the Pokemon Emerald client
         """
@@ -1157,7 +1156,7 @@ class SC2Context(CommonContext):
             if lock - reply["original_value"][TRADE_DATASTORAGE_LOCK] < TRADE_LOCK_TIME:
                 if not keep_trying:
                     return None
-                
+
                 # Multiple clients trying to lock the key may get stuck in a loop of checking the lock
                 # by trying to set it, which will extend its expiration. So if we see that the lock was
                 # too new when we replaced it, we should wait for increasingly longer periods so that
@@ -1173,12 +1172,12 @@ class SC2Context(CommonContext):
             self.trade_lock_start = None
             return reply
         return None
-        
+
 
     async def trade_receive(self, amount: int = 1):
         """
         Tries to pop `amount` units out of the trade storage.
-        """           
+        """
         reply = await self.trade_acquire_storage(True)
 
         if reply is None:
@@ -1187,7 +1186,7 @@ class SC2Context(CommonContext):
 
         # Find available units
         # Ignore units we sent ourselves
-        allowed_slots: typing.List[str] = [
+        allowed_slots: list[str] = [
             slot for slot in reply["value"]
             if slot != TRADE_DATASTORAGE_LOCK \
                 and slot != self.trade_storage_slot()
@@ -1204,9 +1203,9 @@ class SC2Context(CommonContext):
             is_unit_allowed = lambda unit: unit not in worker_units
         else:
             is_unit_allowed = lambda _: True
-        
-        available_units: typing.List[typing.Tuple[str, str, int]] = []
-        available_counts: typing.List[int] = []
+
+        available_units: list[typing.Tuple[str, str, int]] = []
+        available_counts: list[int] = []
         for slot in allowed_slots:
             for (send_time, units) in reply["value"][slot].items():
                 if is_young_enough(int(send_time)):
@@ -1229,8 +1228,8 @@ class SC2Context(CommonContext):
         else:
             units = random.sample(available_units, amount, counts = available_counts)
         # Build response data
-        unit_counts: typing.Dict[str, int] = {}
-        slots_to_update: typing.Dict[str, typing.Dict[int, typing.Dict[str, int]]] = {}
+        unit_counts: dict[str, int] = {}
+        slots_to_update: dict[str, dict[int, dict[str, int]]] = {}
         for (unit, slot, send_time) in units:
             unit_counts[unit] = unit_counts.get(unit, 0) + 1
             if slot not in slots_to_update:
@@ -1261,7 +1260,7 @@ class SC2Context(CommonContext):
         self.trade_underway = False
 
 
-    async def trade_send(self, units: typing.List[str]):
+    async def trade_send(self, units: list[str]):
         """
         Tries to upload `units` to the trade DataStorage.
         """
@@ -1270,17 +1269,17 @@ class SC2Context(CommonContext):
         if reply is None:
             banks.send_trade_received("FailConnection")
             return None
-        
+
         # Create a storage entry for the time the trade was confirmed
         trade_time = reply["value"][TRADE_DATASTORAGE_LOCK]
         storage_entry = {}
         for unit in units:
             storage_entry[unit] = storage_entry.get(unit, 0) + 1
-        
+
         # Update the storage with the new units
-        data: typing.Dict[int, typing.Dict[str, int]] = copy.deepcopy(reply["value"].get(self.trade_storage_slot(), {}))
+        data: dict[int, dict[str, int]] = copy.deepcopy(reply["value"].get(self.trade_storage_slot(), {}))
         data[trade_time] = storage_entry
-        
+
         await self.send_msgs([
             {   # Send the updated data
                 "cmd": "Set",
@@ -1293,12 +1292,12 @@ class SC2Context(CommonContext):
                 "operations": [{ "operation": "update", "value": { TRADE_DATASTORAGE_LOCK: 0 } }]
             }
         ])
-        
-        # Notify the game 
+
+        # Notify the game
         banks.send_trade_received("Success")
         self.trade_response = None
         self.trade_underway = False
-        
+
 
 
 
@@ -1379,13 +1378,13 @@ API3_TO_API4_COMPAT_ITEMS: typing.Set[CompatItemHolder] = {
     CompatItemHolder(item_names.SPORE_CRAWLER_BIO_BONUS),
 }
 
-def compat_item_to_network_items(compat_item: CompatItemHolder) -> typing.List[NetworkItem]:
+def compat_item_to_network_items(compat_item: CompatItemHolder) -> list[NetworkItem]:
     item_id = get_full_item_list()[compat_item.name].code
     network_item = NetworkItem(item_id, 0, 0, 0)
     return compat_item.quantity * [network_item]
 
 
-def calculate_items(ctx: SC2Context) -> typing.Dict[SC2Race, typing.List[int]]:
+def calculate_items(ctx: SC2Context) -> dict[SC2Race, list[int]]:
     items = ctx.items_received.copy()
     item_list = get_full_item_list()
     def create_network_item(item_name: str) -> NetworkItem:
@@ -1414,7 +1413,7 @@ def calculate_items(ctx: SC2Context) -> typing.Dict[SC2Race, typing.List[int]]:
     orbital_command_count: int = 0
 
     network_item: NetworkItem
-    accumulators: typing.Dict[SC2Race, typing.List[int]] = {
+    accumulators: dict[SC2Race, list[int]] = {
         race: [0 for element in item_type_enum_class if element.flag_word >= 0]
         for race, item_type_enum_class in race_to_item_type.items()
     }
@@ -1484,7 +1483,7 @@ def calculate_items(ctx: SC2Context) -> typing.Dict[SC2Race, typing.List[int]]:
 
     # Deprecated Orbital Command handling (Backwards compatibility):
     if orbital_command_count > 0:
-        orbital_command_replacement_items: typing.List[str] = [
+        orbital_command_replacement_items: list[str] = [
             item_names.COMMAND_CENTER_SCANNER_SWEEP,
             item_names.COMMAND_CENTER_MULE,
             item_names.COMMAND_CENTER_EXTRA_SUPPLIES,
@@ -1527,8 +1526,8 @@ def calculate_items(ctx: SC2Context) -> typing.Dict[SC2Race, typing.List[int]]:
     return accumulators
 
 
-def get_bundle_upgrade_member_numbers(bundled_item: str) -> typing.List[int]:
-    upgrade_elements: typing.List[str] = upgrade_bundles[bundled_item]
+def get_bundle_upgrade_member_numbers(bundled_item: str) -> list[int]:
+    upgrade_elements: list[str] = upgrade_bundles[bundled_item]
     if bundled_item in (item_names.PROGRESSIVE_PROTOSS_GROUND_UPGRADE, item_names.PROGRESSIVE_PROTOSS_AIR_UPGRADE):
         # Shields are handled as a maximum of those two
         upgrade_elements = [item_name for item_name in upgrade_elements if item_name != item_names.PROGRESSIVE_PROTOSS_SHIELDS]
@@ -1548,7 +1547,7 @@ def calc_difficulty(difficulty: int):
     return 'X'
 
 
-def get_kerrigan_level(ctx: SC2Context, items: typing.Dict[SC2Race, typing.List[int]], missions_beaten: int) -> int:
+def get_kerrigan_level(ctx: SC2Context, items: dict[SC2Race, list[int]], missions_beaten: int) -> int:
     item_value = items[SC2Race.ZERG][ZergItemType.Level.flag_word]
     mission_value = missions_beaten * ctx.kerrigan_levels_per_mission_completed
     if ctx.kerrigan_levels_per_mission_completed_cap != -1:
@@ -1672,7 +1671,7 @@ def calculate_trade_options(ctx: SC2Context) -> int:
     # Workers allowed
     if ctx.trade_workers_allowed == VoidTradeWorkers.option_true:
         result |= 1 << 1
-    
+
     return result
 
 def kerrigan_primal(ctx: SC2Context, kerrigan_level: int) -> bool:
@@ -1770,13 +1769,12 @@ class ArchipelagoBot(bot.bot_ai.BotAI):
             kerrigan_level = get_kerrigan_level(self.ctx, start_items, missions_beaten)
             kerrigan_options = calculate_kerrigan_options(self.ctx)
             nova_presence = calculate_nova_presence(self.ctx, mission)
-            print(f"Nova presence: {nova_presence}")
             grant_story_tech = calculate_story_tech(self.ctx, mission)
             soa_options = calculate_soa_options(self.ctx, mission)
             generic_upgrade_options = calculate_generic_upgrade_options(self.ctx)
             trade_options = calculate_trade_options(self.ctx)
             mission_variant = get_mission_variant(self.mission_id)  # 0/1/2/3 for unchanged/Terran/Zerg/Protoss
-            uncollected_objectives: typing.List[int] = self.get_uncollected_objectives()
+            uncollected_objectives: list[int] = self.get_uncollected_objectives()
             if self.ctx.difficulty_override >= 0:
                 difficulty = calc_difficulty(self.ctx.difficulty_override)
             else:
@@ -1817,7 +1815,6 @@ class ArchipelagoBot(bot.bot_ai.BotAI):
                 objectives,
                 "1"
             )
-
             self.last_received_update = len(self.ctx.items_received)
         else:
             banks.send_ap_messages_from_queue(self.ctx.announcements)
@@ -1825,7 +1822,7 @@ class ArchipelagoBot(bot.bot_ai.BotAI):
             # Message format:
             # <unit1> <unit2> <unit3>...
             if len(trade_send_string) > 0:
-                units_to_send: typing.List[str] = []
+                units_to_send: list[str] = []
                 non_ap_units: typing.Set[str] = set()
                 for unit_id in trade_send_string.split():
                     if unit_id.startswith("AP_"):
@@ -1840,7 +1837,7 @@ class ArchipelagoBot(bot.bot_ai.BotAI):
                     self.ctx.trade_response = None
                     self.ctx.trade_underway = True
                     async_start(self.ctx.trade_send(units_to_send))
-            
+
             trade_receive_string = self.get_trade_receive_request()
             # Message format:
             # <count>
@@ -1861,12 +1858,14 @@ class ArchipelagoBot(bot.bot_ai.BotAI):
                 self.can_read_game = True
 
             if iteration == 160 and not game_state & 1:
-                banks.send_ap_message({"Warning: Archipelago unable to connect or has lost connection to " +
-                                        "Starcraft 2 (This is likely a map issue)"})
-                
+                banks.send_ap_message([
+                    "Warning: Archipelago unable to connect or has lost connection to "
+                    "Starcraft 2 (This is likely a map issue)"
+                ])
+
             if banks.update_prompt():
                 self.last_received_update = 0
-                
+
             if self.last_received_update < len(self.ctx.items_received):
                 current_items = calculate_items(self.ctx)
                 missions_beaten = self.missions_beaten_count()
@@ -1874,13 +1873,13 @@ class ArchipelagoBot(bot.bot_ai.BotAI):
                 self.update_core_options(current_items)
                 self.update_tech(current_items, kerrigan_level)
                 self.last_received_update = len(self.ctx.items_received)
-            
+
             if game_state & 1:
                 if not self.game_running:
-                    banks.send_ap_message({"Archipelago Connected"})
+                    banks.send_ap_message(["Archipelago Connected"])
                     # print("Archipelago Connected")
                     self.game_running = True
-            
+
                 if self.can_read_game:
                     if game_state & (1 << 1) and not self.mission_completed:
                         victory_locations = [get_location_id(self.mission_id, 0)]
@@ -1888,7 +1887,7 @@ class ArchipelagoBot(bot.bot_ai.BotAI):
                             self.mission_id in self.ctx.final_mission_ids and
                             len(self.ctx.final_locations) == len(self.ctx.checked_locations.union(victory_locations).intersection(self.ctx.final_locations))
                         )
-                        
+
                         # Old slots don't have locations on goal
                         if not send_victory or self.ctx.slot_data_version >= 4:
                             sc2_logger.info("Mission Completed")
@@ -1915,33 +1914,30 @@ class ArchipelagoBot(bot.bot_ai.BotAI):
                                 [{"cmd": 'LocationChecks',
                                   "locations": [get_location_id(self.mission_id, x + 1)]}])
                             self.boni[x] = True
-                    
+
                     # Send Void Trade results
                     if self.ctx.trade_response is not None and self.trade_reply_cooldown == 0:
-                        banks.send_ap_message({self.ctx.trade_response})
+                        banks.send_ap_message([self.ctx.trade_response])
                         # Wait an arbitrary amount of frames before trying again
                         self.trade_reply_cooldown = 60
                 else:
-                    banks.send_ap_message({"LostConnection - Lost connection to game."})
-
-
+                    banks.send_ap_message(["LostConnection - Lost connection to game."])
 
     def get_locations(self) -> int:
         result = banks.read_locations()
         if (result.strip()): # may be "" or " "
             return int(result)
         return 0
-        
-    
+
     def get_trade_units_sent(self) -> str:
         result = banks.read_trade_units()
         return result
-    
+
     def get_trade_receive_request(self) -> str:
         result = banks.read_trade_receive_request()
         return result
-    
-    def get_uncollected_objectives(self) -> typing.List[int]:
+
+    def get_uncollected_objectives(self) -> list[int]:
         result = [
             location % VICTORY_MODULO
             for location in self.ctx.uncollected_locations_in_mission(lookup_id_to_mission[self.mission_id])
@@ -1963,7 +1959,7 @@ class ArchipelagoBot(bot.bot_ai.BotAI):
         ]
         return ' '.join(result)
 
-    def get_resources(self, current_items: typing.Dict[SC2Race, typing.List[int]]) -> str:
+    def get_resources(self, current_items: dict[SC2Race, list[int]]) -> str:
         DEFAULT_MAX_SUPPLY = 200
         max_supply_amount = max(
             DEFAULT_MAX_SUPPLY
@@ -1984,37 +1980,37 @@ class ArchipelagoBot(bot.bot_ai.BotAI):
             max_supply_amount - DEFAULT_MAX_SUPPLY,
         ))
 
-    def get_terran_tech(self, current_items: typing.Dict[SC2Race, typing.List[int]]) -> str:
+    def get_terran_tech(self, current_items: dict[SC2Race, list[int]]) -> str:
         terran_items = current_items[SC2Race.TERRAN]
         return (" ".join(map(str, terran_items)))
 
-    def get_zerg_tech(self, current_items: typing.Dict[SC2Race, typing.List[int]], kerrigan_level: int) -> str:
+    def get_zerg_tech(self, current_items: dict[SC2Race, list[int]], kerrigan_level: int) -> str:
         zerg_items = current_items[SC2Race.ZERG]
         zerg_items = [value for index, value in enumerate(zerg_items) if index not in [ZergItemType.Level.flag_word, ZergItemType.Primal_Form.flag_word]]
         kerrigan_primal_by_items = kerrigan_primal(self.ctx, kerrigan_level)
         kerrigan_primal_bot_value = 1 if kerrigan_primal_by_items else 0
         return(f"{kerrigan_level} {kerrigan_primal_bot_value} " + ' '.join(map(str, zerg_items)))
 
-    def get_protoss_tech(self, current_items: typing.Dict[SC2Race, typing.List[int]]) -> str:
+    def get_protoss_tech(self, current_items: dict[SC2Race, list[int]]) -> str:
         protoss_items = current_items[SC2Race.PROTOSS]
         return (" ".join(map(str, protoss_items)))
 
-    def get_misc_tech(self, current_items: typing.Dict[SC2Race, typing.List[int]]) -> str:
+    def get_misc_tech(self, current_items: dict[SC2Race, list[int]]) -> str:
         return ("{} {} {}".format(
             current_items[SC2Race.ANY][get_item_flag_word(item_names.BUILDING_CONSTRUCTION_SPEED)],
             current_items[SC2Race.ANY][get_item_flag_word(item_names.UPGRADE_RESEARCH_SPEED)],
             current_items[SC2Race.ANY][get_item_flag_word(item_names.UPGRADE_RESEARCH_COST)],
         ))
 
-    def update_tech(self, current_items: typing.Dict[SC2Race, typing.List[int]], kerrigan_level: int):
+    def update_tech(self, current_items: dict[SC2Race, list[int]], kerrigan_level: int):
         banks.send_items(
             self.get_terran_tech(current_items),
             self.get_zerg_tech(current_items, kerrigan_level),
             self.get_protoss_tech(current_items),
             self.get_misc_tech(current_items)
         )
-    
-    def update_core_options(self, current_items: typing.Dict[SC2Race, typing.List[int]]):
+
+    def update_core_options(self, current_items: dict[SC2Race, list[int]]):
         banks.send_core_options(
             self.get_resources(current_items),
             self.get_colors()
@@ -2022,7 +2018,7 @@ class ArchipelagoBot(bot.bot_ai.BotAI):
 
 def calc_unfinished_nodes(
         ctx: SC2Context
-) -> typing.Tuple[typing.List[int], typing.Dict[int, typing.List[int]], typing.List[int], typing.Set[int]]:
+) -> typing.Tuple[list[int], dict[int, list[int]], list[int], typing.Set[int]]:
     unfinished_missions: typing.Set[int] = set()
 
     available_missions, available_layouts, available_campaigns = calc_available_nodes(ctx)
@@ -2033,7 +2029,7 @@ def calc_unfinished_nodes(
             objectives_completed = ctx.checked_locations & objectives
             if len(objectives_completed) < len(objectives):
                 unfinished_missions.add(mission_id)
-    
+
     return available_missions, available_layouts, available_campaigns, unfinished_missions
 
 def is_mission_available(ctx: SC2Context, mission_id_to_check: int) -> bool:
@@ -2041,12 +2037,12 @@ def is_mission_available(ctx: SC2Context, mission_id_to_check: int) -> bool:
 
     return mission_id_to_check in available_missions
 
-def calc_available_nodes(ctx: SC2Context) -> typing.Tuple[typing.List[int], typing.Dict[int, typing.List[int]], typing.List[int]]:
+def calc_available_nodes(ctx: SC2Context) -> typing.Tuple[list[int], dict[int, list[int]], list[int]]:
     beaten_missions: typing.Set[int] = {mission_id for mission_id in ctx.mission_id_to_entry_rules if ctx.is_mission_completed(mission_id)}
     received_items = compute_received_items(ctx)
 
-    mission_order_objects: typing.List[MissionOrderObjectSlotData] = []
-    parent_objects: typing.List[typing.List[MissionOrderObjectSlotData]] = []
+    mission_order_objects: list[MissionOrderObjectSlotData] = []
+    parent_objects: list[list[MissionOrderObjectSlotData]] = []
     for campaign in ctx.custom_mission_order:
         mission_order_objects.append(campaign)
         parent_objects.append([])
@@ -2060,17 +2056,17 @@ def calc_available_nodes(ctx: SC2Context) -> typing.Tuple[typing.List[int], typi
                     mission_order_objects.append(mission)
                     parent_objects.append([campaign, layout])
 
-    candidate_accessible_objects: typing.List[MissionOrderObjectSlotData] = [
+    candidate_accessible_objects: list[MissionOrderObjectSlotData] = [
         mission_order_object for mission_order_object in mission_order_objects
         if mission_order_object.entry_rule.is_accessible(beaten_missions, received_items)
     ]
 
-    accessible_objects: typing.List[MissionOrderObjectSlotData] = []
+    accessible_objects: list[MissionOrderObjectSlotData] = []
 
     while len(candidate_accessible_objects) > 0:
-        accessible_missions: typing.List[MissionSlotData] = [mission_order_object for mission_order_object in accessible_objects if isinstance(mission_order_object, MissionSlotData)]
+        accessible_missions: list[MissionSlotData] = [mission_order_object for mission_order_object in accessible_objects if isinstance(mission_order_object, MissionSlotData)]
         beaten_accessible_missions: typing.Set[int] = {mission.mission_id for mission in accessible_missions if mission.mission_id in beaten_missions}
-        accessible_objects_to_add: typing.List[MissionOrderObjectSlotData] = []
+        accessible_objects_to_add: list[MissionOrderObjectSlotData] = []
         for mission_order_object in candidate_accessible_objects:
             if (
                     mission_order_object.entry_rule.is_accessible(beaten_accessible_missions, received_items)
@@ -2089,7 +2085,7 @@ def calc_available_nodes(ctx: SC2Context) -> typing.Tuple[typing.List[int], typi
         else:
             break
 
-    accessible_missions: typing.List[MissionSlotData] = [mission_order_object for mission_order_object in accessible_objects if isinstance(mission_order_object, MissionSlotData)]
+    accessible_missions: list[MissionSlotData] = [mission_order_object for mission_order_object in accessible_objects if isinstance(mission_order_object, MissionSlotData)]
     beaten_accessible_missions: typing.Set[int] = {mission.mission_id for mission in accessible_missions if mission.mission_id in beaten_missions}
     for mission_order_object in mission_order_objects:
         # re-generate tooltip accessibility
@@ -2097,23 +2093,23 @@ def calc_available_nodes(ctx: SC2Context) -> typing.Tuple[typing.List[int], typi
             sub_rule.was_accessible = False
         mission_order_object.entry_rule.is_accessible(beaten_accessible_missions, received_items)
 
-    available_missions: typing.List[int] = [
+    available_missions: list[int] = [
         mission_order_object.mission_id for mission_order_object in accessible_objects
         if isinstance(mission_order_object, MissionSlotData)
     ]
-    available_campaign_objects: typing.List[CampaignSlotData] = [
+    available_campaign_objects: list[CampaignSlotData] = [
         mission_order_object for mission_order_object in accessible_objects
         if isinstance(mission_order_object, CampaignSlotData)
     ]
-    available_campaigns: typing.List[int] = [
+    available_campaigns: list[int] = [
         campaign_idx for campaign_idx, campaign in enumerate(ctx.custom_mission_order)
         if campaign in available_campaign_objects
     ]
-    available_layout_objects: typing.List[LayoutSlotData] = [
+    available_layout_objects: list[LayoutSlotData] = [
         mission_order_object for mission_order_object in accessible_objects
         if isinstance(mission_order_object, LayoutSlotData)
     ]
-    available_layouts: typing.Dict[int, typing.List[int]] = {
+    available_layouts: dict[int, list[int]] = {
         campaign_idx: [
             layout_idx for layout_idx, layout in enumerate(campaign.layouts) if layout in available_layout_objects
         ]
@@ -2190,17 +2186,17 @@ def is_mod_installed_correctly() -> bool:
             "ArchipelagoTriggers", "ArchipelagoPlayerWoL", "ArchipelagoPlayerHotS",
             "ArchipelagoPlayerLotV", "ArchipelagoPlayerLotVPrologue", "ArchipelagoPlayerNCO"]
     modfiles = [sc2_path / Path("Mods/" + mod + ".SC2Mod") for mod in mods]
-    wol_required_maps: typing.List[str] = ["WoL" + os.sep + mission.map_file + ".SC2Map" for mission in SC2Mission
+    wol_required_maps: list[str] = ["WoL" + os.sep + mission.map_file + ".SC2Map" for mission in SC2Mission
                          if mission.campaign in (SC2Campaign.WOL, SC2Campaign.PROPHECY)]
-    hots_required_maps: typing.List[str] = ["HotS" + os.sep + mission.map_file + ".SC2Map" for mission in campaign_mission_table[SC2Campaign.HOTS]]
-    lotv_required_maps: typing.List[str] = ["LotV" + os.sep + mission.map_file + ".SC2Map" for mission in SC2Mission
+    hots_required_maps: list[str] = ["HotS" + os.sep + mission.map_file + ".SC2Map" for mission in campaign_mission_table[SC2Campaign.HOTS]]
+    lotv_required_maps: list[str] = ["LotV" + os.sep + mission.map_file + ".SC2Map" for mission in SC2Mission
                                             if mission.campaign in (SC2Campaign.LOTV, SC2Campaign.PROLOGUE, SC2Campaign.EPILOGUE)]
-    nco_required_maps: typing.List[str] = ["NCO" + os.sep + mission.map_file + ".SC2Map" for mission in campaign_mission_table[SC2Campaign.NCO]]
+    nco_required_maps: list[str] = ["NCO" + os.sep + mission.map_file + ".SC2Map" for mission in campaign_mission_table[SC2Campaign.NCO]]
     required_maps = wol_required_maps + hots_required_maps + lotv_required_maps + nco_required_maps
     needs_files = False
 
     # Check for maps.
-    missing_maps: typing.List[str] = []
+    missing_maps: list[str] = []
     for mapfile in required_maps:
         if not os.path.isfile(mapdir / mapfile):
             missing_maps.append(mapfile)

--- a/worlds/sc2/client.py
+++ b/worlds/sc2/client.py
@@ -2018,6 +2018,7 @@ class ArchipelagoBot(bot.bot_ai.BotAI):
         return message.replace('<','&lt;').replace('>','&gt;').replace('"','&quot;')
 
     def send_ap_message(self, messages: typing.List[str]):
+        bank = SC2Bank("ArchipelagoMessages")
         if messages:
             i = 0
             for msg in messages:
@@ -2026,7 +2027,6 @@ class ArchipelagoBot(bot.bot_ai.BotAI):
                     i+=1
                     bank.add_entry("Messages",f"Message{str(i)}", self.clean_ap_message(msg))
             if i > 0:
-                bank = SC2Bank("ArchipelagoMessages")
                 bank.make_file()
 
     def get_locations(self) -> str:

--- a/worlds/sc2/client.py
+++ b/worlds/sc2/client.py
@@ -1852,8 +1852,8 @@ class ArchipelagoBot(bot.bot_ai.BotAI):
                 ))
             CoreOptionsBank.addEntry("CoreOptions","LoadFinished","1")
             CoreOptionsBank.makeFile()
-            '''
-            self.last_received_update = len(self.ctx.items_received)"""
+
+            self.last_received_update = len(self.ctx.items_received)
         else:
             #if self.ctx.pending_color_update:
             #    await self.update_colors()
@@ -1872,20 +1872,10 @@ class ArchipelagoBot(bot.bot_ai.BotAI):
                 message = self.ctx.announcements.get(timeout=1)
                 self.send_chat_message({message})
                 self.ctx.announcements.task_done()
-            '''
 
             '''
-            # Archipelago reads the health
-            controller1_state = 0
-            controller2_state = 0
             for unit in self.all_own_units():
-                if unit.health_max == CONTROLLER_HEALTH:
-                    controller1_state = int(CONTROLLER_HEALTH - unit.health)
-                    self.can_read_game = True
-                elif unit.health_max == CONTROLLER2_HEALTH:
-                    controller2_state = int(CONTROLLER2_HEALTH - unit.health)
-                    self.can_read_game = True
-                elif unit.name == TRADE_UNIT:
+                if unit.name == TRADE_UNIT:
                     # Handle Void Trade requests
                     # Check for orders (for buildings this is usually research or training)
                     if not unit.is_idle and not self.ctx.trade_underway:
@@ -1935,10 +1925,8 @@ class ArchipelagoBot(bot.bot_ai.BotAI):
                         # SC2 has no good means of detecting when a unit is queued while supply capped,
                         # so a supply buffer here is the best we can do
                         self.last_supply_used = self.supply_used
-            game_state = controller1_state + (controller2_state << 15)
             '''
 
-            '''
             game_state = self.get_locations()
 
             if game_state & 1:
@@ -1953,8 +1941,7 @@ class ArchipelagoBot(bot.bot_ai.BotAI):
                     self.send_chat_message({"Archipelago Connected"})
                     #print("Archipelago Connected")
                     self.game_running = True
-            '''
-            '''
+            
             if self.last_received_update < len(self.ctx.items_received):
                 current_items = calculate_items(self.ctx)
                 missions_beaten = self.missions_beaten_count()
@@ -1962,7 +1949,7 @@ class ArchipelagoBot(bot.bot_ai.BotAI):
                 self.update_core_options(current_items)
                 self.update_tech(current_items, kerrigan_level)
                 self.last_received_update = len(self.ctx.items_received)
-            '''
+            
             if game_state & 1:
                 if not self.game_running:
                     print("Archipelago Connected")
@@ -2094,7 +2081,7 @@ class ArchipelagoBot(bot.bot_ai.BotAI):
         return (" ".join(map(str, protoss_items)))
 
     def get_misc_tech(self, current_items: typing.Dict[SC2Race, typing.List[int]]) -> str:
-        return self.chat_send("{} {} {}".format(
+        return ("{} {} {}".format(
             current_items[SC2Race.ANY][get_item_flag_word(item_names.BUILDING_CONSTRUCTION_SPEED)],
             current_items[SC2Race.ANY][get_item_flag_word(item_names.UPGRADE_RESEARCH_SPEED)],
             current_items[SC2Race.ANY][get_item_flag_word(item_names.UPGRADE_RESEARCH_COST)],

--- a/worlds/sc2/client.py
+++ b/worlds/sc2/client.py
@@ -1816,8 +1816,9 @@ class ArchipelagoBot(bot.bot_ai.BotAI):
                 game_speed = self.ctx.game_speed_override
             else:
                 game_speed = self.ctx.game_speed
-            await self.chat_send(
-                "?SetOptions"
+
+            OptionsBank = SC2Bank("ArchipelagoOptions")
+            OptionsBank.addEntry("GameOptions","Options",
                 f" {difficulty}"
                 f" {generic_upgrade_options}"
                 f" {self.ctx.all_in_choice}"
@@ -1838,31 +1839,41 @@ class ArchipelagoBot(bot.bot_ai.BotAI):
                 f" {self.ctx.mercenary_highlanders}" # TODO: Possibly rework it into unit options in the next cycle
                 f" {self.ctx.war_council_nerfs}"
             )
-            await self.update_resources(start_items)
-            #await self.update_terran_tech(start_items)
-            terran_items = start_items[SC2Race.TERRAN]
-            b = SC2Bank("ArchipelagoItems")
-            b.addEntry("Items","TerranItems",f" ".join(map(str, terran_items)))
-            b.makeFile()
-            await self.update_zerg_tech(start_items, kerrigan_level)
-            await self.update_protoss_tech(start_items)
-            await self.update_misc_tech(start_items)
-            await self.update_colors()
+            OptionsBank.makeFile()
+            self.update_tech(start_items,kerrigan_level)
+
+            
+            CoreOptionsBank = SC2Bank("ArchipelagoCoreOptions")
+            CoreOptionsBank.addEntry("CoreOptions","StartingResources",self.get_resources(start_items))
+            CoreOptionsBank.addEntry("CoreOptions","FactionColors",self.get_colors())
             if uncollected_objectives:
-                await self.chat_send("?UncollectedLocations {}".format(
+                CoreOptionsBank.addEntry("CoreOptions","UncollectedLocations","{}".format(
                     functools.reduce(lambda a, b: a + " " + b, [str(x) for x in uncollected_objectives])
                 ))
-            await self.chat_send("?LoadFinished")
-            self.last_received_update = len(self.ctx.items_received)
-
+            CoreOptionsBank.addEntry("CoreOptions","LoadFinished","1")
+            CoreOptionsBank.makeFile()
+            '''
+            self.last_received_update = len(self.ctx.items_received)"""
         else:
-            if self.ctx.pending_color_update:
-                await self.update_colors()
+            #if self.ctx.pending_color_update:
+            #    await self.update_colors()
+
+            #messages = []
+            #for i in range(20):
+            #    if not self.ctx.announcements.empty(): 
+            #        messages[i] = self.ctx.announcements.get_nowait()
+            #        self.ctx.announcements.task_done()
+            #    else:
+            #        break
+            #if messages:
+            #    self.send_chat_message(messages)
 
             if not self.ctx.announcements.empty():
                 message = self.ctx.announcements.get(timeout=1)
-                await self.chat_send("?SendMessage " + message)
+                self.send_chat_message({message})
                 self.ctx.announcements.task_done()
+            '''
+
             '''
             # Archipelago reads the health
             controller1_state = 0
@@ -1926,40 +1937,32 @@ class ArchipelagoBot(bot.bot_ai.BotAI):
                         self.last_supply_used = self.supply_used
             game_state = controller1_state + (controller2_state << 15)
             '''
-            next_line = False
-            l = '<Value string="'
-            r = '"/>'
-            with open(get_bank_folder() + "/ArchipelagoLocations.SC2Bank") as locationBank:
-                for line in locationBank:
-                    if next_line:
-                        game_state = int(line[line.find(l) + len(l):line.rfind(r)])
-                        self.can_read_game = True
-                        break
-                    if '<Key name="GameState">' in line:
-                        next_line = True
 
-                    
-            
+            '''
+            game_state = self.get_locations()
+
+            if game_state & 1:
+                self.can_read_game = True
+
             if iteration == 160 and not game_state & 1:
-                await self.chat_send("?SendMessage Warning: Archipelago unable to connect or has lost connection to " +
-                                     "Starcraft 2 (This is likely a map issue)")
+                self.send_chat_message({"Warning: Archipelago unable to connect or has lost connection to " +
+                                        "Starcraft 2 (This is likely a map issue)"})
+                
             if game_state & 1:
                 if not self.game_running:
-                    await self.chat_send("?SendMessage Archipelago Connected")
-                    print("Archipelago Connected")
+                    self.send_chat_message({"Archipelago Connected"})
+                    #print("Archipelago Connected")
                     self.game_running = True
-
+            '''
+            '''
             if self.last_received_update < len(self.ctx.items_received):
                 current_items = calculate_items(self.ctx)
                 missions_beaten = self.missions_beaten_count()
                 kerrigan_level = get_kerrigan_level(self.ctx, current_items, missions_beaten)
-                await self.update_resources(current_items)
-                await self.update_terran_tech(current_items)
-                await self.update_zerg_tech(current_items, kerrigan_level)
-                await self.update_protoss_tech(current_items)
-                await self.update_misc_tech(current_items)
+                self.update_core_options(current_items)
+                self.update_tech(current_items, kerrigan_level)
                 self.last_received_update = len(self.ctx.items_received)
-
+            '''
             if game_state & 1:
                 if not self.game_running:
                     print("Archipelago Connected")
@@ -2006,8 +2009,34 @@ class ArchipelagoBot(bot.bot_ai.BotAI):
                         # Wait an arbitrary amount of frames before trying again
                         self.trade_reply_cooldown = 60
                 else:
-                    await self.chat_send("?SendMessage LostConnection - Lost connection to game.")
+                    self.send_chat_message({"LostConnection - Lost connection to game."})
 
+    def clean_chat_message(self, message: str) -> str:
+        return message.replace('<','&lt;').replace('>','&gt;').replace('"','&quot;')
+
+    def send_chat_message(self, messages: typing.List[str]):
+        bank = SC2Bank("ArchipelagoMessages")
+        i = 0
+        for msg in messages:
+            #TODO: Check for limits/staggering
+            i+=1
+            bank.addEntry("Messages",f"Message{str(i)}", self.clean_chat_message(msg))
+        bank.makeFile()
+
+    def get_locations(self) -> str:
+            result = "0"
+            next_line = False
+            l = '<Value string="'
+            r = '"/>'
+            with open(get_bank_folder() + "/ArchipelagoLocations.SC2Bank") as locationBank:
+                for line in locationBank:
+                    if next_line:
+                        result = int(line[line.find(l) + len(l):line.rfind(r)])
+                        break
+                    if '<Key name="GameState">' in line:
+                        next_line = True
+            return result
+    
     def get_uncollected_objectives(self) -> typing.List[int]:
         result = [
             location % VICTORY_MODULO
@@ -2019,15 +2048,16 @@ class ArchipelagoBot(bot.bot_ai.BotAI):
     def missions_beaten_count(self) -> int:
         return len([location for location in self.ctx.checked_locations if location % VICTORY_MODULO == 0])
 
-    async def update_colors(self):
-        await self.chat_send("?SetColor rr " + str(self.ctx.player_color_raynor))
-        await self.chat_send("?SetColor ks " + str(self.ctx.player_color_zerg))
-        await self.chat_send("?SetColor pz " + str(self.ctx.player_color_zerg_primal))
-        await self.chat_send("?SetColor da " + str(self.ctx.player_color_protoss))
-        await self.chat_send("?SetColor nova " + str(self.ctx.player_color_nova))
+    def get_colors(self) -> str:
         self.ctx.pending_color_update = False
+        return f"""{str(self.ctx.player_color_raynor)} 
+                   {str(self.ctx.player_color_zerg)} 
+                   {str(self.ctx.player_color_zerg_primal)} 
+                   {str(self.ctx.player_color_protoss)} 
+                   {str(self.ctx.player_color_nova)}  
+        """
 
-    async def update_resources(self, current_items: typing.Dict[SC2Race, typing.List[int]]):
+    def get_resources(self, current_items: typing.Dict[SC2Race, typing.List[int]]) -> str:
         DEFAULT_MAX_SUPPLY = 200
         max_supply_amount = max(
             DEFAULT_MAX_SUPPLY
@@ -2041,34 +2071,48 @@ class ArchipelagoBot(bot.bot_ai.BotAI):
             ),
             self.ctx.lowest_maximum_supply,
         )
-        await self.chat_send("?GiveResources {} {} {} {}".format(
+        return ("{} {} {} {}".format(
             current_items[SC2Race.ANY][get_item_flag_word(item_names.STARTING_MINERALS)],
             current_items[SC2Race.ANY][get_item_flag_word(item_names.STARTING_VESPENE)],
             current_items[SC2Race.ANY][get_item_flag_word(item_names.STARTING_SUPPLY)],
             max_supply_amount - DEFAULT_MAX_SUPPLY,
         ))
 
-    async def update_terran_tech(self, current_items: typing.Dict[SC2Race, typing.List[int]]):
+    def get_terran_tech(self, current_items: typing.Dict[SC2Race, typing.List[int]]) -> str:
         terran_items = current_items[SC2Race.TERRAN]
-        await self.chat_send("?GiveTerranTech " + " ".join(map(str, terran_items)))
+        return (" ".join(map(str, terran_items)))
 
-    async def update_zerg_tech(self, current_items: typing.Dict[SC2Race, typing.List[int]], kerrigan_level: int):
+    def get_zerg_tech(self, current_items: typing.Dict[SC2Race, typing.List[int]], kerrigan_level: int) -> str:
         zerg_items = current_items[SC2Race.ZERG]
         zerg_items = [value for index, value in enumerate(zerg_items) if index not in [ZergItemType.Level.flag_word, ZergItemType.Primal_Form.flag_word]]
         kerrigan_primal_by_items = kerrigan_primal(self.ctx, kerrigan_level)
         kerrigan_primal_bot_value = 1 if kerrigan_primal_by_items else 0
-        await self.chat_send(f"?GiveZergTech {kerrigan_level} {kerrigan_primal_bot_value} " + ' '.join(map(str, zerg_items)))
+        return(f"{kerrigan_level} {kerrigan_primal_bot_value} " + ' '.join(map(str, zerg_items)))
 
-    async def update_protoss_tech(self, current_items: typing.Dict[SC2Race, typing.List[int]]):
+    def get_protoss_tech(self, current_items: typing.Dict[SC2Race, typing.List[int]]) -> str:
         protoss_items = current_items[SC2Race.PROTOSS]
-        await self.chat_send("?GiveProtossTech " + " ".join(map(str, protoss_items)))
+        return (" ".join(map(str, protoss_items)))
 
-    async def update_misc_tech(self, current_items: typing.Dict[SC2Race, typing.List[int]]):
-        await self.chat_send("?GiveMiscTech {} {} {}".format(
+    def get_misc_tech(self, current_items: typing.Dict[SC2Race, typing.List[int]]) -> str:
+        return self.chat_send("{} {} {}".format(
             current_items[SC2Race.ANY][get_item_flag_word(item_names.BUILDING_CONSTRUCTION_SPEED)],
             current_items[SC2Race.ANY][get_item_flag_word(item_names.UPGRADE_RESEARCH_SPEED)],
             current_items[SC2Race.ANY][get_item_flag_word(item_names.UPGRADE_RESEARCH_COST)],
         ))
+
+    def update_tech(self, current_items: typing.Dict[SC2Race, typing.List[int]], kerrigan_level: int):
+        ItemBank = SC2Bank("ArchipelagoItems")
+        ItemBank.addEntry("Items","TerranItems",self.get_terran_tech(current_items))
+        ItemBank.addEntry("Items","ZergItems",self.get_zerg_tech(current_items, kerrigan_level))
+        ItemBank.addEntry("Items","ProtossItems",self.get_protoss_tech(current_items))
+        ItemBank.addEntry("Items","MiscItems",self.get_misc_tech(current_items))
+        ItemBank.makeFile()
+    
+    def update_core_options(self, current_items: typing.Dict[SC2Race, typing.List[int]]):
+        CoreOptionsBank = SC2Bank("ArchipelagoCoreOptions")
+        CoreOptionsBank.addEntry("CoreOptions","StartingResources",self.get_resources(current_items))
+        CoreOptionsBank.addEntry("CoreOptions","FactionColors",self.get_colors())
+        CoreOptionsBank.makeFile()
 
 def calc_unfinished_nodes(
         ctx: SC2Context

--- a/worlds/sc2/client.py
+++ b/worlds/sc2/client.py
@@ -91,10 +91,6 @@ DATA_REPO_NAME = "Archipelago-SC2-data"
 DATA_API_VERSION = "API5"
 
 # Void Trade
-# TRADE_UNIT = "AP_TradeStructure" # ID of the unit
-# TRADE_SEND_BUTTON = "AP_TradeStructureDummySend" # ID of the button
-# TRADE_RECEIVE_1_BUTTON = "AP_TradeStructureDummyReceive" # ID of the button
-# TRADE_RECEIVE_5_BUTTON = "AP_TradeStructureDummyReceive5" # ID of the button
 TRADE_DATASTORAGE_TEAM = "SC2_VoidTrade_" # + Team
 TRADE_DATASTORAGE_SLOT = "slot_" # + Slot
 TRADE_DATASTORAGE_LOCK = "_lock"
@@ -683,7 +679,7 @@ class SC2Bank():
                 result = self.sections[section][key]
         return result
 
-    def read_file(self, path: Optional[str] = None) -> None:
+    def read_file(self, path: str = None) -> None:
         # Read a bank file provided by SC2 and convert it into an SC2Bank object
         # Assumes bank files to follow the structure provided by the game
         # Asserts catch malformed files, should never happen unless the player manually edits the files
@@ -2306,7 +2302,8 @@ class ArchipelagoBot(bot.bot_ai.BotAI):
         core_options_bank.add_entry(
             BANK_CORE_OPTIONS_SECTION_CORE_OPTIONS,
             BANK_CORE_OPTIONS_KEY_FACTION_COLORS,
-            self.get_colors())
+            self.get_colors()
+        )
         core_options_bank.write_file()
 
 def calc_unfinished_nodes(

--- a/worlds/sc2/client.py
+++ b/worlds/sc2/client.py
@@ -1819,29 +1819,8 @@ class ArchipelagoBot(bot.bot_ai.BotAI):
             )
 
             self.last_received_update = len(self.ctx.items_received)
-
         else:
-            # TODO: re-enable color update
-            # if self.ctx.pending_color_update:
-            #    await self.update_colors()
-
-            # TODO: send multiple messages at once
-            # messages = []
-            # for i in range(20):
-            #     if not self.ctx.announcements.empty(): 
-            #         messages[i] = self.ctx.announcements.get_nowait()
-            #         self.ctx.announcements.task_done()
-            #     else:
-            #         break
-            # if messages:
-            #     banks.send_ap_message(messages)
-
-            if not self.ctx.announcements.empty():
-                message = self.ctx.announcements.get(timeout=1)
-                banks.send_ap_message({message})
-                self.ctx.announcements.task_done()
-
-        
+            banks.send_ap_messages_from_queue(self.ctx.announcements)
             trade_send_string = self.get_trade_units_sent()
             # Message format:
             # <unit1> <unit2> <unit3>...

--- a/worlds/sc2/client.py
+++ b/worlds/sc2/client.py
@@ -21,6 +21,7 @@ import random
 import concurrent.futures
 import time
 import uuid
+import re
 from pathlib import Path
 
 # CommonClient import first to trigger ModuleUpdater
@@ -90,15 +91,69 @@ DATA_REPO_NAME = "Archipelago-SC2-data"
 DATA_API_VERSION = "API5"
 
 # Void Trade
-TRADE_UNIT = "AP_TradeStructure" # ID of the unit
-TRADE_SEND_BUTTON = "AP_TradeStructureDummySend" # ID of the button
-TRADE_RECEIVE_1_BUTTON = "AP_TradeStructureDummyReceive" # ID of the button
-TRADE_RECEIVE_5_BUTTON = "AP_TradeStructureDummyReceive5" # ID of the button
+# TRADE_UNIT = "AP_TradeStructure" # ID of the unit
+# TRADE_SEND_BUTTON = "AP_TradeStructureDummySend" # ID of the button
+# TRADE_RECEIVE_1_BUTTON = "AP_TradeStructureDummyReceive" # ID of the button
+# TRADE_RECEIVE_5_BUTTON = "AP_TradeStructureDummyReceive5" # ID of the button
 TRADE_DATASTORAGE_TEAM = "SC2_VoidTrade_" # + Team
 TRADE_DATASTORAGE_SLOT = "slot_" # + Slot
 TRADE_DATASTORAGE_LOCK = "_lock"
 TRADE_LOCK_TIME = 5 # Time in seconds that the DataStorage may be considered safe to edit
 TRADE_LOCK_WAIT_LIMIT = 540000 / 1.4 # Time in ms that the client may spend trying to get a lock (540000 = 9 minutes, 1.4 is 'faster' game speed's time scale)
+
+# Banks
+# file names, section names and key names have to match the SC2 trigger implementation
+#
+# Client -> SC2
+# Core Options
+BANK_CORE_OPTIONS_FILE_NAME = "ArchipelagoCoreOptions" # .SC2Bank
+BANK_CORE_OPTIONS_SECTION_CORE_OPTIONS = "CoreOptions"
+BANK_CORE_OPTIONS_KEY_STARTING_RESOURCES = "StartingResources"
+BANK_CORE_OPTIONS_KEY_FACTION_COLORS = "FactionColors"
+BANK_CORE_OPTIONS_KEY_UNCOLLECTED_LOCATIONS = "UncollectedLocations"
+BANK_CORE_OPTIONS_KEY_LOAD_FINISHED = "LoadFinished"
+
+# Options
+# 2 types of options because they are handled in different mod files by SC2
+BANK_OPTIONS_FILE_NAME = "ArchipelagoOptions" # .SC2Bank
+BANK_OPTIONS_SECTION_OPTIONS = "GameOptions"
+BANK_OPTIONS_KEY_OPTIONS = "Options"
+
+# Items
+BANK_ITEMS_FILE_NAME = "ArchipelagoItems" # .SC2Bank
+BANK_ITEMS_SECTION_ITEMS = "Items"
+BANK_ITEMS_KEY_TERRAN_ITEMS = "TerranItems"
+BANK_ITEMS_KEY_ZERG_ITEMS = "ZergItems"
+BANK_ITEMS_KEY_PROTOSS_ITEMS = "ProtossItems"
+BANK_ITEMS_KEY_MISC_ITEMS = "MiscItems"
+
+# Messages
+BANK_MESSAGES_FILE_NAME = "ArchipelagoMessages" # .SC2Bank
+BANK_MESSAGES_SECTION_MESSAGES = "Messages"
+BANK_MESSAGES_KEY_MESSAGE = "Message" # Appends message number 'Message1' 'Message2' ...
+BANK_MESSAGES_KEY_LIMIT = 50 # Limit for messages per bank
+
+# Void Trade Receive (messages received by SC2)
+BANK_TRADE_RECEIVE_FILE_NAME = "ArchipelagoVoidTradeReceive" # .SC2Bank
+BANK_TRADE_RECEIVE_SECTION_TRADE = "VoidTrade"
+BANK_TRADE_RECEIVE_KEY_TRADE_RESPONSE = "TradeResponse"
+
+# SC2 -> Client
+# Locations 
+BANK_LOCATIONS_FILE_NAME = "ArchipelagoLocations" # .SC2Bank
+BANK_LOCATIONS_SECTION_LOCATIONS = "Locations"
+BANK_LOCATIONS_KEY_GAME_STATE = "GameState"
+
+# Update
+# Doesn't need sections or keys. The existence of the file is used as an update prompt for now
+BANK_UPDATE_NAME = "ArchipelagoUpdate" #.SC2Bank
+
+# Void Trade Send (messages sent by SC2)
+BANK_TRADE_SEND_FILE_NAME = "ArchipelagoVoidTradeSend"
+BANK_TRADE_SEND_SECTION_UNITS = "VoidTradeUnits"
+BANK_TRADE_SEND_KEY_UNIT_TYPES = "UnitTypes"
+BANK_TRADE_SEND_SECTION_RECEIVE_REQUEST = "VoidTradeReceiveRequest"
+BANK_TRADE_SEND_KEY_RECEIVE_COUNT = "Count"
 
 # Games
 STARCRAFT2 = "Starcraft 2"
@@ -596,37 +651,85 @@ class SC2JSONtoTextParser(JSONtoTextParser):
         return '<c val="' + self.color_codes[code] + '">'
 
 class SC2Bank():
+    # Banks are XML files used to handle communication between SC2 and the AP Client
     file_name = "NewBank"
     sections = {}
     def __init__(self, name: str) -> None:
-        self.fileName = name
+        self.file_name = name
         self.sections: typing.Dict[str, typing.Dict[str, str]] = {}
+    
+    def __str__(self) -> str:
+        result = []
+        result.append(f'{self.file_name}.SC2Bank:')
+        for name, section in self.sections.items():
+            result.append(f'Section {name}:')
+            for key, value in section.items():
+                result.append(f'  Key {key}:')
+                result.append(f'    Value: {value}')
+        return ('\n'.join(result))
         
-    def add_section(self, sectionName: str) -> None:
-        self.sections[sectionName] = {}
+    def add_section(self, section: str) -> None:
+        self.sections[section] = {}
 
-    def add_entry(self, sectionName: str, key: str, value: str) -> None:
-        if not sectionName in self.sections:
-            self.add_section(sectionName)
-        self.sections[sectionName][key] = value
+    def add_entry(self, section: str, key: str, value: str) -> None:
+        if not section in self.sections:
+            self.add_section(section)
+        self.sections[section][key] = value 
+    
+    def get_value(self, section: str, key: str) -> str:
+        result = ""
+        if section in self.sections:
+            if key in self.sections[section]:
+                result = self.sections[section][key]
+        return result
 
-    def remove_entry_from_file(self, key: str) -> None:
-        path = f"{get_bank_folder()}/{self.fileName}"
+    def read_file(self, path: Optional[str] = None) -> None:
+        # Read a bank file provided by SC2 and convert it into an SC2Bank object
+        # Assumes bank files to follow the structure provided by the game
+        # Asserts catch malformed files, should never happen unless the player manually edits the files
+        if not path:
+            path = f"{get_bank_folder()}/{self.file_name}.SC2Bank"
+        if not os.path.isfile(path):
+            return
         with open(path, "r") as f:
+            SECTION_PATTERN = re.compile(r'<Section name="(\w+)">')
+            KEY_PATTERN = re.compile(r'<Key name="(\w+)">')
+            VALUE_PATTERN = re.compile(r'<Value string="([^"]+)"/>')
+            END_KEY_PATTERN = '</Key>'
+            END_SECTION_PATTERN = '</Section>'
+            section = '' # Use the presence of a section/key as the state variable
+            key = ''     # empty string is not present
             lines = f.readlines()
-        with open(path, "w") as f:
-            deleting = False
             for line in lines:
                 line_content = line.strip()
-                if line_content == f'<Key name="{key}">':
-                    deleting = True
-                elif line_content == '</Key>':
-                    deleting = False
-                elif not deleting:
-                    f.write(line)          
+                if (m := SECTION_PATTERN.match(line_content)):
+                    assert not section, f"Encountered section {m.group(1)} while already inside section {section}"
+                    section = m.group(1)
+                    self.add_section(section)
+                    assert section not in self.sections.items(), f"Duplicate section definition for section {section}"
+                elif (m := KEY_PATTERN.match(line_content)):
+                    assert section, "Encountered a key while not in a section"
+                    assert not key, f"Encountered key {m.group(1)} while already inside key {key}"
+                    key = m.group(1)
+                    assert key not in self.sections[section].items(), f"Duplicate key definition for key {key}"
+                elif (m := VALUE_PATTERN.match(line_content)):
+                    assert section, "Encountered a value while not in a section"
+                    assert key, "Encountered a value while not in a key"
+                    value = m.group(1)
+                    self.add_entry(section, key, value)
+                elif line_content == END_KEY_PATTERN:
+                    assert key, "Closing a key while not already in a key"
+                    key = ''
+                elif line_content == END_SECTION_PATTERN:
+                    assert section, "Closing a section while not already in a section"
+                    section = ''
+                else:
+                    pass
 
-    def make_file(self) -> None:
-        # Making a bank in the client should always be a backup
+    def write_file(self) -> None:
+        # Write a bank file with the formatting expected from SC2
+        # SC2 reads data by restoring a bank from a backup
+        # so we write the new backup file here
         dir = f"{get_bank_folder()}/Backup"
         lines = []
         lines.append(         f'<?xml version="1.0" encoding="utf-8"?>')
@@ -635,14 +738,32 @@ class SC2Bank():
             lines.append(     f'    <Section name="{name}">')
             for key, value in section.items():
                 lines.append( f'        <Key name="{key}">')
-                lines.append( f'            <Value name="{value}"/>')
+                lines.append( f'            <Value string="{value}"/>')
                 lines.append( f'        </Key>')
             lines.append(     f'    </Section>')
         lines.append(         f'</Bank>')
         Path(dir).mkdir(parents=True, exist_ok=True)
         # TODO: Handle multiple backups in the same step (if needed)
-        with open(f"{dir}/{self.fileName}_backup_1.SC2Bank", "w") as f:
+        with open(f"{dir}/{self.file_name}_backup_1.SC2Bank", "w") as f:
             f.write('\n'.join(lines))
+        
+    def remove_entry_from_file(self, key: str) -> None:
+        # Remove one Key/Value pair from a bank file
+        path = f"{get_bank_folder()}/{self.file_name}"
+        with open(path, "r") as f:
+            lines = f.readlines()
+        with open(path, "w") as f:
+            deleting = False
+            for line in lines:
+                line_content = line.strip()
+                # Just find the key tag
+                if line_content == f'<Key name="{key}">':
+                    deleting = True
+                # and delete all lines until finding the closing tag
+                elif line_content == '</Key>':
+                    deleting = False
+                elif not deleting:
+                    f.write(line)         
             
 class SC2Context(CommonContext):
     command_processor = StarcraftClientProcessor
@@ -1096,7 +1217,7 @@ class SC2Context(CommonContext):
                     sc2_logger.warning("Starcraft 2 Client is still running!")
                 self.sc2_run_task.cancel()  # doesn't actually close the game, just stops the python task
             # clean up locations bank from previous map
-            Path(f"{get_bank_folder()}/ArchipelagoLocations.SC2Bank").unlink(missing_ok=True)
+            Path(f"{get_bank_folder()}/{BANK_LOCATIONS_FILE_NAME}.SC2Bank").unlink(missing_ok=True)
             if self.slot is None:
                 sc2_logger.warning("Launching Mission without Archipelago authentication, "
                                    "checks will not be registered to server.")
@@ -1234,12 +1355,16 @@ class SC2Context(CommonContext):
         """
         Tries to pop `amount` units out of the trade storage.
         """
-        trade_received_bank = SC2Bank("ArchipelagoVoidTradeReceive")               
+        trade_received_bank = SC2Bank(BANK_TRADE_RECEIVE_FILE_NAME)               
         reply = await self.trade_acquire_storage(True)
 
         if reply is None:
-            trade_received_bank.add_entry("VoidTrade", "TradeResponse", "FailConnection")
-            trade_received_bank.make_file()
+            trade_received_bank.add_entry(
+                BANK_TRADE_RECEIVE_SECTION_TRADE, 
+                BANK_TRADE_RECEIVE_KEY_TRADE_RESPONSE, 
+                 "FailConnection"
+            )
+            trade_received_bank.write_file()
             return None
 
         # Find available units
@@ -1313,8 +1438,12 @@ class SC2Context(CommonContext):
         ])
         # Write units to bank
         value = f"ReceiveUnits {refunds} " + " ".join(f"{unit} {count}" for (unit, count) in unit_counts.items())
-        trade_received_bank.add_entry("VoidTrade", "TradeResponse", value)
-        trade_received_bank.make_file()
+        trade_received_bank.add_entry(
+                BANK_TRADE_RECEIVE_SECTION_TRADE, 
+                BANK_TRADE_RECEIVE_KEY_TRADE_RESPONSE, 
+                value
+            )
+        trade_received_bank.write_file()
         self.trade_response = None
         self.trade_underway = False
 
@@ -1323,12 +1452,16 @@ class SC2Context(CommonContext):
         """
         Tries to upload `units` to the trade DataStorage.
         """
-        trade_received_bank = SC2Bank("ArchipelagoVoidTradeReceive")
+        trade_received_bank = SC2Bank(BANK_TRADE_RECEIVE_FILE_NAME)
         reply = await self.trade_acquire_storage(True)
 
         if reply is None:
-            trade_received_bank.add_entry("VoidTrade", "TradeResponse", "FailConnection")
-            trade_received_bank.make_file()
+            trade_received_bank.add_entry(
+                BANK_TRADE_RECEIVE_SECTION_TRADE, 
+                BANK_TRADE_RECEIVE_KEY_TRADE_RESPONSE, 
+                 "FailConnection"
+            )
+            trade_received_bank.write_file()
             return None
         
         # Create a storage entry for the time the trade was confirmed
@@ -1355,8 +1488,12 @@ class SC2Context(CommonContext):
         ])
         
         # Notify the game 
-        trade_received_bank.add_entry("VoidTrade", "TradeResponse", "Success")
-        trade_received_bank.make_file()
+        trade_received_bank.add_entry(
+            BANK_TRADE_RECEIVE_SECTION_TRADE, 
+            BANK_TRADE_RECEIVE_KEY_TRADE_RESPONSE, 
+            "Success"
+        )
+        trade_received_bank.write_file()
         self.trade_response = None
         self.trade_underway = False
         
@@ -1846,8 +1983,10 @@ class ArchipelagoBot(bot.bot_ai.BotAI):
             else:
                 game_speed = self.ctx.game_speed
 
-            options_bank = SC2Bank("ArchipelagoOptions")
-            options_bank.add_entry("GameOptions", "Options",
+            options_bank = SC2Bank(BANK_OPTIONS_FILE_NAME)
+            options_bank.add_entry(
+                BANK_OPTIONS_SECTION_OPTIONS,
+                BANK_OPTIONS_KEY_OPTIONS,
                 f" {difficulty}"
                 f" {generic_upgrade_options}"
                 f" {self.ctx.all_in_choice}"
@@ -1865,22 +2004,37 @@ class ArchipelagoBot(bot.bot_ai.BotAI):
                 f" {mission_variant}"
                 f" {trade_options}"
                 f" {self.ctx.difficulty_damage_modifier}"
-                f" {self.ctx.mercenary_highlanders}" # TODO: Possibly rework it into unit options in the next cycle
+                f" {self.ctx.mercenary_highlanders}" # TODO: Possibly rework into unit options
                 f" {self.ctx.war_council_nerfs}"
             )
-            options_bank.make_file()
+            options_bank.write_file()
             self.update_tech(start_items, kerrigan_level)
 
             
-            core_options_bank = SC2Bank("ArchipelagoCoreOptions")
-            core_options_bank.add_entry("CoreOptions", "StartingResources", self.get_resources(start_items))
-            core_options_bank.add_entry("CoreOptions", "FactionColors", self.get_colors())
+            core_options_bank = SC2Bank(BANK_CORE_OPTIONS_FILE_NAME)
+            core_options_bank.add_entry(
+                BANK_CORE_OPTIONS_SECTION_CORE_OPTIONS, 
+                BANK_CORE_OPTIONS_KEY_STARTING_RESOURCES, 
+                self.get_resources(start_items)
+            )
+            core_options_bank.add_entry(
+                BANK_CORE_OPTIONS_SECTION_CORE_OPTIONS,
+                BANK_CORE_OPTIONS_KEY_FACTION_COLORS,
+                self.get_colors()
+            )
             if uncollected_objectives:
-                core_options_bank.add_entry("CoreOptions", "UncollectedLocations","{}".format(
-                    functools.reduce(lambda a, b: a + " " + b, [str(x) for x in uncollected_objectives])
-                ))
-            core_options_bank.add_entry("CoreOptions", "LoadFinished", "1")
-            core_options_bank.make_file()
+                core_options_bank.add_entry(
+                    BANK_CORE_OPTIONS_SECTION_CORE_OPTIONS,
+                    BANK_CORE_OPTIONS_KEY_UNCOLLECTED_LOCATIONS,
+                    "{}".format(
+                        functools.reduce(lambda a, b: a + " " + b, [str(x) for x in uncollected_objectives])
+                    )
+                )
+            core_options_bank.add_entry(
+                BANK_CORE_OPTIONS_SECTION_CORE_OPTIONS,
+                BANK_CORE_OPTIONS_KEY_LOAD_FINISHED,
+                "1")
+            core_options_bank.write_file()
 
             self.last_received_update = len(self.ctx.items_received)
 
@@ -1919,9 +2073,13 @@ class ArchipelagoBot(bot.bot_ai.BotAI):
                         non_ap_units.add(unit_id)
                 if len(non_ap_units) > 0:
                     sc2_logger.info(f"Void Trade tried to send non-AP units: {', '.join(non_ap_units)}")
-                    trade_received_bank = SC2Bank("ArchipelagoVoidTradeReceive")               
-                    trade_received_bank.add_entry("VoidTrade", "TradeResponse", "FailNonAPUnits")
-                    trade_received_bank.make_file()
+                    trade_received_bank = SC2Bank(BANK_TRADE_RECEIVE_FILE_NAME)               
+                    trade_received_bank.add_entry(
+                        BANK_TRADE_RECEIVE_SECTION_TRADE,
+                        BANK_TRADE_RECEIVE_KEY_TRADE_RESPONSE,
+                        "FailNonAPUnits"
+                    )
+                    trade_received_bank.write_file()
                     #self.ctx.trade_response = "?TradeFail Void Trade rejected: Trade contains invalid units."
                     self.ctx.trade_underway = True
                 else:
@@ -1952,10 +2110,11 @@ class ArchipelagoBot(bot.bot_ai.BotAI):
                 self.send_ap_message({"Warning: Archipelago unable to connect or has lost connection to " +
                                         "Starcraft 2 (This is likely a map issue)"})
                 
-            if os.path.isfile(f"{get_bank_folder()}/ArchipelagoUpdate.SC2Bank"):
+            path =f"{get_bank_folder()}/{BANK_UPDATE_NAME}.SC2Bank"
+            if os.path.isfile(path):
                 # if bank exists, we want an update prompt. No need to check the values
                 self.last_received_update = 0
-                os.remove(f"{get_bank_folder()}/ArchipelagoUpdate.SC2Bank")
+                os.remove(path)
                 
             if self.last_received_update < len(self.ctx.items_received):
                 current_items = calculate_items(self.ctx)
@@ -2018,71 +2177,49 @@ class ArchipelagoBot(bot.bot_ai.BotAI):
         return message.replace('<','&lt;').replace('>','&gt;').replace('"','&quot;')
 
     def send_ap_message(self, messages: typing.List[str]):
-        bank = SC2Bank("ArchipelagoMessages")
+        bank = SC2Bank(BANK_MESSAGES_FILE_NAME)
         if messages:
             i = 0
             for msg in messages:
                 if msg:
                     # TODO: Check for limits/staggering
                     i+=1
-                    bank.add_entry("Messages",f"Message{str(i)}", self.clean_ap_message(msg))
+                    bank.add_entry(
+                        BANK_MESSAGES_SECTION_MESSAGES,
+                        f"{BANK_MESSAGES_KEY_MESSAGE}{str(i)}", 
+                        self.clean_ap_message(msg)
+                    )
             if i > 0:
-                bank.make_file()
+                bank.write_file()
 
-    def get_locations(self) -> str:
-        result = 0
-        path = f"{get_bank_folder()}/ArchipelagoLocations.SC2Bank"
-        if os.path.isfile(path):
-            next_line = False
-            l = '<Value string="'
-            r = '"/>'
-            with open(path) as locationBank:
-                for line in locationBank:
-                    if next_line:
-                        result = int(line[line.find(l) + len(l):line.rfind(r)])
-                        break
-                    if '<Key name="GameState">' in line:
-                        next_line = True
-        return result
+    def get_locations(self) -> int:
+        location_bank = SC2Bank(BANK_LOCATIONS_FILE_NAME)
+        location_bank.read_file()
+        return int(location_bank.get_value(
+            BANK_LOCATIONS_SECTION_LOCATIONS,
+            BANK_LOCATIONS_KEY_GAME_STATE
+        ))
     
     def get_trade_units_sent(self) -> str:
-        result = ""
-        key = "UnitTypes"
-        path = f"{get_bank_folder()}/ArchipelagoVoidTradeSend.SC2Bank"
-        if os.path.isfile(path):
-            next_line = False
-            l = '<Value string="'
-            r = '"/>'
-            with open(path) as locationBank:
-                for line in locationBank:
-                    if next_line:
-                        result = line[line.find(l) + len(l):line.rfind(r)]
-                        break
-                    if f'<Key name="{key}">' in line:
-                        next_line = True
+        trade_send_bank = SC2Bank(BANK_TRADE_SEND_FILE_NAME)
+        trade_send_bank.read_file()
+        result = trade_send_bank.get_value(
+            BANK_TRADE_SEND_SECTION_UNITS,
+            BANK_TRADE_SEND_KEY_UNIT_TYPES
+        )
         if result != "":
-            bank = SC2Bank("ArchipelagoVoidTradeSend.SC2Bank")
-            bank.remove_entry_from_file(key)
+            trade_send_bank.remove_entry_from_file(BANK_TRADE_SEND_KEY_UNIT_TYPES)
         return result
     
     def get_trade_receive_request(self) -> str:
-        result = ""
-        key = "Count"
-        path = f"{get_bank_folder()}/ArchipelagoVoidTradeSend.SC2Bank"
-        if os.path.isfile(path):
-            next_line = False
-            l = '<Value string="'
-            r = '"/>'
-            with open(path) as locationBank:
-                for line in locationBank:
-                    if next_line:
-                        result = line[line.find(l) + len(l):line.rfind(r)]
-                        break
-                    if f'<Key name="{key}">' in line:
-                        next_line = True
+        trade_send_bank = SC2Bank(BANK_TRADE_SEND_FILE_NAME)
+        trade_send_bank.read_file()
+        result = trade_send_bank.get_value(
+            BANK_TRADE_SEND_SECTION_RECEIVE_REQUEST,
+            BANK_TRADE_SEND_KEY_RECEIVE_COUNT
+        )
         if result != "":
-            bank = SC2Bank("ArchipelagoVoidTradeSend.SC2Bank")
-            bank.remove_entry_from_file(key)
+            trade_send_bank.remove_entry_from_file(BANK_TRADE_SEND_KEY_RECEIVE_COUNT)
         return result
     
     def get_uncollected_objectives(self) -> typing.List[int]:
@@ -2151,18 +2288,26 @@ class ArchipelagoBot(bot.bot_ai.BotAI):
         ))
 
     def update_tech(self, current_items: typing.Dict[SC2Race, typing.List[int]], kerrigan_level: int):
-        item_bank = SC2Bank("ArchipelagoItems")
-        item_bank.add_entry("Items", "TerranItems", self.get_terran_tech(current_items))
-        item_bank.add_entry("Items", "ZergItems", self.get_zerg_tech(current_items, kerrigan_level))
-        item_bank.add_entry("Items", "ProtossItems", self.get_protoss_tech(current_items))
-        item_bank.add_entry("Items", "MiscItems", self.get_misc_tech(current_items))
-        item_bank.make_file()
+        item_bank = SC2Bank(BANK_ITEMS_FILE_NAME)
+        section = BANK_ITEMS_SECTION_ITEMS
+        item_bank.add_entry(section, BANK_ITEMS_KEY_TERRAN_ITEMS, self.get_terran_tech(current_items))
+        item_bank.add_entry(section, BANK_ITEMS_KEY_ZERG_ITEMS, self.get_zerg_tech(current_items, kerrigan_level))
+        item_bank.add_entry(section, BANK_ITEMS_KEY_PROTOSS_ITEMS, self.get_protoss_tech(current_items))
+        item_bank.add_entry(section, BANK_ITEMS_KEY_MISC_ITEMS, self.get_misc_tech(current_items))
+        item_bank.write_file()
     
     def update_core_options(self, current_items: typing.Dict[SC2Race, typing.List[int]]):
-        core_options_bank = SC2Bank("ArchipelagoCoreOptions")
-        core_options_bank.add_entry("CoreOptions", "StartingResources", self.get_resources(current_items))
-        core_options_bank.add_entry("CoreOptions", "FactionColors", self.get_colors())
-        core_options_bank.make_file()
+        core_options_bank = SC2Bank(BANK_CORE_OPTIONS_FILE_NAME)
+        core_options_bank.add_entry(
+            BANK_CORE_OPTIONS_SECTION_CORE_OPTIONS,
+            BANK_CORE_OPTIONS_KEY_STARTING_RESOURCES,
+            self.get_resources(current_items)
+        )
+        core_options_bank.add_entry(
+            BANK_CORE_OPTIONS_SECTION_CORE_OPTIONS,
+            BANK_CORE_OPTIONS_KEY_FACTION_COLORS,
+            self.get_colors())
+        core_options_bank.write_file()
 
 def calc_unfinished_nodes(
         ctx: SC2Context

--- a/worlds/sc2/client.py
+++ b/worlds/sc2/client.py
@@ -115,6 +115,10 @@ STARCRAFT2_WOL = "Starcraft 2 Wings of Liberty"
 def get_metadata_file() -> str:
     return os.environ["SC2PATH"] + os.sep + "ArchipelagoSC2Metadata.txt"
 
+# file path to bank folder.
+def get_bank_folder() -> str:
+    return os.path.expanduser("~/Documents/StarCraft II/Banks")
+
 
 def _remap_color_option(slot_data_version: int, color: int) -> int:
     """Remap colour options for backwards compatibility with older slot data"""
@@ -595,7 +599,34 @@ class SC2JSONtoTextParser(JSONtoTextParser):
     def color_code(self, code: str) -> str:
         return '<c val="' + self.color_codes[code] + '">'
 
+class SC2Bank():
+    fileName = "NewBank"
+    sections = {}
+    def __init__(self, name: str) -> None:
+        self.fileName = name
+        self.sections: typing.Dict[str, typing.Dict[str, str]] = {}
 
+    def addSection(self, sectionName: str) -> None:
+        self.sections[sectionName] = {}
+
+    def addEntry(self, sectionName: str, key: str, value: str) -> None:
+        if not sectionName in self.sections:
+            self.addSection(sectionName)
+        self.sections[sectionName][key]=value
+
+    def makeFile(self) -> None:
+        content =          f'<?xml version="1.0" encoding="utf-8"?>\n<Bank version="1">\n'
+        for name, section in self.sections.items():
+            content +=     f'    <Section name="{name}">\n'
+            for key, value in section.items():
+                content += f'        <Key name="{key}">\n'
+                content += f'            <Value name="{value}"/>\n'
+                content += f'        </Key>\n'
+            content +=     f'    </Section>\n'
+        content +=         f'</Bank>'
+        with open(get_bank_folder() + f"/Backup/{self.fileName}_backup_0.SC2Bank", "w") as f:
+            f.write(content)
+            
 class SC2Context(CommonContext):
     command_processor = StarcraftClientProcessor
     game = STARCRAFT2
@@ -1808,7 +1839,11 @@ class ArchipelagoBot(bot.bot_ai.BotAI):
                 f" {self.ctx.war_council_nerfs}"
             )
             await self.update_resources(start_items)
-            await self.update_terran_tech(start_items)
+            #await self.update_terran_tech(start_items)
+            terran_items = start_items[SC2Race.TERRAN]
+            b = SC2Bank("ArchipelagoItems")
+            b.addEntry("Items","TerranItems",f" ".join(map(str, terran_items)))
+            b.makeFile()
             await self.update_zerg_tech(start_items, kerrigan_level)
             await self.update_protoss_tech(start_items)
             await self.update_misc_tech(start_items)
@@ -1828,7 +1863,7 @@ class ArchipelagoBot(bot.bot_ai.BotAI):
                 message = self.ctx.announcements.get(timeout=1)
                 await self.chat_send("?SendMessage " + message)
                 self.ctx.announcements.task_done()
-
+            '''
             # Archipelago reads the health
             controller1_state = 0
             controller2_state = 0
@@ -1890,10 +1925,29 @@ class ArchipelagoBot(bot.bot_ai.BotAI):
                         # so a supply buffer here is the best we can do
                         self.last_supply_used = self.supply_used
             game_state = controller1_state + (controller2_state << 15)
+            '''
+            next_line = False
+            l = '<Value string="'
+            r = '"/>'
+            with open(get_bank_folder() + "/ArchipelagoLocations.SC2Bank") as locationBank:
+                for line in locationBank:
+                    if next_line:
+                        game_state = int(line[line.find(l) + len(l):line.rfind(r)])
+                        self.can_read_game = True
+                        break
+                    if '<Key name="GameState">' in line:
+                        next_line = True
 
+                    
+            
             if iteration == 160 and not game_state & 1:
                 await self.chat_send("?SendMessage Warning: Archipelago unable to connect or has lost connection to " +
                                      "Starcraft 2 (This is likely a map issue)")
+            if game_state & 1:
+                if not self.game_running:
+                    await self.chat_send("?SendMessage Archipelago Connected")
+                    print("Archipelago Connected")
+                    self.game_running = True
 
             if self.last_received_update < len(self.ctx.items_received):
                 current_items = calculate_items(self.ctx)

--- a/worlds/sc2/client.py
+++ b/worlds/sc2/client.py
@@ -603,15 +603,15 @@ class SC2Bank():
         self.fileName = name
         self.sections: typing.Dict[str, typing.Dict[str, str]] = {}
         
-    def addSection(self, sectionName: str) -> None:
+    def add_section(self, sectionName: str) -> None:
         self.sections[sectionName] = {}
 
-    def addEntry(self, sectionName: str, key: str, value: str) -> None:
+    def add_entry(self, sectionName: str, key: str, value: str) -> None:
         if not sectionName in self.sections:
-            self.addSection(sectionName)
+            self.add_section(sectionName)
         self.sections[sectionName][key]=value
 
-    def removeEntryFromFile(self, key: str) -> None:
+    def remove_entry_from_file(self, key: str) -> None:
         path = f"{get_bank_folder()}/{self.fileName}"
         with open(path, "r") as f:
             lines = f.readlines()
@@ -625,7 +625,7 @@ class SC2Bank():
                 elif deleting == False:
                     f.write(line)          
 
-    def makeFile(self) -> None:
+    def make_file(self) -> None:
         # Making a bank in the client should always be a backup
         dir = f"{get_bank_folder()}/Backup"
         content =          f'<?xml version="1.0" encoding="utf-8"?>\n<Bank version="1">\n'
@@ -1236,8 +1236,8 @@ class SC2Context(CommonContext):
         reply = await self.trade_acquire_storage(True)
 
         if reply is None:
-            trade_received_bank.addEntry("VoidTrade", "TradeResponse", "FailConnection")
-            trade_received_bank.makeFile()
+            trade_received_bank.add_entry("VoidTrade", "TradeResponse", "FailConnection")
+            trade_received_bank.make_file()
             return None
 
         # Find available units
@@ -1311,8 +1311,8 @@ class SC2Context(CommonContext):
         ])
         # Write unite to bank
         value = f"ReceiveUnits {refunds} " + " ".join(f"{unit} {count}" for (unit, count) in unit_counts.items())
-        trade_received_bank.addEntry("VoidTrade", "TradeResponse", value)
-        trade_received_bank.makeFile()
+        trade_received_bank.add_entry("VoidTrade", "TradeResponse", value)
+        trade_received_bank.make_file()
         self.trade_response = None
         self.trade_underway = False
         #self.trade_response = f"?Trade {refunds} " + " ".join(f"{unit} {count}" for (unit, count) in unit_counts.items())
@@ -1326,8 +1326,8 @@ class SC2Context(CommonContext):
         reply = await self.trade_acquire_storage(True)
 
         if reply is None:
-            trade_received_bank.addEntry("VoidTrade", "TradeResponse", "FailConnection")
-            trade_received_bank.makeFile()
+            trade_received_bank.add_entry("VoidTrade", "TradeResponse", "FailConnection")
+            trade_received_bank.make_file()
             return None
         
         # Create a storage entry for the time the trade was confirmed
@@ -1354,8 +1354,8 @@ class SC2Context(CommonContext):
         ])
         
         # Notify the game 
-        trade_received_bank.addEntry("VoidTrade", "TradeResponse", "Success")
-        trade_received_bank.makeFile()
+        trade_received_bank.add_entry("VoidTrade", "TradeResponse", "Success")
+        trade_received_bank.make_file()
         self.trade_response = None
         self.trade_underway = False
         
@@ -1846,7 +1846,7 @@ class ArchipelagoBot(bot.bot_ai.BotAI):
                 game_speed = self.ctx.game_speed
 
             options_bank = SC2Bank("ArchipelagoOptions")
-            options_bank.addEntry("GameOptions", "Options",
+            options_bank.add_entry("GameOptions", "Options",
                 f" {difficulty}"
                 f" {generic_upgrade_options}"
                 f" {self.ctx.all_in_choice}"
@@ -1867,19 +1867,19 @@ class ArchipelagoBot(bot.bot_ai.BotAI):
                 f" {self.ctx.mercenary_highlanders}" # TODO: Possibly rework it into unit options in the next cycle
                 f" {self.ctx.war_council_nerfs}"
             )
-            options_bank.makeFile()
+            options_bank.make_file()
             self.update_tech(start_items, kerrigan_level)
 
             
             core_options_bank = SC2Bank("ArchipelagoCoreOptions")
-            core_options_bank.addEntry("CoreOptions", "StartingResources", self.get_resources(start_items))
-            core_options_bank.addEntry("CoreOptions", "FactionColors", self.get_colors())
+            core_options_bank.add_entry("CoreOptions", "StartingResources", self.get_resources(start_items))
+            core_options_bank.add_entry("CoreOptions", "FactionColors", self.get_colors())
             if uncollected_objectives:
-                core_options_bank.addEntry("CoreOptions", "UncollectedLocations","{}".format(
+                core_options_bank.add_entry("CoreOptions", "UncollectedLocations","{}".format(
                     functools.reduce(lambda a, b: a + " " + b, [str(x) for x in uncollected_objectives])
                 ))
-            core_options_bank.addEntry("CoreOptions", "LoadFinished", "1")
-            core_options_bank.makeFile()
+            core_options_bank.add_entry("CoreOptions", "LoadFinished", "1")
+            core_options_bank.make_file()
 
             self.last_received_update = len(self.ctx.items_received)
 
@@ -1917,8 +1917,8 @@ class ArchipelagoBot(bot.bot_ai.BotAI):
                 if len(non_ap_units) > 0:
                     sc2_logger.info(f"Void Trade tried to send non-AP units: {', '.join(non_ap_units)}")
                     trade_received_bank = SC2Bank("ArchipelagoVoidTradeReceive")               
-                    trade_received_bank.addEntry("VoidTrade", "TradeResponse", "FailNonAPUnits")
-                    trade_received_bank.makeFile()
+                    trade_received_bank.add_entry("VoidTrade", "TradeResponse", "FailNonAPUnits")
+                    trade_received_bank.make_file()
                     #self.ctx.trade_response = "?TradeFail Void Trade rejected: Trade contains invalid units."
                     self.ctx.trade_underway = True
                 else:
@@ -2077,9 +2077,9 @@ class ArchipelagoBot(bot.bot_ai.BotAI):
                 if msg:
                     # TODO: Check for limits/staggering
                     i+=1
-                    bank.addEntry("Messages",f"Message{str(i)}", self.clean_ap_message(msg))
+                    bank.add_entry("Messages",f"Message{str(i)}", self.clean_ap_message(msg))
             if i > 0:
-                bank.makeFile()
+                bank.make_file()
 
     def get_locations(self) -> str:
         result = 0
@@ -2114,7 +2114,7 @@ class ArchipelagoBot(bot.bot_ai.BotAI):
                         next_line = True
         if result != "":
             bank = SC2Bank("ArchipelagoVoidTradeSend.SC2Bank")
-            bank.removeEntryFromFile(key)
+            bank.remove_entry_from_file(key)
         return result
     
     def get_trade_receive_request(self) -> str:
@@ -2134,7 +2134,7 @@ class ArchipelagoBot(bot.bot_ai.BotAI):
                         next_line = True
         if result != "":
             bank = SC2Bank("ArchipelagoVoidTradeSend.SC2Bank")
-            bank.removeEntryFromFile(key)
+            bank.remove_entry_from_file(key)
         return result
     
     def get_uncollected_objectives(self) -> typing.List[int]:
@@ -2203,17 +2203,17 @@ class ArchipelagoBot(bot.bot_ai.BotAI):
 
     def update_tech(self, current_items: typing.Dict[SC2Race, typing.List[int]], kerrigan_level: int):
         item_bank = SC2Bank("ArchipelagoItems")
-        item_bank.addEntry("Items", "TerranItems", self.get_terran_tech(current_items))
-        item_bank.addEntry("Items", "ZergItems", self.get_zerg_tech(current_items, kerrigan_level))
-        item_bank.addEntry("Items", "ProtossItems", self.get_protoss_tech(current_items))
-        item_bank.addEntry("Items", "MiscItems", self.get_misc_tech(current_items))
-        item_bank.makeFile()
+        item_bank.add_entry("Items", "TerranItems", self.get_terran_tech(current_items))
+        item_bank.add_entry("Items", "ZergItems", self.get_zerg_tech(current_items, kerrigan_level))
+        item_bank.add_entry("Items", "ProtossItems", self.get_protoss_tech(current_items))
+        item_bank.add_entry("Items", "MiscItems", self.get_misc_tech(current_items))
+        item_bank.make_file()
     
     def update_core_options(self, current_items: typing.Dict[SC2Race, typing.List[int]]):
         core_options_bank = SC2Bank("ArchipelagoCoreOptions")
-        core_options_bank.addEntry("CoreOptions", "StartingResources", self.get_resources(current_items))
-        core_options_bank.addEntry("CoreOptions", "FactionColors", self.get_colors())
-        core_options_bank.makeFile()
+        core_options_bank.add_entry("CoreOptions", "StartingResources", self.get_resources(current_items))
+        core_options_bank.add_entry("CoreOptions", "FactionColors", self.get_colors())
+        core_options_bank.make_file()
 
 def calc_unfinished_nodes(
         ctx: SC2Context

--- a/worlds/sc2/client.py
+++ b/worlds/sc2/client.py
@@ -21,7 +21,6 @@ import random
 import concurrent.futures
 import time
 import uuid
-import pathlib
 from pathlib import Path
 
 # CommonClient import first to trigger ModuleUpdater
@@ -597,7 +596,7 @@ class SC2JSONtoTextParser(JSONtoTextParser):
         return '<c val="' + self.color_codes[code] + '">'
 
 class SC2Bank():
-    fileName = "NewBank"
+    file_name = "NewBank"
     sections = {}
     def __init__(self, name: str) -> None:
         self.fileName = name
@@ -609,7 +608,7 @@ class SC2Bank():
     def add_entry(self, sectionName: str, key: str, value: str) -> None:
         if not sectionName in self.sections:
             self.add_section(sectionName)
-        self.sections[sectionName][key]=value
+        self.sections[sectionName][key] = value
 
     def remove_entry_from_file(self, key: str) -> None:
         path = f"{get_bank_folder()}/{self.fileName}"
@@ -618,29 +617,32 @@ class SC2Bank():
         with open(path, "w") as f:
             deleting = False
             for line in lines:
-                if f'<Key name="{key}">' in line:
+                line_content = line.strip()
+                if line_content == f'<Key name="{key}">':
                     deleting = True
-                elif '</Key>' in line and deleting:
+                elif line_content == '</Key>':
                     deleting = False
-                elif deleting == False:
+                elif not deleting:
                     f.write(line)          
 
     def make_file(self) -> None:
         # Making a bank in the client should always be a backup
         dir = f"{get_bank_folder()}/Backup"
-        content =          f'<?xml version="1.0" encoding="utf-8"?>\n<Bank version="1">\n'
+        lines = []
+        lines.append(         f'<?xml version="1.0" encoding="utf-8"?>')
+        lines.append(         f'<Bank version="1">')
         for name, section in self.sections.items():
-            content +=     f'    <Section name="{name}">\n'
+            lines.append(     f'    <Section name="{name}">')
             for key, value in section.items():
-                content += f'        <Key name="{key}">\n'
-                content += f'            <Value name="{value}"/>\n'
-                content += f'        </Key>\n'
-            content +=     f'    </Section>\n'
-        content +=         f'</Bank>'
+                lines.append( f'        <Key name="{key}">')
+                lines.append( f'            <Value name="{value}"/>')
+                lines.append( f'        </Key>')
+            lines.append(     f'    </Section>')
+        lines.append(         f'</Bank>')
         Path(dir).mkdir(parents=True, exist_ok=True)
         # TODO: Handle multiple backups in the same step (if needed)
         with open(f"{dir}/{self.fileName}_backup_1.SC2Bank", "w") as f:
-            f.write(content)
+            f.write('\n'.join(lines))
             
 class SC2Context(CommonContext):
     command_processor = StarcraftClientProcessor
@@ -1094,7 +1096,7 @@ class SC2Context(CommonContext):
                     sc2_logger.warning("Starcraft 2 Client is still running!")
                 self.sc2_run_task.cancel()  # doesn't actually close the game, just stops the python task
             # clean up locations bank from previous map
-            pathlib.Path(f"{get_bank_folder()}/ArchipelagoLocations.SC2Bank").unlink(missing_ok=True)
+            Path(f"{get_bank_folder()}/ArchipelagoLocations.SC2Bank").unlink(missing_ok=True)
             if self.slot is None:
                 sc2_logger.warning("Launching Mission without Archipelago authentication, "
                                    "checks will not be registered to server.")
@@ -1231,7 +1233,7 @@ class SC2Context(CommonContext):
     async def trade_receive(self, amount: int = 1):
         """
         Tries to pop `amount` units out of the trade storage.
-        """     
+        """
         trade_received_bank = SC2Bank("ArchipelagoVoidTradeReceive")               
         reply = await self.trade_acquire_storage(True)
 
@@ -1309,13 +1311,12 @@ class SC2Context(CommonContext):
                 "operations": [{ "operation": "update", "value": { TRADE_DATASTORAGE_LOCK: 0 } }]
             }
         ])
-        # Write unite to bank
+        # Write units to bank
         value = f"ReceiveUnits {refunds} " + " ".join(f"{unit} {count}" for (unit, count) in unit_counts.items())
         trade_received_bank.add_entry("VoidTrade", "TradeResponse", value)
         trade_received_bank.make_file()
         self.trade_response = None
         self.trade_underway = False
-        #self.trade_response = f"?Trade {refunds} " + " ".join(f"{unit} {count}" for (unit, count) in unit_counts.items())
 
 
     async def trade_send(self, units: typing.List[str]):
@@ -1884,18 +1885,20 @@ class ArchipelagoBot(bot.bot_ai.BotAI):
             self.last_received_update = len(self.ctx.items_received)
 
         else:
-            #if self.ctx.pending_color_update:
+            # TODO: re-enable color update
+            # if self.ctx.pending_color_update:
             #    await self.update_colors()
 
-            #messages = []
-            #for i in range(20):
-            #    if not self.ctx.announcements.empty(): 
-            #        messages[i] = self.ctx.announcements.get_nowait()
-            #        self.ctx.announcements.task_done()
-            #    else:
-            #        break
-            #if messages:
-            #    self.send_ap_message(messages)
+            # TODO: send multiple messages at once
+            # messages = []
+            # for i in range(20):
+            #     if not self.ctx.announcements.empty(): 
+            #         messages[i] = self.ctx.announcements.get_nowait()
+            #         self.ctx.announcements.task_done()
+            #     else:
+            #         break
+            # if messages:
+            #     self.send_ap_message(messages)
 
             if not self.ctx.announcements.empty():
                 message = self.ctx.announcements.get(timeout=1)
@@ -1940,61 +1943,6 @@ class ArchipelagoBot(bot.bot_ai.BotAI):
                     self.ctx.trade_response = None
                     async_start(self.ctx.trade_receive(5))
 
-
-            
-            # for unit in self.all_own_units():
-            #     if unit.name == TRADE_UNIT:
-            #         # Handle Void Trade requests
-            #         # Check for orders (for buildings this is usually research or training)
-            #         if not unit.is_idle and not self.ctx.trade_underway:
-            #             button = unit.orders[0].ability.button_name
-            #             if button == TRADE_SEND_BUTTON and len(self.last_trade_cargo) > 0:
-            #                 units_to_send: typing.List[str] = []
-            #                 non_ap_units: typing.Set[str] = set()
-            #                 for passenger in self.last_trade_cargo:
-            #                     # Alternatively passenger._type_data.name but passenger.name seems to always match
-            #                     unit_name = passenger.name
-            #                     if unit_name.startswith("AP_"):
-            #                         units_to_send.append(normalized_unit_types.get(unit_name, unit_name))
-            #                     else:
-            #                         non_ap_units.add(unit_name)
-            #                 if len(non_ap_units) > 0:
-            #                     sc2_logger.info(f"Void Trade tried to send non-AP units: {', '.join(non_ap_units)}")
-            #                     self.ctx.trade_response = "?TradeFail Void Trade rejected: Trade contains invalid units."
-            #                     self.ctx.trade_underway = True
-            #                 else:
-            #                     self.ctx.trade_response = None
-            #                     self.ctx.trade_underway = True
-            #                     async_start(self.ctx.trade_send(units_to_send))
-            #             elif button == TRADE_RECEIVE_1_BUTTON:
-            #                 self.ctx.trade_underway = True
-            #                 if self.supply_used != self.last_supply_used:
-            #                     self.ctx.trade_response = None
-            #                     async_start(self.ctx.trade_receive(1))
-            #                 else:
-            #                     self.ctx.trade_response = "?TradeFail Void Trade rejected: Not enough supply."
-            #             elif button == TRADE_RECEIVE_5_BUTTON:
-            #                 self.ctx.trade_underway = True
-            #                 if self.supply_used != self.last_supply_used:
-            #                     self.ctx.trade_response = None
-            #                     async_start(self.ctx.trade_receive(5))
-            #                 else:
-            #                     self.ctx.trade_response = "?TradeFail Void Trade rejected: Not enough supply."
-            #         elif not unit.is_idle and self.trade_reply_cooldown > 0:
-            #             self.trade_reply_cooldown -= 1
-            #         elif unit.is_idle and self.trade_reply_cooldown > 0:
-            #             self.trade_reply_cooldown = 0
-            #             self.ctx.trade_response = None
-            #             self.ctx.trade_underway = False
-            #         else:
-            #             # The API returns no passengers for researching/training buildings,
-            #             # so we need to buffer the passengers each frame
-            #             self.last_trade_cargo = unit.passengers
-            #             # SC2 has no good means of detecting when a unit is queued while supply capped,
-            #             # so a supply buffer here is the best we can do
-            #             self.last_supply_used = self.supply_used
-            
-
             game_state = self.get_locations()
 
             if game_state & 1:
@@ -2020,7 +1968,7 @@ class ArchipelagoBot(bot.bot_ai.BotAI):
             if game_state & 1:
                 if not self.game_running:
                     self.send_ap_message({"Archipelago Connected"})
-                    #print("Archipelago Connected")
+                    # print("Archipelago Connected")
                     self.game_running = True
             
                 if self.can_read_game:
@@ -2071,7 +2019,6 @@ class ArchipelagoBot(bot.bot_ai.BotAI):
 
     def send_ap_message(self, messages: typing.List[str]):
         if messages:
-            bank = SC2Bank("ArchipelagoMessages")
             i = 0
             for msg in messages:
                 if msg:
@@ -2079,6 +2026,7 @@ class ArchipelagoBot(bot.bot_ai.BotAI):
                     i+=1
                     bank.add_entry("Messages",f"Message{str(i)}", self.clean_ap_message(msg))
             if i > 0:
+                bank = SC2Bank("ArchipelagoMessages")
                 bank.make_file()
 
     def get_locations(self) -> str:
@@ -2150,13 +2098,14 @@ class ArchipelagoBot(bot.bot_ai.BotAI):
 
     def get_colors(self) -> str:
         self.ctx.pending_color_update = False
-        return f"""\
-        {str(self.ctx.player_color_raynor)} \
-        {str(self.ctx.player_color_zerg)} \
-        {str(self.ctx.player_color_zerg_primal)} \
-        {str(self.ctx.player_color_protoss)} \
-        {str(self.ctx.player_color_nova)}  \
-        """
+        result = [
+            str(self.ctx.player_color_raynor),
+            str(self.ctx.player_color_zerg),
+            str(self.ctx.player_color_zerg_primal),
+            str(self.ctx.player_color_protoss),
+            str(self.ctx.player_color_nova),
+        ]
+        return ' '.join(result)
 
     def get_resources(self, current_items: typing.Dict[SC2Race, typing.List[int]]) -> str:
         DEFAULT_MAX_SUPPLY = 200

--- a/worlds/sc2/client.py
+++ b/worlds/sc2/client.py
@@ -76,6 +76,7 @@ from .mission_tables import (
 import colorama
 from NetUtils import ClientStatus, NetworkItem, JSONtoTextParser, JSONMessagePart, add_json_item, add_json_location, add_json_text, JSONTypes
 from MultiServer import mark_raw
+from . import banks
 
 if typing.TYPE_CHECKING:
     from Options import Option
@@ -97,60 +98,6 @@ TRADE_DATASTORAGE_LOCK = "_lock"
 TRADE_LOCK_TIME = 5 # Time in seconds that the DataStorage may be considered safe to edit
 TRADE_LOCK_WAIT_LIMIT = 540000 / 1.4 # Time in ms that the client may spend trying to get a lock (540000 = 9 minutes, 1.4 is 'faster' game speed's time scale)
 
-# Banks
-# file names, section names and key names have to match the SC2 trigger implementation
-#
-# Client -> SC2
-# Core Options
-BANK_CORE_OPTIONS_FILE_NAME = "ArchipelagoCoreOptions" # .SC2Bank
-BANK_CORE_OPTIONS_SECTION_CORE_OPTIONS = "CoreOptions"
-BANK_CORE_OPTIONS_KEY_STARTING_RESOURCES = "StartingResources"
-BANK_CORE_OPTIONS_KEY_FACTION_COLORS = "FactionColors"
-BANK_CORE_OPTIONS_KEY_UNCOLLECTED_LOCATIONS = "UncollectedLocations"
-BANK_CORE_OPTIONS_KEY_LOAD_FINISHED = "LoadFinished"
-
-# Options
-# 2 types of options because they are handled in different mod files by SC2
-BANK_OPTIONS_FILE_NAME = "ArchipelagoOptions" # .SC2Bank
-BANK_OPTIONS_SECTION_OPTIONS = "GameOptions"
-BANK_OPTIONS_KEY_OPTIONS = "Options"
-
-# Items
-BANK_ITEMS_FILE_NAME = "ArchipelagoItems" # .SC2Bank
-BANK_ITEMS_SECTION_ITEMS = "Items"
-BANK_ITEMS_KEY_TERRAN_ITEMS = "TerranItems"
-BANK_ITEMS_KEY_ZERG_ITEMS = "ZergItems"
-BANK_ITEMS_KEY_PROTOSS_ITEMS = "ProtossItems"
-BANK_ITEMS_KEY_MISC_ITEMS = "MiscItems"
-
-# Messages
-BANK_MESSAGES_FILE_NAME = "ArchipelagoMessages" # .SC2Bank
-BANK_MESSAGES_SECTION_MESSAGES = "Messages"
-BANK_MESSAGES_KEY_MESSAGE = "Message" # Appends message number 'Message1' 'Message2' ...
-BANK_MESSAGES_KEY_LIMIT = 50 # Limit for messages per bank
-
-# Void Trade Receive (messages received by SC2)
-BANK_TRADE_RECEIVE_FILE_NAME = "ArchipelagoVoidTradeReceive" # .SC2Bank
-BANK_TRADE_RECEIVE_SECTION_TRADE = "VoidTrade"
-BANK_TRADE_RECEIVE_KEY_TRADE_RESPONSE = "TradeResponse"
-
-# SC2 -> Client
-# Locations 
-BANK_LOCATIONS_FILE_NAME = "ArchipelagoLocations" # .SC2Bank
-BANK_LOCATIONS_SECTION_LOCATIONS = "Locations"
-BANK_LOCATIONS_KEY_GAME_STATE = "GameState"
-
-# Update
-# Doesn't need sections or keys. The existence of the file is used as an update prompt for now
-BANK_UPDATE_NAME = "ArchipelagoUpdate" #.SC2Bank
-
-# Void Trade Send (messages sent by SC2)
-BANK_TRADE_SEND_FILE_NAME = "ArchipelagoVoidTradeSend"
-BANK_TRADE_SEND_SECTION_UNITS = "VoidTradeUnits"
-BANK_TRADE_SEND_KEY_UNIT_TYPES = "UnitTypes"
-BANK_TRADE_SEND_SECTION_RECEIVE_REQUEST = "VoidTradeReceiveRequest"
-BANK_TRADE_SEND_KEY_RECEIVE_COUNT = "Count"
-
 # Games
 STARCRAFT2 = "Starcraft 2"
 STARCRAFT2_WOL = "Starcraft 2 Wings of Liberty"
@@ -161,11 +108,6 @@ STARCRAFT2_WOL = "Starcraft 2 Wings of Liberty"
 # Associated with /download_data command
 def get_metadata_file() -> str:
     return os.environ["SC2PATH"] + os.sep + "ArchipelagoSC2Metadata.txt"
-
-# file path to bank folder.
-def get_bank_folder() -> str:
-    return os.path.expanduser("~/Documents/StarCraft II/Banks")
-
 
 def _remap_color_option(slot_data_version: int, color: int) -> int:
     """Remap colour options for backwards compatibility with older slot data"""
@@ -646,121 +588,7 @@ class SC2JSONtoTextParser(JSONtoTextParser):
     def color_code(self, code: str) -> str:
         return '<c val="' + self.color_codes[code] + '">'
 
-class SC2Bank():
-    # Banks are XML files used to handle communication between SC2 and the AP Client
-    file_name = "NewBank"
-    sections = {}
-    def __init__(self, name: str) -> None:
-        self.file_name = name
-        self.sections: typing.Dict[str, typing.Dict[str, str]] = {}
-    
-    def __str__(self) -> str:
-        result = []
-        result.append(f'{self.file_name}.SC2Bank:')
-        for name, section in self.sections.items():
-            result.append(f'Section {name}:')
-            for key, value in section.items():
-                result.append(f'  Key {key}:')
-                result.append(f'    Value: {value}')
-        return ('\n'.join(result))
-        
-    def add_section(self, section: str) -> None:
-        self.sections[section] = {}
 
-    def add_entry(self, section: str, key: str, value: str) -> None:
-        if not section in self.sections:
-            self.add_section(section)
-        self.sections[section][key] = value 
-    
-    def get_value(self, section: str, key: str) -> str:
-        result = ""
-        if section in self.sections:
-            if key in self.sections[section]:
-                result = self.sections[section][key]
-        return result
-
-    def read_file(self, path: str = None) -> None:
-        # Read a bank file provided by SC2 and convert it into an SC2Bank object
-        # Assumes bank files to follow the structure provided by the game
-        # Asserts catch malformed files, should never happen unless the player manually edits the files
-        if not path:
-            path = f"{get_bank_folder()}/{self.file_name}.SC2Bank"
-        if not os.path.isfile(path):
-            return
-        with open(path, "r") as f:
-            SECTION_PATTERN = re.compile(r'<Section name="(\w+)">')
-            KEY_PATTERN = re.compile(r'<Key name="(\w+)">')
-            VALUE_PATTERN = re.compile(r'<Value string="([^"]+)"/>')
-            END_KEY_PATTERN = '</Key>'
-            END_SECTION_PATTERN = '</Section>'
-            section = '' # Use the presence of a section/key as the state variable
-            key = ''     # empty string is not present
-            lines = f.readlines()
-            for line in lines:
-                line_content = line.strip()
-                if (m := SECTION_PATTERN.match(line_content)):
-                    assert not section, f"Encountered section {m.group(1)} while already inside section {section}"
-                    section = m.group(1)
-                    self.add_section(section)
-                    assert section not in self.sections.items(), f"Duplicate section definition for section {section}"
-                elif (m := KEY_PATTERN.match(line_content)):
-                    assert section, "Encountered a key while not in a section"
-                    assert not key, f"Encountered key {m.group(1)} while already inside key {key}"
-                    key = m.group(1)
-                    assert key not in self.sections[section].items(), f"Duplicate key definition for key {key}"
-                elif (m := VALUE_PATTERN.match(line_content)):
-                    assert section, "Encountered a value while not in a section"
-                    assert key, "Encountered a value while not in a key"
-                    value = m.group(1)
-                    self.add_entry(section, key, value)
-                elif line_content == END_KEY_PATTERN:
-                    assert key, "Closing a key while not already in a key"
-                    key = ''
-                elif line_content == END_SECTION_PATTERN:
-                    assert section, "Closing a section while not already in a section"
-                    section = ''
-                else:
-                    pass
-
-    def write_file(self) -> None:
-        # Write a bank file with the formatting expected from SC2
-        # SC2 reads data by restoring a bank from a backup
-        # so we write the new backup file here
-        dir = f"{get_bank_folder()}/Backup"
-        lines = []
-        lines.append(         f'<?xml version="1.0" encoding="utf-8"?>')
-        lines.append(         f'<Bank version="1">')
-        for name, section in self.sections.items():
-            lines.append(     f'    <Section name="{name}">')
-            for key, value in section.items():
-                lines.append( f'        <Key name="{key}">')
-                lines.append( f'            <Value string="{value}"/>')
-                lines.append( f'        </Key>')
-            lines.append(     f'    </Section>')
-        lines.append(         f'</Bank>')
-        Path(dir).mkdir(parents=True, exist_ok=True)
-        # TODO: Handle multiple backups in the same step (if needed)
-        with open(f"{dir}/{self.file_name}_backup_1.SC2Bank", "w") as f:
-            f.write('\n'.join(lines))
-        
-    def remove_entry_from_file(self, key: str) -> None:
-        # Remove one Key/Value pair from a bank file
-        path = f"{get_bank_folder()}/{self.file_name}"
-        with open(path, "r") as f:
-            lines = f.readlines()
-        with open(path, "w") as f:
-            deleting = False
-            for line in lines:
-                line_content = line.strip()
-                # Just find the key tag
-                if line_content == f'<Key name="{key}">':
-                    deleting = True
-                # and delete all lines until finding the closing tag
-                elif line_content == '</Key>':
-                    deleting = False
-                elif not deleting:
-                    f.write(line)         
-            
 class SC2Context(CommonContext):
     command_processor = StarcraftClientProcessor
     game = STARCRAFT2
@@ -1213,7 +1041,7 @@ class SC2Context(CommonContext):
                     sc2_logger.warning("Starcraft 2 Client is still running!")
                 self.sc2_run_task.cancel()  # doesn't actually close the game, just stops the python task
             # clean up locations bank from previous map
-            Path(f"{get_bank_folder()}/{BANK_LOCATIONS_FILE_NAME}.SC2Bank").unlink(missing_ok=True)
+            banks.file_cleanup()
             if self.slot is None:
                 sc2_logger.warning("Launching Mission without Archipelago authentication, "
                                    "checks will not be registered to server.")
@@ -1350,17 +1178,11 @@ class SC2Context(CommonContext):
     async def trade_receive(self, amount: int = 1):
         """
         Tries to pop `amount` units out of the trade storage.
-        """
-        trade_received_bank = SC2Bank(BANK_TRADE_RECEIVE_FILE_NAME)               
+        """           
         reply = await self.trade_acquire_storage(True)
 
         if reply is None:
-            trade_received_bank.add_entry(
-                BANK_TRADE_RECEIVE_SECTION_TRADE, 
-                BANK_TRADE_RECEIVE_KEY_TRADE_RESPONSE, 
-                 "FailConnection"
-            )
-            trade_received_bank.write_file()
+            banks.send_trade_received("FailConnection")
             return None
 
         # Find available units
@@ -1434,12 +1256,7 @@ class SC2Context(CommonContext):
         ])
         # Write units to bank
         value = f"ReceiveUnits {refunds} " + " ".join(f"{unit} {count}" for (unit, count) in unit_counts.items())
-        trade_received_bank.add_entry(
-                BANK_TRADE_RECEIVE_SECTION_TRADE, 
-                BANK_TRADE_RECEIVE_KEY_TRADE_RESPONSE, 
-                value
-            )
-        trade_received_bank.write_file()
+        banks.send_trade_received(value)
         self.trade_response = None
         self.trade_underway = False
 
@@ -1448,16 +1265,10 @@ class SC2Context(CommonContext):
         """
         Tries to upload `units` to the trade DataStorage.
         """
-        trade_received_bank = SC2Bank(BANK_TRADE_RECEIVE_FILE_NAME)
         reply = await self.trade_acquire_storage(True)
 
         if reply is None:
-            trade_received_bank.add_entry(
-                BANK_TRADE_RECEIVE_SECTION_TRADE, 
-                BANK_TRADE_RECEIVE_KEY_TRADE_RESPONSE, 
-                 "FailConnection"
-            )
-            trade_received_bank.write_file()
+            banks.send_trade_received("FailConnection")
             return None
         
         # Create a storage entry for the time the trade was confirmed
@@ -1484,12 +1295,7 @@ class SC2Context(CommonContext):
         ])
         
         # Notify the game 
-        trade_received_bank.add_entry(
-            BANK_TRADE_RECEIVE_SECTION_TRADE, 
-            BANK_TRADE_RECEIVE_KEY_TRADE_RESPONSE, 
-            "Success"
-        )
-        trade_received_bank.write_file()
+        banks.send_trade_received("Success")
         self.trade_response = None
         self.trade_underway = False
         
@@ -1979,10 +1785,7 @@ class ArchipelagoBot(bot.bot_ai.BotAI):
             else:
                 game_speed = self.ctx.game_speed
 
-            options_bank = SC2Bank(BANK_OPTIONS_FILE_NAME)
-            options_bank.add_entry(
-                BANK_OPTIONS_SECTION_OPTIONS,
-                BANK_OPTIONS_KEY_OPTIONS,
+            banks.send_options(
                 f" {difficulty}"
                 f" {generic_upgrade_options}"
                 f" {self.ctx.all_in_choice}"
@@ -2003,34 +1806,16 @@ class ArchipelagoBot(bot.bot_ai.BotAI):
                 f" {self.ctx.mercenary_highlanders}" # TODO: Possibly rework into unit options
                 f" {self.ctx.war_council_nerfs}"
             )
-            options_bank.write_file()
             self.update_tech(start_items, kerrigan_level)
-
-            
-            core_options_bank = SC2Bank(BANK_CORE_OPTIONS_FILE_NAME)
-            core_options_bank.add_entry(
-                BANK_CORE_OPTIONS_SECTION_CORE_OPTIONS, 
-                BANK_CORE_OPTIONS_KEY_STARTING_RESOURCES, 
-                self.get_resources(start_items)
-            )
-            core_options_bank.add_entry(
-                BANK_CORE_OPTIONS_SECTION_CORE_OPTIONS,
-                BANK_CORE_OPTIONS_KEY_FACTION_COLORS,
-                self.get_colors()
-            )
+            objectives = ""
             if uncollected_objectives:
-                core_options_bank.add_entry(
-                    BANK_CORE_OPTIONS_SECTION_CORE_OPTIONS,
-                    BANK_CORE_OPTIONS_KEY_UNCOLLECTED_LOCATIONS,
-                    "{}".format(
-                        functools.reduce(lambda a, b: a + " " + b, [str(x) for x in uncollected_objectives])
-                    )
-                )
-            core_options_bank.add_entry(
-                BANK_CORE_OPTIONS_SECTION_CORE_OPTIONS,
-                BANK_CORE_OPTIONS_KEY_LOAD_FINISHED,
-                "1")
-            core_options_bank.write_file()
+                objectives = " ".join(f"{str(objective)}" for objective in uncollected_objectives)
+            banks.send_core_options(
+                self.get_resources(start_items),
+                self.get_colors(),
+                objectives,
+                "1"
+            )
 
             self.last_received_update = len(self.ctx.items_received)
 
@@ -2048,11 +1833,11 @@ class ArchipelagoBot(bot.bot_ai.BotAI):
             #     else:
             #         break
             # if messages:
-            #     self.send_ap_message(messages)
+            #     banks.send_ap_message(messages)
 
             if not self.ctx.announcements.empty():
                 message = self.ctx.announcements.get(timeout=1)
-                self.send_ap_message({message})
+                banks.send_ap_message({message})
                 self.ctx.announcements.task_done()
 
         
@@ -2069,14 +1854,7 @@ class ArchipelagoBot(bot.bot_ai.BotAI):
                         non_ap_units.add(unit_id)
                 if len(non_ap_units) > 0:
                     sc2_logger.info(f"Void Trade tried to send non-AP units: {', '.join(non_ap_units)}")
-                    trade_received_bank = SC2Bank(BANK_TRADE_RECEIVE_FILE_NAME)               
-                    trade_received_bank.add_entry(
-                        BANK_TRADE_RECEIVE_SECTION_TRADE,
-                        BANK_TRADE_RECEIVE_KEY_TRADE_RESPONSE,
-                        "FailNonAPUnits"
-                    )
-                    trade_received_bank.write_file()
-                    #self.ctx.trade_response = "?TradeFail Void Trade rejected: Trade contains invalid units."
+                    banks.send_trade_received("FailNonAPUnits")
                     self.ctx.trade_underway = True
                 else:
                     self.ctx.trade_response = None
@@ -2103,14 +1881,11 @@ class ArchipelagoBot(bot.bot_ai.BotAI):
                 self.can_read_game = True
 
             if iteration == 160 and not game_state & 1:
-                self.send_ap_message({"Warning: Archipelago unable to connect or has lost connection to " +
+                banks.send_ap_message({"Warning: Archipelago unable to connect or has lost connection to " +
                                         "Starcraft 2 (This is likely a map issue)"})
                 
-            path =f"{get_bank_folder()}/{BANK_UPDATE_NAME}.SC2Bank"
-            if os.path.isfile(path):
-                # if bank exists, we want an update prompt. No need to check the values
+            if banks.update_prompt():
                 self.last_received_update = 0
-                os.remove(path)
                 
             if self.last_received_update < len(self.ctx.items_received):
                 current_items = calculate_items(self.ctx)
@@ -2122,7 +1897,7 @@ class ArchipelagoBot(bot.bot_ai.BotAI):
             
             if game_state & 1:
                 if not self.game_running:
-                    self.send_ap_message({"Archipelago Connected"})
+                    banks.send_ap_message({"Archipelago Connected"})
                     # print("Archipelago Connected")
                     self.game_running = True
             
@@ -2163,59 +1938,27 @@ class ArchipelagoBot(bot.bot_ai.BotAI):
                     
                     # Send Void Trade results
                     if self.ctx.trade_response is not None and self.trade_reply_cooldown == 0:
-                        self.send_ap_message({self.ctx.trade_response})
+                        banks.send_ap_message({self.ctx.trade_response})
                         # Wait an arbitrary amount of frames before trying again
                         self.trade_reply_cooldown = 60
                 else:
-                    self.send_ap_message({"LostConnection - Lost connection to game."})
+                    banks.send_ap_message({"LostConnection - Lost connection to game."})
 
-    def clean_ap_message(self, message: str) -> str:
-        return message.replace('<','&lt;').replace('>','&gt;').replace('"','&quot;')
 
-    def send_ap_message(self, messages: typing.List[str]):
-        bank = SC2Bank(BANK_MESSAGES_FILE_NAME)
-        if messages:
-            i = 0
-            for msg in messages:
-                if msg:
-                    # TODO: Check for limits/staggering
-                    i+=1
-                    bank.add_entry(
-                        BANK_MESSAGES_SECTION_MESSAGES,
-                        f"{BANK_MESSAGES_KEY_MESSAGE}{str(i)}", 
-                        self.clean_ap_message(msg)
-                    )
-            if i > 0:
-                bank.write_file()
 
     def get_locations(self) -> int:
-        location_bank = SC2Bank(BANK_LOCATIONS_FILE_NAME)
-        location_bank.read_file()
-        return int(location_bank.get_value(
-            BANK_LOCATIONS_SECTION_LOCATIONS,
-            BANK_LOCATIONS_KEY_GAME_STATE
-        ))
+        result = banks.read_locations()
+        if (result.strip()): # may be "" or " "
+            return int(result)
+        return 0
+        
     
     def get_trade_units_sent(self) -> str:
-        trade_send_bank = SC2Bank(BANK_TRADE_SEND_FILE_NAME)
-        trade_send_bank.read_file()
-        result = trade_send_bank.get_value(
-            BANK_TRADE_SEND_SECTION_UNITS,
-            BANK_TRADE_SEND_KEY_UNIT_TYPES
-        )
-        if result != "":
-            trade_send_bank.remove_entry_from_file(BANK_TRADE_SEND_KEY_UNIT_TYPES)
+        result = banks.read_trade_units()
         return result
     
     def get_trade_receive_request(self) -> str:
-        trade_send_bank = SC2Bank(BANK_TRADE_SEND_FILE_NAME)
-        trade_send_bank.read_file()
-        result = trade_send_bank.get_value(
-            BANK_TRADE_SEND_SECTION_RECEIVE_REQUEST,
-            BANK_TRADE_SEND_KEY_RECEIVE_COUNT
-        )
-        if result != "":
-            trade_send_bank.remove_entry_from_file(BANK_TRADE_SEND_KEY_RECEIVE_COUNT)
+        result = banks.read_trade_receive_request()
         return result
     
     def get_uncollected_objectives(self) -> typing.List[int]:
@@ -2284,27 +2027,18 @@ class ArchipelagoBot(bot.bot_ai.BotAI):
         ))
 
     def update_tech(self, current_items: typing.Dict[SC2Race, typing.List[int]], kerrigan_level: int):
-        item_bank = SC2Bank(BANK_ITEMS_FILE_NAME)
-        section = BANK_ITEMS_SECTION_ITEMS
-        item_bank.add_entry(section, BANK_ITEMS_KEY_TERRAN_ITEMS, self.get_terran_tech(current_items))
-        item_bank.add_entry(section, BANK_ITEMS_KEY_ZERG_ITEMS, self.get_zerg_tech(current_items, kerrigan_level))
-        item_bank.add_entry(section, BANK_ITEMS_KEY_PROTOSS_ITEMS, self.get_protoss_tech(current_items))
-        item_bank.add_entry(section, BANK_ITEMS_KEY_MISC_ITEMS, self.get_misc_tech(current_items))
-        item_bank.write_file()
+        banks.send_items(
+            self.get_terran_tech(current_items),
+            self.get_zerg_tech(current_items, kerrigan_level),
+            self.get_protoss_tech(current_items),
+            self.get_misc_tech(current_items)
+        )
     
     def update_core_options(self, current_items: typing.Dict[SC2Race, typing.List[int]]):
-        core_options_bank = SC2Bank(BANK_CORE_OPTIONS_FILE_NAME)
-        core_options_bank.add_entry(
-            BANK_CORE_OPTIONS_SECTION_CORE_OPTIONS,
-            BANK_CORE_OPTIONS_KEY_STARTING_RESOURCES,
-            self.get_resources(current_items)
-        )
-        core_options_bank.add_entry(
-            BANK_CORE_OPTIONS_SECTION_CORE_OPTIONS,
-            BANK_CORE_OPTIONS_KEY_FACTION_COLORS,
+        banks.send_core_options(
+            self.get_resources(current_items),
             self.get_colors()
         )
-        core_options_bank.write_file()
 
 def calc_unfinished_nodes(
         ctx: SC2Context

--- a/worlds/sc2/client.py
+++ b/worlds/sc2/client.py
@@ -862,14 +862,14 @@ class SC2Context(CommonContext):
             self.nova_grant_story_tech = args["slot_data"].get("nova_grant_story_tech", False)
             if self.slot_data_version < 4:
                 if args["slot_data"].get("nova_covert_ops_only", True):
-                    self.nova_presence = {NovaPresenceOptions.NCO_TERRAN},
+                    self.nova_presence = {NovaPresenceOptions.NCO_TERRAN}
                 else:
-                    self.nova_presence = {NovaPresenceOptions.NCO_TERRAN, NovaPresenceOptions.GHOST_OF_A_CHANCE},
+                    self.nova_presence = {NovaPresenceOptions.NCO_TERRAN, NovaPresenceOptions.GHOST_OF_A_CHANCE}
             if self.slot_data_version < 5:
                 if args["slot_data"].get("use_nova_wol_fallback", True):
-                    self.nova_presence = {NovaPresenceOptions.NCO_TERRAN},
+                    self.nova_presence = {NovaPresenceOptions.NCO_TERRAN}
                 else:
-                    self.nova_presence = {NovaPresenceOptions.NCO_TERRAN, NovaPresenceOptions.GHOST_OF_A_CHANCE},
+                    self.nova_presence = {NovaPresenceOptions.NCO_TERRAN, NovaPresenceOptions.GHOST_OF_A_CHANCE}
             self.trade_enabled = args["slot_data"].get("enable_void_trade", EnableVoidTrade.option_false)
             self.trade_age_limit = args["slot_data"].get("void_trade_age_limit", VoidTradeAgeLimit.default)
             self.trade_workers_allowed = args["slot_data"].get("void_trade_workers", VoidTradeWorkers.default)
@@ -1770,6 +1770,7 @@ class ArchipelagoBot(bot.bot_ai.BotAI):
             kerrigan_level = get_kerrigan_level(self.ctx, start_items, missions_beaten)
             kerrigan_options = calculate_kerrigan_options(self.ctx)
             nova_presence = calculate_nova_presence(self.ctx, mission)
+            print(f"Nova presence: {nova_presence}")
             grant_story_tech = calculate_story_tech(self.ctx, mission)
             soa_options = calculate_soa_options(self.ctx, mission)
             generic_upgrade_options = calculate_generic_upgrade_options(self.ctx)

--- a/worlds/sc2/client.py
+++ b/worlds/sc2/client.py
@@ -1936,6 +1936,10 @@ class ArchipelagoBot(bot.bot_ai.BotAI):
                 self.send_chat_message({"Warning: Archipelago unable to connect or has lost connection to " +
                                         "Starcraft 2 (This is likely a map issue)"})
                 
+            if os.path.isfile(f"{get_bank_folder()}/ArchipelagoUpdate.SC2Bank"):
+                self.last_received_update = 0
+                os.remove(f"{get_bank_folder()}/ArchipelagoUpdate.SC2Bank")
+                
             if self.last_received_update < len(self.ctx.items_received):
                 current_items = calculate_items(self.ctx)
                 missions_beaten = self.missions_beaten_count()

--- a/worlds/sc2/client.py
+++ b/worlds/sc2/client.py
@@ -613,21 +613,16 @@ class SC2Bank():
 
     def removeEntryFromFile(self, key: str) -> None:
         path = f"{get_bank_folder()}/{self.fileName}"
-        print(f"checking for: {str}")
         with open(path, "r") as f:
             lines = f.readlines()
         with open(path, "w") as f:
             deleting = False
             for line in lines:
-                print(line)
                 if f'<Key name="{key}">' in line:
-                    print("key")
                     deleting = True
                 elif '</Key>' in line and deleting:
-                    print("deleting")
                     deleting = False
                 elif deleting == False:
-                    print("writing")
                     f.write(line)          
 
     def makeFile(self) -> None:
@@ -643,6 +638,7 @@ class SC2Bank():
             content +=     f'    </Section>\n'
         content +=         f'</Bank>'
         Path(dir).mkdir(parents=True, exist_ok=True)
+        # TODO: Handle multiple backups in the same step (if needed)
         with open(f"{dir}/{self.fileName}_backup_1.SC2Bank", "w") as f:
             f.write(content)
             
@@ -1233,11 +1229,10 @@ class SC2Context(CommonContext):
         
 
     async def trade_receive(self, amount: int = 1):
-        trade_received_bank = SC2Bank("ArchipelagoVoidTradeReceive")
         """
         Tries to pop `amount` units out of the trade storage.
-        """                    
-        print("trade_receive")
+        """     
+        trade_received_bank = SC2Bank("ArchipelagoVoidTradeReceive")               
         reply = await self.trade_acquire_storage(True)
 
         if reply is None:
@@ -1288,7 +1283,6 @@ class SC2Context(CommonContext):
             units = []
         else:
             units = random.sample(available_units, amount, counts = available_counts)
-        print("found units")
         # Build response data
         unit_counts: typing.Dict[str, int] = {}
         slots_to_update: typing.Dict[str, typing.Dict[int, typing.Dict[str, int]]] = {}
@@ -1303,7 +1297,6 @@ class SC2Context(CommonContext):
             # Clean up trades that were completely exhausted
             if len(slots_to_update[slot][send_time]) == 0:
                 slots_to_update[slot].pop(send_time)
-        print("made string")
         await self.send_msgs([
             {   # Update server storage
                 "cmd": "Set",
@@ -1316,22 +1309,20 @@ class SC2Context(CommonContext):
                 "operations": [{ "operation": "update", "value": { TRADE_DATASTORAGE_LOCK: 0 } }]
             }
         ])
-        print("pop storage")
         # Write unite to bank
         value = f"ReceiveUnits {refunds} " + " ".join(f"{unit} {count}" for (unit, count) in unit_counts.items())
         trade_received_bank.addEntry("VoidTrade", "TradeResponse", value)
         trade_received_bank.makeFile()
         self.trade_response = None
         self.trade_underway = False
-        print(f"save bank: {value}")
         #self.trade_response = f"?Trade {refunds} " + " ".join(f"{unit} {count}" for (unit, count) in unit_counts.items())
 
 
     async def trade_send(self, units: typing.List[str]):
-        trade_received_bank = SC2Bank("ArchipelagoVoidTradeReceive")
         """
         Tries to upload `units` to the trade DataStorage.
         """
+        trade_received_bank = SC2Bank("ArchipelagoVoidTradeReceive")
         reply = await self.trade_acquire_storage(True)
 
         if reply is None:
@@ -1362,8 +1353,7 @@ class SC2Context(CommonContext):
             }
         ])
         
-        # Notify the game
-            
+        # Notify the game 
         trade_received_bank.addEntry("VoidTrade", "TradeResponse", "Success")
         trade_received_bank.makeFile()
         self.trade_response = None
@@ -1905,11 +1895,11 @@ class ArchipelagoBot(bot.bot_ai.BotAI):
             #    else:
             #        break
             #if messages:
-            #    self.send_chat_message(messages)
+            #    self.send_ap_message(messages)
 
             if not self.ctx.announcements.empty():
                 message = self.ctx.announcements.get(timeout=1)
-                self.send_chat_message({message})
+                self.send_ap_message({message})
                 self.ctx.announcements.task_done()
 
         
@@ -1924,14 +1914,17 @@ class ArchipelagoBot(bot.bot_ai.BotAI):
                         units_to_send.append(normalized_unit_types.get(unit_id, unit_id))
                     else:
                         non_ap_units.add(unit_id)
-                    if len(non_ap_units) > 0:
-                        sc2_logger.info(f"Void Trade tried to send non-AP units: {', '.join(non_ap_units)}")
-                        self.ctx.trade_response = "?TradeFail Void Trade rejected: Trade contains invalid units."
-                        self.ctx.trade_underway = True
-                    else:
-                        self.ctx.trade_response = None
-                        self.ctx.trade_underway = True
-                        async_start(self.ctx.trade_send(units_to_send))
+                if len(non_ap_units) > 0:
+                    sc2_logger.info(f"Void Trade tried to send non-AP units: {', '.join(non_ap_units)}")
+                    trade_received_bank = SC2Bank("ArchipelagoVoidTradeReceive")               
+                    trade_received_bank.addEntry("VoidTrade", "TradeResponse", "FailNonAPUnits")
+                    trade_received_bank.makeFile()
+                    #self.ctx.trade_response = "?TradeFail Void Trade rejected: Trade contains invalid units."
+                    self.ctx.trade_underway = True
+                else:
+                    self.ctx.trade_response = None
+                    self.ctx.trade_underway = True
+                    async_start(self.ctx.trade_send(units_to_send))
             
             trade_receive_string = self.get_trade_receive_request()
             # Message format:
@@ -1948,59 +1941,59 @@ class ArchipelagoBot(bot.bot_ai.BotAI):
                     async_start(self.ctx.trade_receive(5))
 
 
-            '''
-            for unit in self.all_own_units():
-                if unit.name == TRADE_UNIT:
-                    # Handle Void Trade requests
-                    # Check for orders (for buildings this is usually research or training)
-                    if not unit.is_idle and not self.ctx.trade_underway:
-                        button = unit.orders[0].ability.button_name
-                        if button == TRADE_SEND_BUTTON and len(self.last_trade_cargo) > 0:
-                            units_to_send: typing.List[str] = []
-                            non_ap_units: typing.Set[str] = set()
-                            for passenger in self.last_trade_cargo:
-                                # Alternatively passenger._type_data.name but passenger.name seems to always match
-                                unit_name = passenger.name
-                                if unit_name.startswith("AP_"):
-                                    units_to_send.append(normalized_unit_types.get(unit_name, unit_name))
-                                else:
-                                    non_ap_units.add(unit_name)
-                            if len(non_ap_units) > 0:
-                                sc2_logger.info(f"Void Trade tried to send non-AP units: {', '.join(non_ap_units)}")
-                                self.ctx.trade_response = "?TradeFail Void Trade rejected: Trade contains invalid units."
-                                self.ctx.trade_underway = True
-                            else:
-                                self.ctx.trade_response = None
-                                self.ctx.trade_underway = True
-                                async_start(self.ctx.trade_send(units_to_send))
-                        elif button == TRADE_RECEIVE_1_BUTTON:
-                            self.ctx.trade_underway = True
-                            if self.supply_used != self.last_supply_used:
-                                self.ctx.trade_response = None
-                                async_start(self.ctx.trade_receive(1))
-                            else:
-                                self.ctx.trade_response = "?TradeFail Void Trade rejected: Not enough supply."
-                        elif button == TRADE_RECEIVE_5_BUTTON:
-                            self.ctx.trade_underway = True
-                            if self.supply_used != self.last_supply_used:
-                                self.ctx.trade_response = None
-                                async_start(self.ctx.trade_receive(5))
-                            else:
-                                self.ctx.trade_response = "?TradeFail Void Trade rejected: Not enough supply."
-                    elif not unit.is_idle and self.trade_reply_cooldown > 0:
-                        self.trade_reply_cooldown -= 1
-                    elif unit.is_idle and self.trade_reply_cooldown > 0:
-                        self.trade_reply_cooldown = 0
-                        self.ctx.trade_response = None
-                        self.ctx.trade_underway = False
-                    else:
-                        # The API returns no passengers for researching/training buildings,
-                        # so we need to buffer the passengers each frame
-                        self.last_trade_cargo = unit.passengers
-                        # SC2 has no good means of detecting when a unit is queued while supply capped,
-                        # so a supply buffer here is the best we can do
-                        self.last_supply_used = self.supply_used
-            '''
+            
+            # for unit in self.all_own_units():
+            #     if unit.name == TRADE_UNIT:
+            #         # Handle Void Trade requests
+            #         # Check for orders (for buildings this is usually research or training)
+            #         if not unit.is_idle and not self.ctx.trade_underway:
+            #             button = unit.orders[0].ability.button_name
+            #             if button == TRADE_SEND_BUTTON and len(self.last_trade_cargo) > 0:
+            #                 units_to_send: typing.List[str] = []
+            #                 non_ap_units: typing.Set[str] = set()
+            #                 for passenger in self.last_trade_cargo:
+            #                     # Alternatively passenger._type_data.name but passenger.name seems to always match
+            #                     unit_name = passenger.name
+            #                     if unit_name.startswith("AP_"):
+            #                         units_to_send.append(normalized_unit_types.get(unit_name, unit_name))
+            #                     else:
+            #                         non_ap_units.add(unit_name)
+            #                 if len(non_ap_units) > 0:
+            #                     sc2_logger.info(f"Void Trade tried to send non-AP units: {', '.join(non_ap_units)}")
+            #                     self.ctx.trade_response = "?TradeFail Void Trade rejected: Trade contains invalid units."
+            #                     self.ctx.trade_underway = True
+            #                 else:
+            #                     self.ctx.trade_response = None
+            #                     self.ctx.trade_underway = True
+            #                     async_start(self.ctx.trade_send(units_to_send))
+            #             elif button == TRADE_RECEIVE_1_BUTTON:
+            #                 self.ctx.trade_underway = True
+            #                 if self.supply_used != self.last_supply_used:
+            #                     self.ctx.trade_response = None
+            #                     async_start(self.ctx.trade_receive(1))
+            #                 else:
+            #                     self.ctx.trade_response = "?TradeFail Void Trade rejected: Not enough supply."
+            #             elif button == TRADE_RECEIVE_5_BUTTON:
+            #                 self.ctx.trade_underway = True
+            #                 if self.supply_used != self.last_supply_used:
+            #                     self.ctx.trade_response = None
+            #                     async_start(self.ctx.trade_receive(5))
+            #                 else:
+            #                     self.ctx.trade_response = "?TradeFail Void Trade rejected: Not enough supply."
+            #         elif not unit.is_idle and self.trade_reply_cooldown > 0:
+            #             self.trade_reply_cooldown -= 1
+            #         elif unit.is_idle and self.trade_reply_cooldown > 0:
+            #             self.trade_reply_cooldown = 0
+            #             self.ctx.trade_response = None
+            #             self.ctx.trade_underway = False
+            #         else:
+            #             # The API returns no passengers for researching/training buildings,
+            #             # so we need to buffer the passengers each frame
+            #             self.last_trade_cargo = unit.passengers
+            #             # SC2 has no good means of detecting when a unit is queued while supply capped,
+            #             # so a supply buffer here is the best we can do
+            #             self.last_supply_used = self.supply_used
+            
 
             game_state = self.get_locations()
 
@@ -2008,7 +2001,7 @@ class ArchipelagoBot(bot.bot_ai.BotAI):
                 self.can_read_game = True
 
             if iteration == 160 and not game_state & 1:
-                self.send_chat_message({"Warning: Archipelago unable to connect or has lost connection to " +
+                self.send_ap_message({"Warning: Archipelago unable to connect or has lost connection to " +
                                         "Starcraft 2 (This is likely a map issue)"})
                 
             if os.path.isfile(f"{get_bank_folder()}/ArchipelagoUpdate.SC2Bank"):
@@ -2026,7 +2019,7 @@ class ArchipelagoBot(bot.bot_ai.BotAI):
             
             if game_state & 1:
                 if not self.game_running:
-                    self.send_chat_message({"Archipelago Connected"})
+                    self.send_ap_message({"Archipelago Connected"})
                     #print("Archipelago Connected")
                     self.game_running = True
             
@@ -2067,23 +2060,26 @@ class ArchipelagoBot(bot.bot_ai.BotAI):
                     
                     # Send Void Trade results
                     if self.ctx.trade_response is not None and self.trade_reply_cooldown == 0:
-                        await self.send_chat_message(self.ctx.trade_response)
+                        self.send_ap_message({self.ctx.trade_response})
                         # Wait an arbitrary amount of frames before trying again
                         self.trade_reply_cooldown = 60
                 else:
-                    self.send_chat_message({"LostConnection - Lost connection to game."})
+                    self.send_ap_message({"LostConnection - Lost connection to game."})
 
-    def clean_chat_message(self, message: str) -> str:
+    def clean_ap_message(self, message: str) -> str:
         return message.replace('<','&lt;').replace('>','&gt;').replace('"','&quot;')
 
-    def send_chat_message(self, messages: typing.List[str]):
-        bank = SC2Bank("ArchipelagoMessages")
-        i = 0
-        for msg in messages:
-            # TODO: Check for limits/staggering
-            i+=1
-            bank.addEntry("Messages",f"Message{str(i)}", self.clean_chat_message(msg))
-        bank.makeFile()
+    def send_ap_message(self, messages: typing.List[str]):
+        if messages:
+            bank = SC2Bank("ArchipelagoMessages")
+            i = 0
+            for msg in messages:
+                if msg:
+                    # TODO: Check for limits/staggering
+                    i+=1
+                    bank.addEntry("Messages",f"Message{str(i)}", self.clean_ap_message(msg))
+            if i > 0:
+                bank.makeFile()
 
     def get_locations(self) -> str:
         result = 0

--- a/worlds/sc2/client.py
+++ b/worlds/sc2/client.py
@@ -1817,8 +1817,8 @@ class ArchipelagoBot(bot.bot_ai.BotAI):
             else:
                 game_speed = self.ctx.game_speed
 
-            OptionsBank = SC2Bank("ArchipelagoOptions")
-            OptionsBank.addEntry("GameOptions","Options",
+            options_bank = SC2Bank("ArchipelagoOptions")
+            options_bank.addEntry("GameOptions", "Options",
                 f" {difficulty}"
                 f" {generic_upgrade_options}"
                 f" {self.ctx.all_in_choice}"
@@ -1839,19 +1839,19 @@ class ArchipelagoBot(bot.bot_ai.BotAI):
                 f" {self.ctx.mercenary_highlanders}" # TODO: Possibly rework it into unit options in the next cycle
                 f" {self.ctx.war_council_nerfs}"
             )
-            OptionsBank.makeFile()
-            self.update_tech(start_items,kerrigan_level)
+            options_bank.makeFile()
+            self.update_tech(start_items, kerrigan_level)
 
             
-            CoreOptionsBank = SC2Bank("ArchipelagoCoreOptions")
-            CoreOptionsBank.addEntry("CoreOptions","StartingResources",self.get_resources(start_items))
-            CoreOptionsBank.addEntry("CoreOptions","FactionColors",self.get_colors())
+            core_options_bank = SC2Bank("ArchipelagoCoreOptions")
+            core_options_bank.addEntry("CoreOptions", "StartingResources", self.get_resources(start_items))
+            core_options_bank.addEntry("CoreOptions", "FactionColors", self.get_colors())
             if uncollected_objectives:
-                CoreOptionsBank.addEntry("CoreOptions","UncollectedLocations","{}".format(
+                core_options_bank.addEntry("CoreOptions", "UncollectedLocations","{}".format(
                     functools.reduce(lambda a, b: a + " " + b, [str(x) for x in uncollected_objectives])
                 ))
-            CoreOptionsBank.addEntry("CoreOptions","LoadFinished","1")
-            CoreOptionsBank.makeFile()
+            core_options_bank.addEntry("CoreOptions", "LoadFinished", "1")
+            core_options_bank.makeFile()
 
             self.last_received_update = len(self.ctx.items_received)
         else:
@@ -1936,12 +1936,6 @@ class ArchipelagoBot(bot.bot_ai.BotAI):
                 self.send_chat_message({"Warning: Archipelago unable to connect or has lost connection to " +
                                         "Starcraft 2 (This is likely a map issue)"})
                 
-            if game_state & 1:
-                if not self.game_running:
-                    self.send_chat_message({"Archipelago Connected"})
-                    #print("Archipelago Connected")
-                    self.game_running = True
-            
             if self.last_received_update < len(self.ctx.items_received):
                 current_items = calculate_items(self.ctx)
                 missions_beaten = self.missions_beaten_count()
@@ -1952,9 +1946,10 @@ class ArchipelagoBot(bot.bot_ai.BotAI):
             
             if game_state & 1:
                 if not self.game_running:
-                    print("Archipelago Connected")
+                    self.send_chat_message({"Archipelago Connected"})
+                    #print("Archipelago Connected")
                     self.game_running = True
-
+            
                 if self.can_read_game:
                     if game_state & (1 << 1) and not self.mission_completed:
                         victory_locations = [get_location_id(self.mission_id, 0)]
@@ -2088,18 +2083,18 @@ class ArchipelagoBot(bot.bot_ai.BotAI):
         ))
 
     def update_tech(self, current_items: typing.Dict[SC2Race, typing.List[int]], kerrigan_level: int):
-        ItemBank = SC2Bank("ArchipelagoItems")
-        ItemBank.addEntry("Items","TerranItems",self.get_terran_tech(current_items))
-        ItemBank.addEntry("Items","ZergItems",self.get_zerg_tech(current_items, kerrigan_level))
-        ItemBank.addEntry("Items","ProtossItems",self.get_protoss_tech(current_items))
-        ItemBank.addEntry("Items","MiscItems",self.get_misc_tech(current_items))
-        ItemBank.makeFile()
+        item_bank = SC2Bank("ArchipelagoItems")
+        item_bank.addEntry("Items", "TerranItems", self.get_terran_tech(current_items))
+        item_bank.addEntry("Items", "ZergItems", self.get_zerg_tech(current_items, kerrigan_level))
+        item_bank.addEntry("Items", "ProtossItems", self.get_protoss_tech(current_items))
+        item_bank.addEntry("Items", "MiscItems", self.get_misc_tech(current_items))
+        item_bank.makeFile()
     
     def update_core_options(self, current_items: typing.Dict[SC2Race, typing.List[int]]):
-        CoreOptionsBank = SC2Bank("ArchipelagoCoreOptions")
-        CoreOptionsBank.addEntry("CoreOptions","StartingResources",self.get_resources(current_items))
-        CoreOptionsBank.addEntry("CoreOptions","FactionColors",self.get_colors())
-        CoreOptionsBank.makeFile()
+        core_options_bank = SC2Bank("ArchipelagoCoreOptions")
+        core_options_bank.addEntry("CoreOptions", "StartingResources", self.get_resources(current_items))
+        core_options_bank.addEntry("CoreOptions", "FactionColors", self.get_colors())
+        core_options_bank.makeFile()
 
 def calc_unfinished_nodes(
         ctx: SC2Context

--- a/worlds/sc2/client.py
+++ b/worlds/sc2/client.py
@@ -1078,6 +1078,8 @@ class SC2Context(CommonContext):
                 if not self.sc2_run_task.done():
                     sc2_logger.warning("Starcraft 2 Client is still running!")
                 self.sc2_run_task.cancel()  # doesn't actually close the game, just stops the python task
+            # clean up locations bank from previous map
+            pathlib.Path(f"{get_bank_folder()}/ArchipelagoLocations.SC2Bank").unlink(missing_ok=True)
             if self.slot is None:
                 sc2_logger.warning("Launching Mission without Archipelago authentication, "
                                    "checks will not be registered to server.")

--- a/worlds/sc2/client.py
+++ b/worlds/sc2/client.py
@@ -90,10 +90,6 @@ DATA_REPO_OWNER = "archipelago-sc2"
 DATA_REPO_NAME = "Archipelago-SC2-data"
 DATA_API_VERSION = "API5"
 
-# Bot controller
-CONTROLLER_HEALTH: int = 38281
-CONTROLLER2_HEALTH: int = 38282
-
 # Void Trade
 TRADE_UNIT = "AP_TradeStructure" # ID of the unit
 TRADE_SEND_BUTTON = "AP_TradeStructureDummySend" # ID of the button
@@ -606,7 +602,7 @@ class SC2Bank():
     def __init__(self, name: str) -> None:
         self.fileName = name
         self.sections: typing.Dict[str, typing.Dict[str, str]] = {}
-
+        
     def addSection(self, sectionName: str) -> None:
         self.sections[sectionName] = {}
 
@@ -615,7 +611,28 @@ class SC2Bank():
             self.addSection(sectionName)
         self.sections[sectionName][key]=value
 
+    def removeEntryFromFile(self, key: str) -> None:
+        path = f"{get_bank_folder()}/{self.fileName}"
+        print(f"checking for: {str}")
+        with open(path, "r") as f:
+            lines = f.readlines()
+        with open(path, "w") as f:
+            deleting = False
+            for line in lines:
+                print(line)
+                if f'<Key name="{key}">' in line:
+                    print("key")
+                    deleting = True
+                elif '</Key>' in line and deleting:
+                    print("deleting")
+                    deleting = False
+                elif deleting == False:
+                    print("writing")
+                    f.write(line)          
+
     def makeFile(self) -> None:
+        # Making a bank in the client should always be a backup
+        dir = f"{get_bank_folder()}/Backup"
         content =          f'<?xml version="1.0" encoding="utf-8"?>\n<Bank version="1">\n'
         for name, section in self.sections.items():
             content +=     f'    <Section name="{name}">\n'
@@ -625,7 +642,8 @@ class SC2Bank():
                 content += f'        </Key>\n'
             content +=     f'    </Section>\n'
         content +=         f'</Bank>'
-        with open(get_bank_folder() + f"/Backup/{self.fileName}_backup_0.SC2Bank", "w") as f:
+        Path(dir).mkdir(parents=True, exist_ok=True)
+        with open(f"{dir}/{self.fileName}_backup_1.SC2Bank", "w") as f:
             f.write(content)
             
 class SC2Context(CommonContext):
@@ -1215,13 +1233,16 @@ class SC2Context(CommonContext):
         
 
     async def trade_receive(self, amount: int = 1):
+        trade_received_bank = SC2Bank("ArchipelagoVoidTradeReceive")
         """
         Tries to pop `amount` units out of the trade storage.
-        """
+        """                    
+        print("trade_receive")
         reply = await self.trade_acquire_storage(True)
 
         if reply is None:
-            self.trade_response = "?TradeFail Void Trade failed: Could not communicate with server. Trade cost refunded."
+            trade_received_bank.addEntry("VoidTrade", "TradeResponse", "FailConnection")
+            trade_received_bank.makeFile()
             return None
 
         # Find available units
@@ -1267,7 +1288,7 @@ class SC2Context(CommonContext):
             units = []
         else:
             units = random.sample(available_units, amount, counts = available_counts)
-
+        print("found units")
         # Build response data
         unit_counts: typing.Dict[str, int] = {}
         slots_to_update: typing.Dict[str, typing.Dict[int, typing.Dict[str, int]]] = {}
@@ -1282,7 +1303,7 @@ class SC2Context(CommonContext):
             # Clean up trades that were completely exhausted
             if len(slots_to_update[slot][send_time]) == 0:
                 slots_to_update[slot].pop(send_time)
-
+        print("made string")
         await self.send_msgs([
             {   # Update server storage
                 "cmd": "Set",
@@ -1295,19 +1316,27 @@ class SC2Context(CommonContext):
                 "operations": [{ "operation": "update", "value": { TRADE_DATASTORAGE_LOCK: 0 } }]
             }
         ])
-
-        # Give units to bot
-        self.trade_response = f"?Trade {refunds} " + " ".join(f"{unit} {count}" for (unit, count) in unit_counts.items())
+        print("pop storage")
+        # Write unite to bank
+        value = f"ReceiveUnits {refunds} " + " ".join(f"{unit} {count}" for (unit, count) in unit_counts.items())
+        trade_received_bank.addEntry("VoidTrade", "TradeResponse", value)
+        trade_received_bank.makeFile()
+        self.trade_response = None
+        self.trade_underway = False
+        print(f"save bank: {value}")
+        #self.trade_response = f"?Trade {refunds} " + " ".join(f"{unit} {count}" for (unit, count) in unit_counts.items())
 
 
     async def trade_send(self, units: typing.List[str]):
+        trade_received_bank = SC2Bank("ArchipelagoVoidTradeReceive")
         """
         Tries to upload `units` to the trade DataStorage.
         """
         reply = await self.trade_acquire_storage(True)
 
         if reply is None:
-            self.trade_response = "?TradeFail Void Trade failed: Could not communicate with server. Your units remain."
+            trade_received_bank.addEntry("VoidTrade", "TradeResponse", "FailConnection")
+            trade_received_bank.makeFile()
             return None
         
         # Create a storage entry for the time the trade was confirmed
@@ -1334,7 +1363,13 @@ class SC2Context(CommonContext):
         ])
         
         # Notify the game
-        self.trade_response = "?TradeSuccess Void Trade successful: Units sent!"
+            
+        trade_received_bank.addEntry("VoidTrade", "TradeResponse", "Success")
+        trade_received_bank.makeFile()
+        self.trade_response = None
+        self.trade_underway = False
+        
+
 
 
 class CompatItemHolder(typing.NamedTuple):
@@ -1857,6 +1892,7 @@ class ArchipelagoBot(bot.bot_ai.BotAI):
             core_options_bank.makeFile()
 
             self.last_received_update = len(self.ctx.items_received)
+
         else:
             #if self.ctx.pending_color_update:
             #    await self.update_colors()
@@ -1875,6 +1911,42 @@ class ArchipelagoBot(bot.bot_ai.BotAI):
                 message = self.ctx.announcements.get(timeout=1)
                 self.send_chat_message({message})
                 self.ctx.announcements.task_done()
+
+        
+            trade_send_string = self.get_trade_units_sent()
+            # Message format:
+            # <unit1> <unit2> <unit3>...
+            if len(trade_send_string) > 0:
+                units_to_send: typing.List[str] = []
+                non_ap_units: typing.Set[str] = set()
+                for unit_id in trade_send_string.split():
+                    if unit_id.startswith("AP_"):
+                        units_to_send.append(normalized_unit_types.get(unit_id, unit_id))
+                    else:
+                        non_ap_units.add(unit_id)
+                    if len(non_ap_units) > 0:
+                        sc2_logger.info(f"Void Trade tried to send non-AP units: {', '.join(non_ap_units)}")
+                        self.ctx.trade_response = "?TradeFail Void Trade rejected: Trade contains invalid units."
+                        self.ctx.trade_underway = True
+                    else:
+                        self.ctx.trade_response = None
+                        self.ctx.trade_underway = True
+                        async_start(self.ctx.trade_send(units_to_send))
+            
+            trade_receive_string = self.get_trade_receive_request()
+            # Message format:
+            # <count>
+            if len(trade_receive_string) > 0:
+                if int(trade_receive_string) == 1:
+                    self.ctx.trade_underway = True
+                    self.ctx.trade_response = None
+                    async_start(self.ctx.trade_receive(1))
+                    # TODO: handle supply, self.ctx.trade_response = "?TradeFail Void Trade rejected: Not enough supply."
+                elif int(trade_receive_string) == 5:
+                    self.ctx.trade_underway = True
+                    self.ctx.trade_response = None
+                    async_start(self.ctx.trade_receive(5))
+
 
             '''
             for unit in self.all_own_units():
@@ -1940,6 +2012,7 @@ class ArchipelagoBot(bot.bot_ai.BotAI):
                                         "Starcraft 2 (This is likely a map issue)"})
                 
             if os.path.isfile(f"{get_bank_folder()}/ArchipelagoUpdate.SC2Bank"):
+                # if bank exists, we want an update prompt. No need to check the values
                 self.last_received_update = 0
                 os.remove(f"{get_bank_folder()}/ArchipelagoUpdate.SC2Bank")
                 
@@ -1994,7 +2067,7 @@ class ArchipelagoBot(bot.bot_ai.BotAI):
                     
                     # Send Void Trade results
                     if self.ctx.trade_response is not None and self.trade_reply_cooldown == 0:
-                        await self.chat_send(self.ctx.trade_response)
+                        await self.send_chat_message(self.ctx.trade_response)
                         # Wait an arbitrary amount of frames before trying again
                         self.trade_reply_cooldown = 60
                 else:
@@ -2007,24 +2080,66 @@ class ArchipelagoBot(bot.bot_ai.BotAI):
         bank = SC2Bank("ArchipelagoMessages")
         i = 0
         for msg in messages:
-            #TODO: Check for limits/staggering
+            # TODO: Check for limits/staggering
             i+=1
             bank.addEntry("Messages",f"Message{str(i)}", self.clean_chat_message(msg))
         bank.makeFile()
 
     def get_locations(self) -> str:
-            result = "0"
+        result = 0
+        path = f"{get_bank_folder()}/ArchipelagoLocations.SC2Bank"
+        if os.path.isfile(path):
             next_line = False
             l = '<Value string="'
             r = '"/>'
-            with open(get_bank_folder() + "/ArchipelagoLocations.SC2Bank") as locationBank:
+            with open(path) as locationBank:
                 for line in locationBank:
                     if next_line:
                         result = int(line[line.find(l) + len(l):line.rfind(r)])
                         break
                     if '<Key name="GameState">' in line:
                         next_line = True
-            return result
+        return result
+    
+    def get_trade_units_sent(self) -> str:
+        result = ""
+        key = "UnitTypes"
+        path = f"{get_bank_folder()}/ArchipelagoVoidTradeSend.SC2Bank"
+        if os.path.isfile(path):
+            next_line = False
+            l = '<Value string="'
+            r = '"/>'
+            with open(path) as locationBank:
+                for line in locationBank:
+                    if next_line:
+                        result = line[line.find(l) + len(l):line.rfind(r)]
+                        break
+                    if f'<Key name="{key}">' in line:
+                        next_line = True
+        if result != "":
+            bank = SC2Bank("ArchipelagoVoidTradeSend.SC2Bank")
+            bank.removeEntryFromFile(key)
+        return result
+    
+    def get_trade_receive_request(self) -> str:
+        result = ""
+        key = "Count"
+        path = f"{get_bank_folder()}/ArchipelagoVoidTradeSend.SC2Bank"
+        if os.path.isfile(path):
+            next_line = False
+            l = '<Value string="'
+            r = '"/>'
+            with open(path) as locationBank:
+                for line in locationBank:
+                    if next_line:
+                        result = line[line.find(l) + len(l):line.rfind(r)]
+                        break
+                    if f'<Key name="{key}">' in line:
+                        next_line = True
+        if result != "":
+            bank = SC2Bank("ArchipelagoVoidTradeSend.SC2Bank")
+            bank.removeEntryFromFile(key)
+        return result
     
     def get_uncollected_objectives(self) -> typing.List[int]:
         result = [
@@ -2039,11 +2154,12 @@ class ArchipelagoBot(bot.bot_ai.BotAI):
 
     def get_colors(self) -> str:
         self.ctx.pending_color_update = False
-        return f"""{str(self.ctx.player_color_raynor)} 
-                   {str(self.ctx.player_color_zerg)} 
-                   {str(self.ctx.player_color_zerg_primal)} 
-                   {str(self.ctx.player_color_protoss)} 
-                   {str(self.ctx.player_color_nova)}  
+        return f"""\
+        {str(self.ctx.player_color_raynor)} \
+        {str(self.ctx.player_color_zerg)} \
+        {str(self.ctx.player_color_zerg_primal)} \
+        {str(self.ctx.player_color_protoss)} \
+        {str(self.ctx.player_color_nova)}  \
         """
 
     def get_resources(self, current_items: typing.Dict[SC2Race, typing.List[int]]) -> str:

--- a/worlds/sc2/client.py
+++ b/worlds/sc2/client.py
@@ -21,6 +21,7 @@ import random
 import concurrent.futures
 import time
 import uuid
+import pathlib
 from pathlib import Path
 
 # CommonClient import first to trigger ModuleUpdater


### PR DESCRIPTION
## What is this fixing or adding?

Currently, SC2 communicates with the AP client through 2 channels:
- SC2 -> Client: A controller unit changes health values to pass bitflags through the SC2 bot API
- Client -> SC2: The client sends chat messages through the SC2 bot API

This has several drawbacks, including:
- Controller unit can interfere with the game state
- Controller unit can be interacted with in triggers. It can be killed or the HP values can be changed unintentionally
  - As a result a system is in place to constantly check if the controller still exists, and has the correct values
- very limited amount of data can be reasonably transferred
---
- Chat messages are displayed on screen and need to be cleaned up
  - As a result, chat is disabled in AP missions currently, which is irritating
- Chat is rate limited, for fast moving asyncs or a big release, you often get spammed with tons of messages, some of which don't get registered properly
- Initial setup needs to be slowed down, so the chat has time to pass all the necessary info. 
  - As a result, missions did implement a noticable loading stage at the start with a blackout screen
  - Besides being irritating, this has caused multiple issues on certain maps

## Banks

This PR aims to replace both channels with Bank files.
- Bank files are XML tables designed to save gameplay data inbetween gameplay sessions, or transfer data between different maps
- Maps can save and load arbitrary strings (or other data types) in these bank files, and they can easily be created and read by the AP client
- They provide a significantly more intentional and robust 2-way communication channel between the client and the game

## Pros

Swapping the communication to banks has multiple advantages. We can:
- remove the controller unit
- restore the chat system
- shorten or remove the initial blackout
- probably remove the SC2 bot API altogether
- maybe restore save/load functionality? Not sure on this one

## Cons

Preliminary testing showed checking for bank changes has a fairly significant computation time in the trigger debug window. However, checking in with SC2Mapster experts, this is probably not a big issue. Talv theorized it's not actually computation time, just waiting for file system things. So while the numbers shown in the trig debug window are big, the actual effect on performance is minimal.

## ToDo list

The bank system is used for all communication and working well. I declare removing the bot API out of scope for this PR.

- [x] Test Client -> SC2 communication
- [x] Test SC2 -> Client communication
- [x] Test sending AP items
- [x] Test sending Locations
- [x] Test sending Options
- [x] Test sending AP messages
- [x] Test sending Void Trade units
- [x] Test receiving Void Trade units
- [x] Implement for all Locations
- [x] Implement for all AP items
- [x] Implement for all Options
- [x] Implement for all AP messages
- [x] Implement for all Void Trade
- [x] Remove controller unit system
- [x] Restore chat functionality
- [x] If possible, remove initial blackscreen - Loading was noticably reduced. Banks finish loading in about 1 second game time
- [x] Cleanup, remove test code, remove debug messages
- [x] Stress test


## How was this tested?

Several local campaigns, a local async to test Void Trade 

[SC2Data changes](https://github.com/archipelago-sc2/Archipelago-SC2-data/pull/14)
