### PR TITLE
sc2: removing unreleased item tag from Royal Guard

### DIFF
--- a/worlds/sc2/__init__.py
+++ b/worlds/sc2/__init__.py
@@ -968,7 +968,8 @@ def flag_unreleased_items(item_list: list[FilterItem]) -> None:
     """Remove all unreleased items unless they're explicitly locked"""
     for item in item_list:
         if (item.name in unreleased_items
-                and not (ItemFilterFlags.Locked|ItemFilterFlags.StartInventory) & item.flags):
+            and not (ItemFilterFlags.Locked|ItemFilterFlags.StartInventory) & item.flags
+        ):
             item.flags |= ItemFilterFlags.Removed
 
 

--- a/worlds/sc2/item/item_groups.py
+++ b/worlds/sc2/item/item_groups.py
@@ -1210,21 +1210,8 @@ item_name_groups[ItemGroupNames.OVERPOWERED_ITEMS] = overpowered_items = [
 
 # Items not aimed to be officially released
 # These need further balancing, and they shouldn't generate normally unless explicitly locked
-# Added here to not confuse the client
 item_name_groups[ItemGroupNames.UNRELEASED_ITEMS] = unreleased_items = [
-    item_names.PRIDE_OF_AUGUSTRGRAD,
-    item_names.SKY_FURY,
-    item_names.SHOCK_DIVISION,
-    item_names.BLACKHAMMER,
-    item_names.AEGIS_GUARD,
-    item_names.EMPERORS_SHADOW,
-    item_names.SON_OF_KORHAL,
-    item_names.BULWARK_COMPANY,
-    item_names.FIELD_RESPONSE_THETA,
-    item_names.EMPERORS_GUARDIAN,
-    item_names.NIGHT_HAWK,
-    item_names.NIGHT_WOLF,
-    item_names.EMPERORS_SHADOW_SOVEREIGN_TACTICAL_MISSILES,
+    # Empty for now! Leaving the group in case we add more unreleased items in future
 ]
 
 # A place for traits that were released before but are to be taken down by default.

--- a/worlds/sc2/test/test_generation.py
+++ b/worlds/sc2/test/test_generation.py
@@ -5,12 +5,16 @@ from typing import *
 
 from .test_base import Sc2SetupTestBase
 
-from .. import mission_groups, mission_tables, options, locations, SC2Mission, SC2Campaign, SC2Race, unreleased_items, \
-    RequiredTactics
+from .. import (
+    mission_groups, mission_tables, options, locations, SC2Mission, SC2Campaign, SC2Race, unreleased_items,
+    RequiredTactics,
+)
 from ..item import item_groups, item_tables, item_names
 from .. import get_all_missions, get_random_first_mission
-from ..options import EnabledCampaigns, MissionOrder, ExcludeOverpoweredItems, \
-    VanillaItemsOnly, MaximumCampaignSize
+from ..options import (
+    EnabledCampaigns, MissionOrder, ExcludeOverpoweredItems,
+    VanillaItemsOnly, MaximumCampaignSize,
+)
 from ..tables import NovaPresenceOptions
 
 class TestItemFiltering(Sc2SetupTestBase):


### PR DESCRIPTION
## What is this fixing or adding?
Now that Royal Guard updates are merged, setting the units to now be included in generation by default.

## How was this tested?
Did a test generation. Checked the spoiler log and verified that Aegis Guard, Son of Korhal, Pride of Augustgrad, Blackhammer, and Bulwark Company were all present.

## If this makes graphical changes, please attach screenshots.
None.