### PR TITLE
[SC2] Add Oracle ground mode

### DIFF
--- a/worlds/sc2/item/item_descriptions.py
+++ b/worlds/sc2/item/item_descriptions.py
@@ -972,6 +972,10 @@ item_descriptions = {
     item_names.ORACLE_SKYWARD_CHRONOANOMALY: "The Oracle's Stasis Ward can affect air units.",
     item_names.ORACLE_TEMPORAL_ACCELERATION_BEAM: "Oracles no longer need to spend energy to attack.",
     item_names.ORACLE_BOSONIC_CORE: "Increases starting energy by 150 and maximum energy by 50.",
+    item_names.ORACLE_SURFACE_STABILIZER: inspect.cleandoc("""
+        Allows the Oracle to transform into Ground mode.
+        Ground mode grants increased life and shields, and allows attacking only air units.
+    """),
     item_names.ARBITER_CHRONOSTATIC_REINFORCEMENT: "Arbiters gain +50 maximum life and +1 armor.",
     item_names.ARBITER_KHAYDARIN_CORE: _get_start_and_max_energy_desc("Arbiters"),
     item_names.ARBITER_SPACETIME_ANCHOR: "Allows Arbiters to use an alternate version of Stasis Field which lasts 50 seconds longer.",

--- a/worlds/sc2/item/item_names.py
+++ b/worlds/sc2/item/item_names.py
@@ -762,6 +762,7 @@ ORACLE_STEALTH_DRIVE                                    = "Stealth Drive (Oracle
 ORACLE_SKYWARD_CHRONOANOMALY                            = "Skyward Chronoanomaly (Oracle)"
 ORACLE_TEMPORAL_ACCELERATION_BEAM                       = "Temporal Acceleration Beam (Oracle)"
 ORACLE_BOSONIC_CORE                                     = "Bosonic Core (Oracle)"
+ORACLE_SURFACE_STABILIZER                               = "Surface Stabilizer (Oracle)"
 ARBITER_CHRONOSTATIC_REINFORCEMENT                      = "Chronostatic Reinforcement (Arbiter)"
 ARBITER_KHAYDARIN_CORE                                  = "Khaydarin Core (Arbiter)"
 ARBITER_SPACETIME_ANCHOR                                = "Spacetime Anchor (Arbiter)"

--- a/worlds/sc2/item/item_tables.py
+++ b/worlds/sc2/item/item_tables.py
@@ -1887,6 +1887,7 @@ item_table = {
     item_names.MOTHERSHIP_TALDARIM_SHADOW_OF_DEATH: ItemData(423 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_5, 3, SC2Race.PROTOSS, parent=item_names.MOTHERSHIP_TALDARIM),
     item_names.MOTHERSHIP_TALDARIM_SOUL_FORGED_CONDUITS: ItemData(424 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_5, 4, SC2Race.PROTOSS, parent=item_names.MOTHERSHIP_TALDARIM),
     item_names.MOTHERSHIP_TALDARIM_BLOOD_FUSED_PARTICLES: ItemData(425 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_5, 5, SC2Race.PROTOSS, parent=item_names.MOTHERSHIP_TALDARIM),
+    item_names.ORACLE_SURFACE_STABILIZER: ItemData(426 + SC2LOTV_ITEM_ID_OFFSET, ProtossItemType.Forge_5, 6, SC2Race.PROTOSS, parent=item_names.ORACLE),
 
 
     # War Council


### PR DESCRIPTION
## What is this fixing or adding?

Adds an upgrade for Oracle, that allows it to transform into a ground unit. 
<img width="929" height="124" alt="grafik" src="https://github.com/user-attachments/assets/9a0fa925-0e47-4930-acf8-edba89347096" />

## How was this tested?

Generated local campaign.

## If this makes graphical changes, please attach screenshots.


![GIF 29 01 2026 20-54-44](https://github.com/user-attachments/assets/1f2e869f-3852-4801-8c77-1fddf60b5894)
![GIF 29 01 2026 20-58-36](https://github.com/user-attachments/assets/e2e9943f-5620-470a-ae31-8ce40aad0186)

[SC2Data PR](https://github.com/archipelago-sc2/Archipelago-SC2-data/pull/39)
