### PR TITLE
sc2: lower minimum max supply

### DIFF
--- a/worlds/sc2/options.py
+++ b/worlds/sc2/options.py
@@ -1316,7 +1316,7 @@ class MaximumSupplyReductionPerItem(Range):
 class LowestMaximumSupply(Range):
     """Controls how far max supply reduction traps can reduce maximum supply."""
     display_name = "Lowest Maximum Supply"
-    range_start = 100
+    range_start = 50
     range_end = 200
     default = 180
 


### PR DESCRIPTION
## What is this fixing or adding?
Per MindHawk's [user request on 2025-12-05](https://discord.com/channels/731205301247803413/1101186175722598521/1446699556527145101), lowering how low max supply traps can take the supply cap from 100 to 50.

Note I made this change on top of the changelist for #7 because I wanted faster unit tests.

## How was this tested?
Visually; it's a trivial change.

## If this makes graphical changes, please attach screenshots.
None.