### PR TITLE
sc2: Fixing miscellaneous typing and variable naming issues

### DIFF
--- a/worlds/sc2/__init__.py
+++ b/worlds/sc2/__init__.py
@@ -9,13 +9,11 @@ from Options import Accessibility, OptionError
 from worlds.AutoWorld import WebWorld, World
 from . import location_groups
 from .item.item_groups import unreleased_items, war_council_upgrades
-from .item.item_tables import (
-    get_full_item_list,
-    not_balanced_starting_units, WEAPON_ARMOR_UPGRADE_MAX_LEVEL,
-)
 from .item import (
-    FilterItem, ItemFilterFlags, StarcraftItem, item_groups, item_names, item_tables, item_parents,
-    ZergItemType, ProtossItemType, ItemData
+    item_groups, item_names, item_tables, item_parents,
+    FilterItem, ItemFilterFlags, StarcraftItem,
+    ZergItemType, ProtossItemType, TerranItemType,
+    ItemData,
 )
 from .locations import (
 	get_locations, DEFAULT_LOCATION_LIST, get_location_types, get_location_flags,
@@ -95,7 +93,7 @@ class SC2World(World):
     web = Starcraft2WebWorld()
     settings: ClassVar[settings.Starcraft2Settings]
 
-    item_name_to_id = {name: data.code for name, data in get_full_item_list().items()}
+    item_name_to_id = {name: data.code for name, data in item_tables.item_table.items()}
     location_name_to_id = {location.name: location.code for location in DEFAULT_LOCATION_LIST}
     options_dataclass = Starcraft2Options
     options: Starcraft2Options
@@ -119,7 +117,7 @@ class SC2World(World):
         self.logic = None
 
     def create_item(self, name: str) -> StarcraftItem:
-        data = get_full_item_list()[name]
+        data = item_tables.item_table[name]
         return StarcraftItem(name, data.classification, data.code, self.player)
 
     def generate_early(self) -> None:
@@ -304,7 +302,9 @@ class SC2World(World):
                 state.update_reachable_regions(self.player)
                 return state
 
-            self._fill_needed_items(state_with_kerrigan_levels, weapon_armor_item_names, WEAPON_ARMOR_UPGRADE_MAX_LEVEL)
+            self._fill_needed_items(
+                state_with_kerrigan_levels, weapon_armor_item_names, item_tables.WEAPON_ARMOR_UPGRADE_MAX_LEVEL
+            )
         if (
             self.options.kerrigan_levels_per_mission_completed > 0
             and self.options.required_tactics != RequiredTactics.option_no_logic
@@ -563,7 +563,7 @@ def flag_excludes_by_faction_presence(world: SC2World, item_list: list[FilterIte
                 item.flags |= ItemFilterFlags.FilterExcluded
                 continue
         if not zerg_missions and item.data.race == SC2Race.ZERG:
-            if (item.data.type != item_tables.ZergItemType.Ability
+            if (item.data.type != ZergItemType.Ability
                 and item.data.type != ZergItemType.Level
             ):
                 item.flags |= ItemFilterFlags.FilterExcluded
@@ -583,9 +583,9 @@ def flag_excludes_by_faction_presence(world: SC2World, item_list: list[FilterIte
             item.flags |= ItemFilterFlags.FilterExcluded
         if (not zerg_build_missions
             and item.data.type in (
-                item_tables.ZergItemType.Unit,
-                item_tables.ZergItemType.Mercenary,
-                item_tables.ZergItemType.Evolution_Pit,
+                ZergItemType.Unit,
+                ZergItemType.Mercenary,
+                ZergItemType.Evolution_Pit,
             )
             and item.name not in allowed_remaining_zerg_units
         ):
@@ -595,9 +595,9 @@ def flag_excludes_by_faction_presence(world: SC2World, item_list: list[FilterIte
             # or warp gate improvements because that item type is mixed in with
             # e.g. Reconstruction Beam and Overwatch
             and item.data.type in (
-                item_tables.ProtossItemType.Unit,
-                item_tables.ProtossItemType.Unit_2,
-                item_tables.ProtossItemType.Building,
+                ProtossItemType.Unit,
+                ProtossItemType.Unit_2,
+                ProtossItemType.Building,
             )
             and item.name not in allowed_remaining_protoss_units
         ):
@@ -614,17 +614,17 @@ def flag_excludes_by_faction_presence(world: SC2World, item_list: list[FilterIte
                 item.flags |= ItemFilterFlags.FilterExcluded
 
         # Faction +attack/armour upgrades
-        if (item.data.type == item_tables.TerranItemType.Upgrade
+        if (item.data.type == TerranItemType.Upgrade
             and not terran_build_missions
             and not auto_upgrades_in_nobuilds
         ):
             item.flags |= ItemFilterFlags.FilterExcluded
-        if (item.data.type == item_tables.ZergItemType.Upgrade
+        if (item.data.type == ZergItemType.Upgrade
             and not zerg_build_missions
             and not auto_upgrades_in_nobuilds
         ):
             item.flags |= ItemFilterFlags.FilterExcluded
-        if (item.data.type == item_tables.ProtossItemType.Upgrade
+        if (item.data.type == ProtossItemType.Upgrade
             and not protoss_build_missions
             and not auto_upgrades_in_nobuilds
         ):
@@ -741,13 +741,13 @@ def flag_mission_based_item_excludes(world: SC2World, item_list: list[FilterItem
 
         # Todo(mm): How should no-build only / grant_story_tech affect excluding Kerrigan items?
         # Exclude Primal form based on Kerrigan presence or primal form option
-        if (item.data.type == item_tables.ZergItemType.Primal_Form
+        if (item.data.type == ZergItemType.Primal_Form
             and ((not kerrigan_is_present) or world.options.kerrigan_primal_status != KerriganPrimalStatus.option_item)
         ):
             item.flags |= ItemFilterFlags.FilterExcluded
 
         # Remove Kerrigan abilities if there's no Kerrigan
-        if item.data.type == item_tables.ZergItemType.Ability and remove_kerrigan_abils:
+        if item.data.type == ZergItemType.Ability and remove_kerrigan_abils:
             item.flags |= ItemFilterFlags.FilterExcluded
 
         # Remove Nova items if there's no Nova
@@ -848,7 +848,7 @@ def flag_start_unit(world: SC2World, item_list: list[FilterItem], starter_unit: 
         # The race of the early unit has been chosen
         basic_units = get_basic_units(world.options.required_tactics.value, first_race)
         if starter_unit == StarterUnit.option_balanced:
-            basic_units = basic_units.difference(not_balanced_starting_units)
+            basic_units = basic_units.difference(item_tables.not_balanced_starting_units)
         if first_mission == SC2Mission.DARK_WHISPERS:
             # Special case - you don't have a logicless location but need an AA
             basic_units = basic_units.difference(

--- a/worlds/sc2/__init__.py
+++ b/worlds/sc2/__init__.py
@@ -1,7 +1,8 @@
 from dataclasses import fields
 import logging
 
-from typing import *
+from collections import Counter
+from typing import Any, ClassVar, Callable, Mapping
 from math import floor, ceil
 from BaseClasses import Item, MultiWorld, Location, Tutorial, ItemClassification, CollectionState
 from Options import Accessibility, OptionError
@@ -101,14 +102,14 @@ class SC2World(World):
 
     item_name_groups = item_groups.item_name_groups  # type: ignore
     location_name_groups = location_groups.get_location_groups()
-    locked_locations: List[str]
+    locked_locations: list[str]
     """Locations locked to contain specific items, such as victory events or forced resources"""
-    location_cache: List[Location]
-    final_missions: List[int]
+    location_cache: list[Location]
+    final_missions: list[int]
     required_client_version = 0, 6, 4
     custom_mission_order: SC2MissionOrder
-    logic: Optional['SC2Logic']
-    filler_items_distribution: Dict[str, int]
+    logic: 'SC2Logic | None'
+    filler_items_distribution: dict[str, int]
 
     def __init__(self, multiworld: MultiWorld, player: int):
         super(SC2World, self).__init__(multiworld, player)
@@ -177,7 +178,7 @@ class SC2World(World):
         setup_events(self.player, self.locked_locations, self.location_cache)
         set_up_filler_items_distribution(self)
 
-        item_list: List[FilterItem] = create_and_flag_explicit_item_locks_and_excludes(self)
+        item_list: list[FilterItem] = create_and_flag_explicit_item_locks_and_excludes(self)
         flag_excludes_by_faction_presence(self, item_list)
         flag_mission_based_item_excludes(self, item_list)
         flag_allowed_orphan_items(self, item_list)
@@ -187,13 +188,13 @@ class SC2World(World):
         flag_war_council_items(self, item_list)
         flag_and_add_resource_locations(self, item_list)
         flag_mission_order_required_items(self, item_list)
-        pruned_items: List[StarcraftItem] = prune_item_pool(self, item_list)
+        pruned_items: list[StarcraftItem] = prune_item_pool(self, item_list)
 
         start_inventory = [item for item in pruned_items if ItemFilterFlags.StartInventory in item.filter_flags]
         pool = [item for item in pruned_items if ItemFilterFlags.StartInventory not in item.filter_flags]
 
         # Tell the logic which unit classes are used for required W/A upgrades
-        used_item_names: Set[str] = {item.name for item in pruned_items}
+        used_item_names: set[str] = {item.name for item in pruned_items}
         used_item_names = used_item_names.union(item.name for item in self.multiworld.itempool if item.player == self.player)
         assert self.logic is not None
         if used_item_names.isdisjoint(item_groups.barracks_wa_group):
@@ -236,7 +237,7 @@ class SC2World(World):
 
     def fill_slot_data(self) -> Mapping[str, Any]:
         assert self.logic
-        slot_data: Dict[str, Any] = {}
+        slot_data: dict[str, Any] = {}
         for option_name in [field.name for field in fields(Starcraft2Options)]:
             option = get_option_value(self, option_name)
             if type(option) in {str, int}:
@@ -256,7 +257,7 @@ class SC2World(World):
             slot_data["kerrigan_presence"] = KerriganPresence.option_not_present
 
         if self.options.mission_order_scouting != MissionOrderScouting.option_none:
-            mission_item_classification: Dict[str, int] = {}
+            mission_item_classification: dict[str, int] = {}
             for location in self.multiworld.get_locations(self.player):
                 # Event do not hold items
                 if not location.is_event:
@@ -312,7 +313,7 @@ class SC2World(World):
             self._fill_needed_items(lambda: self.multiworld.get_all_state(False), [item_names.KERRIGAN_LEVELS_1], 70)
 
 
-    def _fill_needed_items(self, all_state_getter: Callable[[],CollectionState], items_to_use: List[str], max_attempts: int) -> None:
+    def _fill_needed_items(self, all_state_getter: Callable[[],CollectionState], items_to_use: list[str], max_attempts: int) -> None:
         """
         Helper for pre-fill, seeks if the world is actually solvable and inserts items to start inventory if necessary.
         :param all_state_getter:
@@ -338,7 +339,7 @@ class SC2World(World):
                 return
 
 
-    def extend_hint_information(self, hint_data: Dict[int, Dict[int, str]]) -> None:
+    def extend_hint_information(self, hint_data: dict[int, dict[int, str]]) -> None:
         """
         Generate information to hint where each mission is actually located in the mission order
         :param hint_data:
@@ -389,7 +390,7 @@ def _get_column_display(index: int, single_row_layout: bool) -> str:
         return f(index + 1)
 
 
-def setup_events(player: int, locked_locations: List[str], location_cache: List[Location]) -> None:
+def setup_events(player: int, locked_locations: list[str], location_cache: list[Location]) -> None:
     for location in location_cache:
         if location.address is None:
             item = Item(location.name, ItemClassification.progression, None, player)
@@ -399,7 +400,7 @@ def setup_events(player: int, locked_locations: List[str], location_cache: List[
             location.place_locked_item(item)
 
 
-def create_and_flag_explicit_item_locks_and_excludes(world: SC2World) -> List[FilterItem]:
+def create_and_flag_explicit_item_locks_and_excludes(world: SC2World) -> list[FilterItem]:
     """
     Handles `excluded_items`, `locked_items`, and `start_inventory`
     Returns a list of all possible non-filler items that can be added, with an accompanying flags bitfield.
@@ -445,7 +446,7 @@ def create_and_flag_explicit_item_locks_and_excludes(world: SC2World) -> List[Fi
                 auto_excludes[item_name] = item_data.quantity
 
 
-    result: List[FilterItem] = []
+    result: list[FilterItem] = []
     for item_name, item_data in item_tables.item_table.items():
         max_count = item_data.quantity
         auto_excluded_count = auto_excludes.get(item_name, 0)
@@ -500,7 +501,7 @@ def create_and_flag_explicit_item_locks_and_excludes(world: SC2World) -> List[Fi
     return result
 
 
-def flag_excludes_by_faction_presence(world: SC2World, item_list: List[FilterItem]) -> None:
+def flag_excludes_by_faction_presence(world: SC2World, item_list: list[FilterItem]) -> None:
     """Excludes items based on if their faction has a mission present where they can be used"""
     missions = get_all_missions(world.custom_mission_order)
     if world.options.take_over_ai_allies.value:
@@ -630,7 +631,7 @@ def flag_excludes_by_faction_presence(world: SC2World, item_list: List[FilterIte
             item.flags |= ItemFilterFlags.FilterExcluded
 
 
-def flag_mission_based_item_excludes(world: SC2World, item_list: List[FilterItem]) -> None:
+def flag_mission_based_item_excludes(world: SC2World, item_list: list[FilterItem]) -> None:
     """
     Excludes items based on mission / campaign presence: Nova Gear, Kerrigan abilities, SOA
     """
@@ -777,7 +778,7 @@ def flag_mission_based_item_excludes(world: SC2World, item_list: List[FilterItem
     return
 
 
-def flag_allowed_orphan_items(world: SC2World, item_list: List[FilterItem]) -> None:
+def flag_allowed_orphan_items(world: SC2World, item_list: list[FilterItem]) -> None:
     """Adds the `Allowed_Orphan` flag to items that shouldn't be filtered with their parents, like combat shield"""
     missions = get_all_missions(world.custom_mission_order)
     if SC2Mission.PIERCING_OF_THE_SHROUD in missions:
@@ -804,7 +805,7 @@ def flag_allowed_orphan_items(world: SC2World, item_list: List[FilterItem]) -> N
                 item.flags |= ItemFilterFlags.AllowedOrphan
 
 
-def flag_start_inventory(world: SC2World, item_list: List[FilterItem]) -> None:
+def flag_start_inventory(world: SC2World, item_list: list[FilterItem]) -> None:
     """Adds items to start_inventory based on first mission logic and options like `starter_unit` and `start_primary_abilities`"""
     potential_starters = world.custom_mission_order.get_starting_missions()
     starter_mission_names = [mission.mission_name for mission in potential_starters]
@@ -827,7 +828,7 @@ def flag_start_inventory(world: SC2World, item_list: List[FilterItem]) -> None:
     flag_start_abilities(world, item_list)
 
 
-def flag_start_unit(world: SC2World, item_list: List[FilterItem], starter_unit: int) -> None:
+def flag_start_unit(world: SC2World, item_list: list[FilterItem], starter_unit: int) -> None:
     first_mission = get_random_first_mission(world, world.custom_mission_order)
     first_race = first_mission.race
 
@@ -911,7 +912,7 @@ def flag_start_unit(world: SC2World, item_list: List[FilterItem], starter_unit: 
             starter_weapon.flags |= ItemFilterFlags.StartInventory
 
 
-def flag_start_abilities(world: SC2World, item_list: List[FilterItem]) -> None:
+def flag_start_abilities(world: SC2World, item_list: list[FilterItem]) -> None:
     starter_abilities = world.options.start_primary_abilities
     if not starter_abilities:
         return
@@ -943,12 +944,12 @@ def flag_start_abilities(world: SC2World, item_list: List[FilterItem]) -> None:
             ability.flags |= ItemFilterFlags.StartInventory
 
 
-def flag_unused_upgrade_types(world: SC2World, item_list: List[FilterItem]) -> None:
+def flag_unused_upgrade_types(world: SC2World, item_list: list[FilterItem]) -> None:
     """Excludes +armour/attack upgrades based on generic upgrade strategy.
     Caps upgrade items based on `max_upgrade_level`."""
     include_upgrades = world.options.generic_upgrade_missions == 0
     upgrade_items = world.options.generic_upgrade_items.value
-    upgrade_included_counts: Dict[str, int] = {}
+    upgrade_included_counts: dict[str, int] = {}
     for item in item_list:
         if item.data.type in item_tables.upgrade_item_types:
             if not include_upgrades or (item.name not in upgrade_included_names[upgrade_items]):
@@ -963,7 +964,7 @@ def flag_unused_upgrade_types(world: SC2World, item_list: List[FilterItem]) -> N
                 elif ItemFilterFlags.UserExcluded not in item.flags:
                     upgrade_included_counts[item.name] = included + 1
 
-def flag_unreleased_items(item_list: List[FilterItem]) -> None:
+def flag_unreleased_items(item_list: list[FilterItem]) -> None:
     """Remove all unreleased items unless they're explicitly locked"""
     for item in item_list:
         if (item.name in unreleased_items
@@ -971,7 +972,7 @@ def flag_unreleased_items(item_list: List[FilterItem]) -> None:
             item.flags |= ItemFilterFlags.Removed
 
 
-def flag_war_council_items(world: SC2World, item_list: List[FilterItem]) -> None:
+def flag_war_council_items(world: SC2World, item_list: list[FilterItem]) -> None:
     """Excludes / start-inventories items based on `nerf_unit_baselines` option.
     Will skip items that are excluded by other sources."""
     if world.options.war_council_nerfs:
@@ -988,7 +989,7 @@ def flag_war_council_items(world: SC2World, item_list: List[FilterItem]) -> None
             item.flags |= ItemFilterFlags.StartInventory
 
 
-def flag_and_add_resource_locations(world: SC2World, item_list: List[FilterItem]) -> None:
+def flag_and_add_resource_locations(world: SC2World, item_list: list[FilterItem]) -> None:
     """
     Filters the locations in the world using a trash or Nothing item
     :param world: The sc2 world object
@@ -1016,7 +1017,7 @@ def flag_and_add_resource_locations(world: SC2World, item_list: List[FilterItem]
                 world.locked_locations.append(location.name)
 
 
-def flag_mission_order_required_items(world: SC2World, item_list: List[FilterItem]) -> None:
+def flag_mission_order_required_items(world: SC2World, item_list: list[FilterItem]) -> None:
     """Marks items that are necessary for item rules in the mission order and forces them to be progression."""
     locks_required = world.custom_mission_order.get_items_to_lock()
     locks_done = {item: 0 for item in locks_required}
@@ -1027,7 +1028,7 @@ def flag_mission_order_required_items(world: SC2World, item_list: List[FilterIte
             locks_done[item.name] += 1
 
 
-def prune_item_pool(world: SC2World, item_list: List[FilterItem]) -> List[StarcraftItem]:
+def prune_item_pool(world: SC2World, item_list: list[FilterItem]) -> list[StarcraftItem]:
     """Prunes the item pool size to be less than the number of available locations"""
 
     item_list = [
@@ -1046,7 +1047,7 @@ def prune_item_pool(world: SC2World, item_list: List[FilterItem]) -> List[Starcr
         last_num_items = num_items
         num_items = len(item_list)
 
-    pool: List[StarcraftItem] = []
+    pool: list[StarcraftItem] = []
     for item in item_list:
         ap_item = create_item_with_correct_settings(world.player, item.name, item.flags)
         if ItemFilterFlags.ForceProgression in item.flags:
@@ -1058,14 +1059,14 @@ def prune_item_pool(world: SC2World, item_list: List[FilterItem]) -> List[Starcr
     return filtered_pool
 
 
-def item_list_contains_parent(world: SC2World, item_data: ItemData, item_name_list: List[str]) -> bool:
+def item_list_contains_parent(world: SC2World, item_data: ItemData, item_name_list: list[str]) -> bool:
     if item_data.parent is None:
         # The item has no associated parent, the item is valid
         return True
     return item_parents.parent_present[item_data.parent](item_name_list, world.options)
 
 
-def pad_item_pool_with_filler(world: SC2World, num_items: int, pool: List[StarcraftItem]):
+def pad_item_pool_with_filler(world: SC2World, num_items: int, pool: list[StarcraftItem]):
     for _ in range(num_items):
         item = create_item_with_correct_settings(world.player, world.get_filler_item_name())
         pool.append(item)
@@ -1118,7 +1119,7 @@ def get_random_first_mission(world: SC2World, mission_order: SC2MissionOrder) ->
     return world.random.choice(first_mission_candidates)
 
 
-def get_all_missions(mission_order: SC2MissionOrder) -> List[SC2Mission]:
+def get_all_missions(mission_order: SC2MissionOrder) -> list[SC2Mission]:
     return mission_order.get_used_missions()
 
 
@@ -1132,7 +1133,7 @@ def create_item_with_correct_settings(player: int, name: str, filter_flags: Item
     return item
 
 
-def fill_pool_with_kerrigan_levels(world: SC2World, item_pool: List[StarcraftItem]):
+def fill_pool_with_kerrigan_levels(world: SC2World, item_pool: list[StarcraftItem]):
     total_levels = world.options.kerrigan_level_item_sum.value
     missions = get_all_missions(world.custom_mission_order)
     kerrigan_missions = [mission for mission in missions if MissionFlag.Kerrigan in mission.flags]
@@ -1175,7 +1176,7 @@ def fill_pool_with_kerrigan_levels(world: SC2World, item_pool: List[StarcraftIte
         add_kerrigan_level_items(size, round_func(float(total_levels) / size))
 
 
-def push_precollected_items_to_multiworld(world: SC2World, item_list: List[StarcraftItem]) -> None:
+def push_precollected_items_to_multiworld(world: SC2World, item_list: list[StarcraftItem]) -> None:
     # Clear the pre-collected items, as AP will try to do this for us,
     # and we want to be able to filer out precollected items in the case of upgrade packages.
     auto_precollected_items = world.multiworld.precollected_items[world.player].copy()

--- a/worlds/sc2/__init__.py
+++ b/worlds/sc2/__init__.py
@@ -30,6 +30,7 @@ from .options import (
     NovaPresence, MissionOrder, VanillaItemsOnly, ExcludeOverpoweredItems,
     is_mission_in_soa_presence,
 )
+from . import options
 from .rules import get_basic_units, SC2Logic
 from . import settings
 from .pool_filter import filter_items
@@ -234,6 +235,7 @@ class SC2World(World):
         return self.random.choices(tuple(self.filler_items_distribution), weights=self.filler_items_distribution.values())[0]  # type: ignore
 
     def fill_slot_data(self) -> Mapping[str, Any]:
+        assert self.logic
         slot_data: Dict[str, Any] = {}
         for option_name in [field.name for field in fields(Starcraft2Options)]:
             option = get_option_value(self, option_name)
@@ -322,8 +324,10 @@ class SC2World(World):
             all_state: CollectionState = all_state_getter()
             location_failed = False
             for location in self.location_cache:
-                if not (all_state.can_reach_location(location.name, self.player)
-                        and all_state.can_reach_region(location.parent_region.name, self.player)):
+                if not (
+                    all_state.can_reach_location(location.name, self.player)
+                    and all_state.can_reach_region(location.parent_region.name, self.player)
+                ):
                     location_failed = True
                     break
             if location_failed:

--- a/worlds/sc2/client.py
+++ b/worlds/sc2/client.py
@@ -657,7 +657,7 @@ class SC2Context(CommonContext):
         self.trade_underway: bool = False
         self.trade_latest_reply: dict[str, Any] | None = None
         self.trade_reply_event = asyncio.Event()
-        self.trade_lock_wait: int = 0
+        self.trade_lock_wait: float = 0.0
         self.trade_lock_start: float | None = None
         self.trade_response: str | None = None
         self.difficulty_damage_modifier: int = DifficultyDamageModifier.default
@@ -1594,7 +1594,7 @@ def calculate_story_tech(ctx: SC2Context, mission: SC2Mission) -> bool:
         result = GrantStoryTech.option_grant
     else:
         result = ctx.grant_story_tech
-    return result
+    return result != 0
 
 def calculate_soa_options(ctx: SC2Context, mission: SC2Mission) -> int:
     """
@@ -2084,8 +2084,14 @@ def calc_available_nodes(ctx: SC2Context) -> tuple[list[int], dict[int, list[int
         else:
             break
 
-    accessible_missions = [mission_order_object for mission_order_object in accessible_objects if isinstance(mission_order_object, MissionSlotData)]
-    beaten_accessible_missions: set[int] = {mission.mission_id for mission in accessible_missions if mission.mission_id in beaten_missions}
+    accessible_missions = [
+        mission_order_object
+        for mission_order_object in accessible_objects
+        if isinstance(mission_order_object, MissionSlotData)
+    ]
+    beaten_accessible_missions = {
+        mission.mission_id for mission in accessible_missions if mission.mission_id in beaten_missions
+    }
     for mission_order_object in mission_order_objects:
         # re-generate tooltip accessibility
         for sub_rule in mission_order_object.entry_rule.sub_rules:

--- a/worlds/sc2/client.py
+++ b/worlds/sc2/client.py
@@ -61,10 +61,11 @@ from worlds._sc2common.bot.data import Race
 from worlds._sc2common.bot.main import run_game
 from worlds._sc2common.bot.player import Bot
 from .item.item_tables import (
-    lookup_id_to_name, get_full_item_list, ItemData,
+    lookup_id_to_name, ItemData,
     ZergItemType, upgrade_bundles,
     WEAPON_ARMOR_UPGRADE_MAX_LEVEL,
 )
+from .item import item_tables
 from .locations import SC2WOL_LOC_ID_OFFSET, LocationType, LocationFlag, SC2HOTS_LOC_ID_OFFSET, VICTORY_CACHE_OFFSET
 from .mission_tables import (
     lookup_id_to_mission, SC2Campaign, MissionInfo,
@@ -128,7 +129,7 @@ class ConfigurableOptionInfo(NamedTuple):
 
 class ColouredMessage:
     def __init__(self, text: str = '', *, keep_markup: bool = False) -> None:
-        self.parts: list[dict] = []
+        self.parts: list[dict[str, Any]] = []
         if text:
             self(text, keep_markup=keep_markup)
     def __call__(self, text: str, *, keep_markup: bool = False) -> 'ColouredMessage':
@@ -265,7 +266,7 @@ class StarcraftClientProcessor(ClientCommandProcessor):
                 return True
             return False
 
-        items = get_full_item_list()
+        items = item_tables.item_table
         categorized_items: dict[SC2Race, list[int | str]] = {}
         parent_to_child: dict[int | str, list[int]] = {}
         items_received: dict[int, list[NetworkItem]] = {}
@@ -1027,7 +1028,7 @@ class SC2Context(CommonContext):
         if self.sc2_run_task:
             self.sc2_run_task.cancel()
 
-    async def disconnect(self, allow_autoreconnect: bool = False):
+    async def disconnect(self, allow_autoreconnect: bool = False) -> None:
         self.finished_game = False
         await super(SC2Context, self).disconnect(allow_autoreconnect=allow_autoreconnect)
 
@@ -1304,11 +1305,11 @@ class CompatItemHolder(NamedTuple):
     quantity: int = 1
 
 
-async def main(args: Sequence[str] | None):
+async def main(arguments: Sequence[str] | None):
     multiprocessing.freeze_support()
     parser = get_base_parser()
     parser.add_argument('--name', default=None, help="Slot Name to connect as.")
-    args, uri = parser.parse_known_args(args)
+    args, uri = parser.parse_known_args(arguments)
 
     if uri and uri[0].startswith('archipelago://'):
         args.url = uri[0]
@@ -1377,14 +1378,14 @@ API3_TO_API4_COMPAT_ITEMS: set[CompatItemHolder] = {
 }
 
 def compat_item_to_network_items(compat_item: CompatItemHolder) -> list[NetworkItem]:
-    item_id = get_full_item_list()[compat_item.name].code
+    item_id = item_tables.item_table[compat_item.name].code
     network_item = NetworkItem(item_id, 0, 0, 0)
     return compat_item.quantity * [network_item]
 
 
 def calculate_items(ctx: SC2Context) -> dict[SC2Race, list[int]]:
     items = ctx.items_received.copy()
-    item_list = get_full_item_list()
+    item_list = item_tables.item_table
     def create_network_item(item_name: str) -> NetworkItem:
         return NetworkItem(item_list[item_name].code, 0, 0, 0)
 
@@ -1487,7 +1488,7 @@ def calculate_items(ctx: SC2Context) -> dict[SC2Race, list[int]]:
             item_names.COMMAND_CENTER_EXTRA_SUPPLIES,
             item_names.PLANETARY_FORTRESS_ORBITAL_MODULE
         ]
-        replacement_item_ids = [get_full_item_list()[item_name].code for item_name in orbital_command_replacement_items]
+        replacement_item_ids = [item_tables.item_table[item_name].code for item_name in orbital_command_replacement_items]
         if sum(item_id in replacement_item_ids for item_id in items) > 0:
             logger.warning(inspect.cleandoc("""
                 Both old Orbital Command and its replacements are present in the world. Skipping compatibility handling.
@@ -1495,13 +1496,13 @@ def calculate_items(ctx: SC2Context) -> dict[SC2Race, list[int]]:
         else:
             # None of replacement items are present
             # L1: MULE and Scanner Sweep
-            scanner_sweep_data = get_full_item_list()[item_names.COMMAND_CENTER_SCANNER_SWEEP]
-            mule_data = get_full_item_list()[item_names.COMMAND_CENTER_MULE]
+            scanner_sweep_data = item_tables.item_table[item_names.COMMAND_CENTER_SCANNER_SWEEP]
+            mule_data = item_tables.item_table[item_names.COMMAND_CENTER_MULE]
             accumulators[scanner_sweep_data.race][scanner_sweep_data.type.flag_word] += 1 << scanner_sweep_data.number
             accumulators[mule_data.race][mule_data.type.flag_word] += 1 << mule_data.number
             if orbital_command_count >= 2:
                 # L2 MULE and Scanner Sweep usable even in Planetary Fortress Mode
-                planetary_orbital_module_data = get_full_item_list()[item_names.PLANETARY_FORTRESS_ORBITAL_MODULE]
+                planetary_orbital_module_data = item_tables.item_table[item_names.PLANETARY_FORTRESS_ORBITAL_MODULE]
                 accumulators[planetary_orbital_module_data.race][planetary_orbital_module_data.type.flag_word] += \
                     1 << planetary_orbital_module_data.number
 
@@ -1516,7 +1517,7 @@ def calculate_items(ctx: SC2Context) -> dict[SC2Race, list[int]]:
         # Equivalent to "Progressive Weapon/Armor Upgrade" item
         global_upgrades: set[str] = upgrade_included_names[GenericUpgradeItems.option_bundle_all]
         for global_upgrade in global_upgrades:
-            race = get_full_item_list()[global_upgrade].race
+            race = item_tables.item_table[global_upgrade].race
             upgrade_flaggroup = race_to_item_type[race]["Upgrade"].flag_word
             for bundled_number in get_bundle_upgrade_member_numbers(global_upgrade):
                 accumulators[race][upgrade_flaggroup] += upgrade_count << bundled_number
@@ -1529,7 +1530,7 @@ def get_bundle_upgrade_member_numbers(bundled_item: str) -> list[int]:
     if bundled_item in (item_names.PROGRESSIVE_PROTOSS_GROUND_UPGRADE, item_names.PROGRESSIVE_PROTOSS_AIR_UPGRADE):
         # Shields are handled as a maximum of those two
         upgrade_elements = [item_name for item_name in upgrade_elements if item_name != item_names.PROGRESSIVE_PROTOSS_SHIELDS]
-    return [get_full_item_list()[item_name].number for item_name in upgrade_elements]
+    return [item_tables.item_table[item_name].number for item_name in upgrade_elements]
 
 
 def calc_difficulty(difficulty: int):
@@ -1686,7 +1687,7 @@ def kerrigan_primal(ctx: SC2Context, kerrigan_level: int) -> bool:
         return completed >= (total_missions / 2)
     elif ctx.kerrigan_primal_status == KerriganPrimalStatus.option_item:
         codes = [item.item for item in ctx.items_received]
-        return get_full_item_list()[item_names.KERRIGAN_PRIMAL_FORM].code in codes
+        return item_tables.item_table[item_names.KERRIGAN_PRIMAL_FORM].code in codes
     return False
 
 
@@ -1704,7 +1705,7 @@ def get_mission_variant(mission_id: int) -> int:
 
 
 def get_item_flag_word(item_name: str) -> int:
-    return get_full_item_list()[item_name].type.flag_word
+    return item_tables.item_table[item_name].type.flag_word
 
 
 async def starcraft_launch(ctx: SC2Context, mission_id: int):
@@ -1753,7 +1754,7 @@ class ArchipelagoBot(bot.bot_ai.BotAI):
 
         super(ArchipelagoBot, self).__init__()
 
-    async def on_step(self, iteration: int):
+    async def on_step(self, iteration: int) -> None:
         if self.want_close:
             self.want_close = False
             await self._client.leave()

--- a/worlds/sc2/client.py
+++ b/worlds/sc2/client.py
@@ -647,7 +647,7 @@ class SC2Context(CommonContext):
         self.maximum_supply_reduction_per_item: int = options.MaximumSupplyReductionPerItem.default
         self.lowest_maximum_supply: int = options.LowestMaximumSupply.default
         self.research_cost_reduction_per_item: int = options.ResearchCostReductionPerItem.default
-        self.nova_presence: set[str] = NovaPresence.default
+        self.nova_presence: frozenset[str] = NovaPresence.default
         self.mercenary_highlanders: bool = False
         self.kerrigan_levels_per_mission_completed = 0
         self.trade_enabled: int = EnableVoidTrade.default
@@ -860,14 +860,14 @@ class SC2Context(CommonContext):
             self.nova_grant_story_tech = args["slot_data"].get("nova_grant_story_tech", False)
             if self.slot_data_version < 4:
                 if args["slot_data"].get("nova_covert_ops_only", True):
-                    self.nova_presence = {NovaPresenceOptions.NCO_TERRAN}
+                    self.nova_presence = frozenset((NovaPresenceOptions.NCO_TERRAN,))
                 else:
-                    self.nova_presence = {NovaPresenceOptions.NCO_TERRAN, NovaPresenceOptions.GHOST_OF_A_CHANCE}
+                    self.nova_presence = frozenset((NovaPresenceOptions.NCO_TERRAN, NovaPresenceOptions.GHOST_OF_A_CHANCE,))
             if self.slot_data_version < 5:
                 if args["slot_data"].get("use_nova_wol_fallback", True):
-                    self.nova_presence = {NovaPresenceOptions.NCO_TERRAN}
+                    self.nova_presence = frozenset((NovaPresenceOptions.NCO_TERRAN,))
                 else:
-                    self.nova_presence = {NovaPresenceOptions.NCO_TERRAN, NovaPresenceOptions.GHOST_OF_A_CHANCE}
+                    self.nova_presence = frozenset((NovaPresenceOptions.NCO_TERRAN, NovaPresenceOptions.GHOST_OF_A_CHANCE,))
             self.trade_enabled = args["slot_data"].get("enable_void_trade", EnableVoidTrade.option_false)
             self.trade_age_limit = args["slot_data"].get("void_trade_age_limit", VoidTradeAgeLimit.default)
             self.trade_workers_allowed = args["slot_data"].get("void_trade_workers", VoidTradeWorkers.default)
@@ -1270,7 +1270,7 @@ class SC2Context(CommonContext):
 
         # Create a storage entry for the time the trade was confirmed
         trade_time = reply["value"][TRADE_DATASTORAGE_LOCK]
-        storage_entry = {}
+        storage_entry: dict[str, int] = {}
         for unit in units:
             storage_entry[unit] = storage_entry.get(unit, 0) + 1
 

--- a/worlds/sc2/client.py
+++ b/worlds/sc2/client.py
@@ -5,14 +5,12 @@ import collections
 import copy
 import ctypes
 import enum
-import functools
 import inspect
 import logging
 import multiprocessing
 import os.path
 import sys
 import tempfile
-import typing
 import queue
 import zipfile
 import io
@@ -22,6 +20,7 @@ import time
 import uuid
 import re
 from pathlib import Path
+from typing import Any, TYPE_CHECKING, NamedTuple, Type, Sequence, Iterable
 
 # CommonClient import first to trigger ModuleUpdater
 from CommonClient import CommonContext, server_loop, ClientCommandProcessor, gui_enabled, get_base_parser, handle_url_arg
@@ -77,7 +76,7 @@ from NetUtils import ClientStatus, NetworkItem, JSONtoTextParser, JSONMessagePar
 from MultiServer import mark_raw
 from . import banks
 
-if typing.TYPE_CHECKING:
+if TYPE_CHECKING:
     from Options import Option
 
 pool = concurrent.futures.ThreadPoolExecutor(1)
@@ -119,10 +118,10 @@ class ConfigurableOptionType(enum.Enum):
     INTEGER = enum.auto()
     ENUM = enum.auto()
 
-class ConfigurableOptionInfo(typing.NamedTuple):
+class ConfigurableOptionInfo(NamedTuple):
     name: str
     variable_name: str
-    option_class: typing.Type[Option]
+    option_class: Type[Option]
     option_type: ConfigurableOptionType = ConfigurableOptionType.ENUM
     can_break_logic: bool = False
 
@@ -267,8 +266,8 @@ class StarcraftClientProcessor(ClientCommandProcessor):
             return False
 
         items = get_full_item_list()
-        categorized_items: dict[SC2Race, list[typing.Union[int, str]]] = {}
-        parent_to_child: dict[typing.Union[int, str], list[int]] = {}
+        categorized_items: dict[SC2Race, list[int | str]] = {}
+        parent_to_child: dict[int | str, list[int]] = {}
         items_received: dict[int, list[NetworkItem]] = {}
         for item in self.ctx.items_received:
             items_received.setdefault(item.item, []).append(item)
@@ -287,11 +286,11 @@ class StarcraftClientProcessor(ClientCommandProcessor):
             else:
                 categorized_items.setdefault(item_data.race, []).append(item_data.code)
 
-        def display_info(element: typing.Union[SC2Race, str, int]) -> tuple:
+        def display_info(element: SC2Race | str | int) -> tuple:
             """Return (should display, name, type, children, sum(obtained), sum(matching filter))"""
             have_item = isinstance(element, int) and element in items_received_set
             if isinstance(element, SC2Race):
-                children: typing.Sequence[typing.Union[str, int]] = categorized_items[faction]
+                children: Sequence[str | int] = categorized_items[faction]
                 name = element.name
             elif isinstance(element, int):
                 children = parent_to_child.get(element, [])
@@ -312,7 +311,7 @@ class StarcraftClientProcessor(ClientCommandProcessor):
             )
 
         def display_tree(
-            should_display: bool, name: str, element: typing.Union[SC2Race, str, int], child_states: tuple, indent: int = 0
+            should_display: bool, name: str, element: SC2Race | str | int, child_states: tuple, indent: int = 0
         ) -> None:
             if not should_display:
                 return
@@ -618,7 +617,7 @@ class SC2Context(CommonContext):
         self.final_mission_ids: list[int] = [29]
         self.final_locations: list[int] = []
         self.announcements: queue.Queue = queue.Queue()
-        self.sc2_run_task: typing.Optional[asyncio.Task] = None
+        self.sc2_run_task: asyncio.Task | None = None
         self.missions_unlocked: bool = False  # allow launching missions ignoring requirements
         self.max_upgrade_level: int = MaxUpgradeLevel.default
         self.generic_upgrade_missions = 0
@@ -631,7 +630,7 @@ class SC2Context(CommonContext):
         self.difficulty_override = -1
         self.game_speed_override = -1
         self.mission_id_to_location_ids: dict[int, list[int]] = {}
-        self.last_bot: typing.Optional[ArchipelagoBot] = None
+        self.last_bot: ArchipelagoBot | None = None
         self.slot_data_version = 2
         self.required_tactics: int = RequiredTactics.default
         self.grant_story_tech: int = GrantStoryTech.default
@@ -648,21 +647,21 @@ class SC2Context(CommonContext):
         self.maximum_supply_reduction_per_item: int = options.MaximumSupplyReductionPerItem.default
         self.lowest_maximum_supply: int = options.LowestMaximumSupply.default
         self.research_cost_reduction_per_item: int = options.ResearchCostReductionPerItem.default
-        self.nova_presence: list[str] = NovaPresence.default
+        self.nova_presence: set[str] = NovaPresence.default
         self.mercenary_highlanders: bool = False
         self.kerrigan_levels_per_mission_completed = 0
         self.trade_enabled: int = EnableVoidTrade.default
         self.trade_age_limit: int = VoidTradeAgeLimit.default
         self.trade_workers_allowed: int = VoidTradeWorkers.default
         self.trade_underway: bool = False
-        self.trade_latest_reply: typing.Optional[dict] = None
+        self.trade_latest_reply: dict[str, Any] | None = None
         self.trade_reply_event = asyncio.Event()
         self.trade_lock_wait: int = 0
-        self.trade_lock_start: typing.Optional[float] = None
-        self.trade_response: typing.Optional[str] = None
+        self.trade_lock_start: float | None = None
+        self.trade_response: str | None = None
         self.difficulty_damage_modifier: int = DifficultyDamageModifier.default
         self.mission_order_scouting = MissionOrderScouting.option_none
-        self.mission_item_classification: typing.Optional[dict[str, int]] = None
+        self.mission_item_classification: dict[str, int] | None = None
         self.war_council_nerfs: bool = False
 
     async def server_auth(self, password_requested: bool = False) -> None:
@@ -927,7 +926,7 @@ class SC2Context(CommonContext):
             self.trade_reply_event.set()
 
     @staticmethod
-    def parse_mission_info(mission_info: dict[str, typing.Any]) -> MissionInfo:
+    def parse_mission_info(mission_info: dict[str, Any]) -> MissionInfo:
         if mission_info.get("id") is not None:
             mission_info["mission"] = lookup_id_to_mission[mission_info["id"]]
         elif isinstance(mission_info["mission"], int):
@@ -938,15 +937,14 @@ class SC2Context(CommonContext):
         )
 
     @staticmethod
-    def parse_mission_req_table(mission_req_table: dict[SC2Campaign, dict[typing.Any, MissionInfo]]) -> list[CampaignSlotData]:
-        campaigns: list[typing.Tuple[int, CampaignSlotData]] = []
+    def parse_mission_req_table(mission_req_table: dict[SC2Campaign, dict[Any, MissionInfo]]) -> list[CampaignSlotData]:
+        campaigns: list[tuple[int, CampaignSlotData]] = []
         rolling_rule_id = 0
         for (campaign, campaign_data) in mission_req_table.items():
             if campaign.campaign_name == "Global":
                 campaign_name = ""
             else:
                 campaign_name = campaign.campaign_name
-
             categories: dict[str, list[MissionSlotData]] = {}
             for mission in campaign_data.values():
                 if mission.category not in categories:
@@ -1052,7 +1050,7 @@ class SC2Context(CommonContext):
             return False
 
     def build_location_to_mission_mapping(self) -> None:
-        mission_id_to_location_ids: dict[int, typing.Set[int]] = {
+        mission_id_to_location_ids: dict[int, set[int]] = {
             mission.mission_id: set()
             for campaign in self.custom_mission_order for layout in campaign.layouts
             for column in layout.missions for mission in column
@@ -1071,27 +1069,27 @@ class SC2Context(CommonContext):
             for mission_id, objectives in mission_id_to_location_ids.items()
         }
 
-    def locations_for_mission(self, mission: SC2Mission) -> typing.Iterable[int]:
+    def locations_for_mission(self, mission: SC2Mission) -> Iterable[int]:
         mission_id: int = mission.id
         objectives = self.mission_id_to_location_ids[mission_id]
         for objective in objectives:
             yield get_location_id(mission_id, objective)
-
-    def locations_for_mission_id(self, mission_id: int) -> typing.Iterable[int]:
+    
+    def locations_for_mission_id(self, mission_id: int) -> Iterable[int]:
         objectives = self.mission_id_to_location_ids[mission_id]
         for objective in objectives:
             yield get_location_id(mission_id, objective)
 
-    def uncollected_locations_in_mission(self, mission: SC2Mission) -> typing.Iterable[int]:
+    def uncollected_locations_in_mission(self, mission: SC2Mission) -> Iterable[int]:
         for location_id in self.locations_for_mission(mission):
             if location_id in self.missing_locations:
                 yield location_id
 
     def is_mission_completed(self, mission_id: int) -> bool:
         return get_location_id(mission_id, 0) in self.checked_locations
-
-
-    async def trade_acquire_storage(self, keep_trying: bool = False) -> typing.Optional[dict]:
+    
+        
+    async def trade_acquire_storage(self, keep_trying: bool = False) -> dict | None:
         # This function was largely taken from the Pokemon Emerald client
         """
         Acquires a lock on the Void Trade DataStorage.
@@ -1188,7 +1186,7 @@ class SC2Context(CommonContext):
         # Ignore units we sent ourselves
         allowed_slots: list[str] = [
             slot for slot in reply["value"]
-            if slot != TRADE_DATASTORAGE_LOCK \
+            if slot != TRADE_DATASTORAGE_LOCK
                 and slot != self.trade_storage_slot()
         ]
         # Filter out trades that are too old
@@ -1204,7 +1202,7 @@ class SC2Context(CommonContext):
         else:
             is_unit_allowed = lambda _: True
 
-        available_units: list[typing.Tuple[str, str, int]] = []
+        available_units: list[tuple[str, str, int]] = []
         available_counts: list[int] = []
         for slot in allowed_slots:
             for (send_time, units) in reply["value"][slot].items():
@@ -1301,12 +1299,12 @@ class SC2Context(CommonContext):
 
 
 
-class CompatItemHolder(typing.NamedTuple):
+class CompatItemHolder(NamedTuple):
     name: str
     quantity: int = 1
 
 
-async def main(args: typing.Sequence[str] | None):
+async def main(args: Sequence[str] | None):
     multiprocessing.freeze_support()
     parser = get_base_parser()
     parser.add_argument('--name', default=None, help="Slot Name to connect as.")
@@ -1330,13 +1328,13 @@ async def main(args: typing.Sequence[str] | None):
     await ctx.shutdown()
 
 # These items must be given to the player if the game is generated on older versions
-API2_TO_API3_COMPAT_ITEMS: typing.Set[CompatItemHolder] = {
+API2_TO_API3_COMPAT_ITEMS: set[CompatItemHolder] = {
     CompatItemHolder(item_names.PHOTON_CANNON),
     CompatItemHolder(item_names.OBSERVER),
     CompatItemHolder(item_names.WARP_HARMONIZATION),
     CompatItemHolder(item_names.PROGRESSIVE_PROTOSS_WEAPON_ARMOR_UPGRADE, 3)
 }
-API3_TO_API4_COMPAT_ITEMS: typing.Set[CompatItemHolder] = {
+API3_TO_API4_COMPAT_ITEMS: set[CompatItemHolder] = {
     # War Council
     CompatItemHolder(item_names.ZEALOT_WHIRLWIND),
     CompatItemHolder(item_names.CENTURION_RESOURCE_EFFICIENCY),
@@ -1516,7 +1514,7 @@ def calculate_items(ctx: SC2Context) -> dict[SC2Race, list[int]]:
         upgrade_count = min(upgrade_count, WEAPON_ARMOR_UPGRADE_MAX_LEVEL)
 
         # Equivalent to "Progressive Weapon/Armor Upgrade" item
-        global_upgrades: typing.Set[str] = upgrade_included_names[GenericUpgradeItems.option_bundle_all]
+        global_upgrades: set[str] = upgrade_included_names[GenericUpgradeItems.option_bundle_all]
         for global_upgrade in global_upgrades:
             race = get_full_item_list()[global_upgrade].race
             upgrade_flaggroup = race_to_item_type[race]["Upgrade"].flag_word
@@ -1823,7 +1821,7 @@ class ArchipelagoBot(bot.bot_ai.BotAI):
             # <unit1> <unit2> <unit3>...
             if len(trade_send_string) > 0:
                 units_to_send: list[str] = []
-                non_ap_units: typing.Set[str] = set()
+                non_ap_units: set[str] = set()
                 for unit_id in trade_send_string.split():
                     if unit_id.startswith("AP_"):
                         units_to_send.append(normalized_unit_types.get(unit_id, unit_id))
@@ -1925,7 +1923,7 @@ class ArchipelagoBot(bot.bot_ai.BotAI):
 
     def get_locations(self) -> int:
         result = banks.read_locations()
-        if (result.strip()): # may be "" or " "
+        if (result.strip()):  # may be "" or " "
             return int(result)
         return 0
 
@@ -2017,9 +2015,9 @@ class ArchipelagoBot(bot.bot_ai.BotAI):
         )
 
 def calc_unfinished_nodes(
-        ctx: SC2Context
-) -> typing.Tuple[list[int], dict[int, list[int]], list[int], typing.Set[int]]:
-    unfinished_missions: typing.Set[int] = set()
+    ctx: SC2Context
+) -> tuple[list[int], dict[int, list[int]], list[int], set[int]]:
+    unfinished_missions: set[int] = set()
 
     available_missions, available_layouts, available_campaigns = calc_available_nodes(ctx)
 
@@ -2037,8 +2035,8 @@ def is_mission_available(ctx: SC2Context, mission_id_to_check: int) -> bool:
 
     return mission_id_to_check in available_missions
 
-def calc_available_nodes(ctx: SC2Context) -> typing.Tuple[list[int], dict[int, list[int]], list[int]]:
-    beaten_missions: typing.Set[int] = {mission_id for mission_id in ctx.mission_id_to_entry_rules if ctx.is_mission_completed(mission_id)}
+def calc_available_nodes(ctx: SC2Context) -> tuple[list[int], dict[int, list[int]], list[int]]:
+    beaten_missions: set[int] = {mission_id for mission_id in ctx.mission_id_to_entry_rules if ctx.is_mission_completed(mission_id)}
     received_items = compute_received_items(ctx)
 
     mission_order_objects: list[MissionOrderObjectSlotData] = []
@@ -2065,7 +2063,7 @@ def calc_available_nodes(ctx: SC2Context) -> typing.Tuple[list[int], dict[int, l
 
     while len(candidate_accessible_objects) > 0:
         accessible_missions: list[MissionSlotData] = [mission_order_object for mission_order_object in accessible_objects if isinstance(mission_order_object, MissionSlotData)]
-        beaten_accessible_missions: typing.Set[int] = {mission.mission_id for mission in accessible_missions if mission.mission_id in beaten_missions}
+        beaten_accessible_missions: set[int] = {mission.mission_id for mission in accessible_missions if mission.mission_id in beaten_missions}
         accessible_objects_to_add: list[MissionOrderObjectSlotData] = []
         for mission_order_object in candidate_accessible_objects:
             if (
@@ -2085,8 +2083,8 @@ def calc_available_nodes(ctx: SC2Context) -> typing.Tuple[list[int], dict[int, l
         else:
             break
 
-    accessible_missions: list[MissionSlotData] = [mission_order_object for mission_order_object in accessible_objects if isinstance(mission_order_object, MissionSlotData)]
-    beaten_accessible_missions: typing.Set[int] = {mission.mission_id for mission in accessible_missions if mission.mission_id in beaten_missions}
+    accessible_missions = [mission_order_object for mission_order_object in accessible_objects if isinstance(mission_order_object, MissionSlotData)]
+    beaten_accessible_missions: set[int] = {mission.mission_id for mission in accessible_missions if mission.mission_id in beaten_missions}
     for mission_order_object in mission_order_objects:
         # re-generate tooltip accessibility
         for sub_rule in mission_order_object.entry_rule.sub_rules:
@@ -2118,11 +2116,13 @@ def calc_available_nodes(ctx: SC2Context) -> typing.Tuple[list[int], dict[int, l
 
     return available_missions, available_layouts, available_campaigns
 
-def compute_received_items(ctx: SC2Context) -> typing.Counter[int]:
-    received_items: typing.Counter[int] = collections.Counter()
+
+def compute_received_items(ctx: SC2Context) -> collections.Counter[int]:
+    received_items: collections.Counter[int] = collections.Counter()
     for network_item in ctx.items_received:
         received_items[network_item.item] += 1
     return received_items
+
 
 def check_game_install_path() -> bool:
     # First thing: go to the default location for ExecuteInfo.
@@ -2231,10 +2231,10 @@ def is_mod_installed_correctly() -> bool:
 class DllDirectory:
     # Credit to Black Sliver for this code.
     # More info: https://docs.microsoft.com/en-us/windows/win32/api/winbase/nf-winbase-setdlldirectoryw
-    _old: typing.Optional[str] = None
-    _new: typing.Optional[str] = None
+    _old: str | None = None
+    _new: str | None = None
 
-    def __init__(self, new: typing.Optional[str]):
+    def __init__(self, new: str | None):
         self._new = new
 
     def __enter__(self):
@@ -2247,7 +2247,7 @@ class DllDirectory:
             self.set(self._old)
 
     @staticmethod
-    def get() -> typing.Optional[str]:
+    def get() -> str | None:
         if sys.platform == "win32":
             n = ctypes.windll.kernel32.GetDllDirectoryW(0, None)
             buf = ctypes.create_unicode_buffer(n)
@@ -2257,7 +2257,7 @@ class DllDirectory:
         return None
 
     @staticmethod
-    def set(s: typing.Optional[str]) -> bool:
+    def set(s: str | None) -> bool:
         if sys.platform == "win32":
             return ctypes.windll.kernel32.SetDllDirectoryW(s) != 0
         # NOTE: other OS may support os.environ["LD_LIBRARY_PATH"], but this fix is windows-specific
@@ -2268,9 +2268,9 @@ def download_latest_release_zip(
     owner: str,
     repo: str,
     api_version: str,
-    metadata: typing.Optional[str] = None,
+    metadata: str | None = None,
     force_download=False
-) -> typing.Tuple[str, typing.Optional[str]]:
+) -> tuple[str, str | None]:
     """Downloads the latest release of a GitHub repo to the current directory as a .zip file."""
     import requests
 

--- a/worlds/sc2/client_gui.py
+++ b/worlds/sc2/client_gui.py
@@ -41,27 +41,27 @@ class MissionButton(HoverableButton, MDTooltip):
     is_goal = BooleanProperty(False)
     showing_tooltip = BooleanProperty(False)
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, **kwargs) -> None:
         super(HoverableButton, self).__init__(**kwargs)
         self._tooltip = ServerToolTip(text=self.text, markup=True)
         self._tooltip.padding = [5, 2, 5, 2]
 
-    def on_enter(self):
+    def on_enter(self) -> None:
         self._tooltip.text = self.tooltip_text
 
         if self.tooltip_text != "":
             self.display_tooltip()
 
-    def on_leave(self):
+    def on_leave(self) -> None:
         self.remove_tooltip()
     
-    def display_tooltip(self, *args):
+    def display_tooltip(self, *args) -> None:
         self.showing_tooltip = True
-        return super().display_tooltip(*args)
+        super().display_tooltip(*args)
     
-    def remove_tooltip(self, *args):
+    def remove_tooltip(self, *args) -> None:
         self.showing_tooltip = False
-        return super().remove_tooltip(*args)
+        super().remove_tooltip(*args)
 
     @property
     def ctx(self) -> SC2Context:
@@ -93,7 +93,7 @@ class MissionCategory(GridLayout):
 
 
 class SC2JSONtoKivyParser(KivyJSONtoTextParser):
-    def _handle_item_name(self, node: JSONMessagePart):
+    def _handle_item_name(self, node: JSONMessagePart) -> str:
         item_name = node["text"]
         if self.ctx.slot_info[node["player"]].game != STARCRAFT2 or item_name not in item_descriptions:
             return super()._handle_item_name(node)
@@ -118,7 +118,7 @@ class SC2JSONtoKivyParser(KivyJSONtoTextParser):
         node.setdefault("refs", []).append(ref)
         return super(KivyJSONtoTextParser, self)._handle_item_name(node)
 
-    def _handle_text(self, node: JSONMessagePart):
+    def _handle_text(self, node: JSONMessagePart) -> str:
         if node.get("keep_markup", False):
             for ref in node.get("refs", []):
                 node["text"] = f"[ref={self.ref_count}|{ref}]{node['text']}[/ref]"

--- a/worlds/sc2/client_gui.py
+++ b/worlds/sc2/client_gui.py
@@ -344,9 +344,10 @@ class SC2Manager(GameManager):
 
     def mission_text(
         self, ctx: SC2Context, mission_id: int, mission_obj: SC2Mission,
-        layout_id: int, is_layout_exit: bool, layout_name: str, campaign_id: int, is_campaign_exit: bool, campaign_name: str,
-        available_missions: List[int], available_layouts: Dict[int, List[int]], available_campaigns: List[int],
-        unfinished_missions: List[int]
+        layout_id: int, is_layout_exit: bool, layout_name: str,
+        campaign_id: int, is_campaign_exit: bool, campaign_name: str,
+        available_missions: list[int], available_layouts: dict[int, List[int]], available_campaigns: list[int],
+        unfinished_missions: Iterable[int]
     ) -> Tuple[str, str]:
         COLOR_MISSION_IMPORTANT = "6495ED" # blue
         COLOR_MISSION_UNIMPORTANT = "A0BEF4" # lighter blue
@@ -529,7 +530,7 @@ class SC2Manager(GameManager):
         ]
         width_override = None
 
-        hinted_item_ids = Counter()
+        hinted_item_ids: Counter[int] = Counter()
         hints = self.ctx.stored_data.get(f"_read_hints_{self.ctx.team}_{self.ctx.slot}")
         if hints:
             for hint in hints:
@@ -569,7 +570,7 @@ class SC2Manager(GameManager):
     def resolve_items_needed(self, mission_id: int) -> Counter[int]:
         def resolve_rule_to_items(rule: RuleData) -> Counter[int]:
             if isinstance(rule, SubRuleRuleData):
-                all_items = Counter()
+                all_items: Counter[int] = Counter()
                 for sub_rule in rule.sub_rules:
                     # Take max of each item across all sub-rules
                     all_items |= resolve_rule_to_items(sub_rule)

--- a/worlds/sc2/options.py
+++ b/worlds/sc2/options.py
@@ -899,7 +899,7 @@ class NovaPresence(OptionSet):
         NovaPresenceOptions.GHOST_OF_A_CHANCE,
         NovaPresenceOptions.GHOST_OF_A_CHANCE_AUTO,
     }
-    default = {NovaPresenceOptions.NCO_TERRAN}
+    default = frozenset((NovaPresenceOptions.NCO_TERRAN,))
 
 class NovaMaxWeapons(Range):
     """

--- a/worlds/sc2/regions.py
+++ b/worlds/sc2/regions.py
@@ -94,6 +94,7 @@ def adjust_mission_pools(world: 'SC2World', pools: SC2MOGenMissionPools) -> None
         world.options.kerrigan_presence.value not in kerrigan_unit_available
         or SC2Campaign.HOTS not in enabled_campaigns
     )
+    assert world.logic
     nova_grant_story_tech = world.logic.nova_grant_story_tech
     # General changes for standard tactics
     if world.options.required_tactics.value == RequiredTactics.option_standard:

--- a/worlds/sc2/rules.py
+++ b/worlds/sc2/rules.py
@@ -2484,7 +2484,7 @@ class SC2Logic:
                     item_names.KERRIGAN_LEAPING_STRIKE,
                     item_names.OVERLORD_VENTRAL_SACS,
                     item_names.YGGDRASIL,
-                    item_names.MUTALISK_CORRUPTOR_VIPER_ASPECT,
+                    item_names.VIPER,
                     item_names.NYDUS_WORM,
                     item_names.BULLFROG,
                 ), self.player)
@@ -3537,7 +3537,7 @@ class SC2Logic:
     
     def protoss_enemy_intelligence_garrisonable_unit(self, state: CollectionState) -> bool:
         """
-        Has zerg unit usable as a Garrison in Enemy Intelligence
+        Has a garrisonable protoss unit in Enemy Intelligence
         """
         return (
             state.has_any((
@@ -3571,27 +3571,33 @@ class SC2Logic:
         )
     
     def zerg_enemy_intelligence_cliff_garrison(self, state: CollectionState) -> bool:
-        return ([
-            state.has_any({
-                item_names.YGGDRASIL, 
-                item_names.OVERLORD_VENTRAL_SACS, 
-                item_names.BULLFROG,
-            }, self.player)
-            or (self.morph_viper(state))]
-            and self.zerg_enemy_intelligence_garrisonable_unit(state) # consider Creep Teleport + Overlord creep?
+        return (
+            (
+                state.has_any((
+                    item_names.YGGDRASIL, 
+                    item_names.OVERLORD_VENTRAL_SACS, 
+                    item_names.BULLFROG,
+                ), self.player)
+                or self.morph_viper(state)
+            )
+            # consider Creep Teleport + Overlord creep?
+            and self.zerg_enemy_intelligence_garrisonable_unit(state)
         ) 
     
     def protoss_enemy_intelligence_cliff_garrison(self, state: CollectionState) -> bool:
         return (
-            state.has_any({
+            state.has_any((
                 item_names.STALKER, 
                 item_names.INSTIGATOR,
                 item_names.COLOSSUS,
                 item_names.WRATHWALKER,
-            }, self.player)
-            or state.has_all({item_names.SLAYER, item_names.SLAYER_PHASE_BLINK}, self.player)
-            or state.has_any({item_names.WARP_PRISM}, self.player)
-            and self.protoss_enemy_intelligence_garrisonable_unit(state) # consider SoA pylon + warpable unit/reinforcements?
+            ), self.player)
+            or state.has_all((item_names.SLAYER, item_names.SLAYER_PHASE_BLINK), self.player)
+            or (
+                state.has(item_names.WARP_PRISM, self.player)
+                # consider SoA pylon + warpable unit/reinforcements?
+                and self.protoss_enemy_intelligence_garrisonable_unit(state)
+            )
         )
 
 


### PR DESCRIPTION
## What is this fixing or adding?
Snarky noticed that the VIPER item variable name was wrong in one of the logic functions following the merge from main.

I hit the repository with mypy to try and track down as many instances of incorrect variables/types as possible, and found a few:
* The aforementioned `item_names.VIPER` issue
* Some other enemy within logic functions had incorrect formatting, and one used the wrong bracket types and so could return a list instead of a boolean
* Fixed an issue where some nova presence variables were incorrectly set as tuples of sets rather than sets directly
* Added a missing `from . import options` to __init__.py, as that seemed to be missing and used in some new code
* Miscellaneous typing fixes to slowly bring our mypy issue count down

Since I was using typing to track issues anyways, I did some typing refactors as well:
* Removed the star import for typing in client.py; switched away from using `typing.List` / `typing.Dict` / `typing.Tuple` etc now that the builtins can be used instead
* Removed typing.List / Dict / Tuple / Set from __init__.py

## How was this tested?
Ran all unit tests. Generated a world and connected, verified UI opened properly.

## If this makes graphical changes, please attach screenshots.
None.