### PR TITLE
[SC2] Add Corruptor ground splash

### DIFF
--- a/worlds/sc2/item/item_descriptions.py
+++ b/worlds/sc2/item/item_descriptions.py
@@ -744,6 +744,7 @@ item_descriptions = {
     item_names.CORRUPTOR_CONSTRUCT_REGENERATION: "Corruptors gain increased life regeneration.",
     item_names.CORRUPTOR_SCOURGE_INCUBATION: "Corruptors spawn 2 Scourge upon death (3 with Swarm Scourge).",
     item_names.CORRUPTOR_RESOURCE_EFFICIENCY: _get_resource_efficiency_desc(item_names.CORRUPTOR),
+    item_names.CORRUPTOR_ACID_SPLASH: "Corruptors attacking air units cause splash damage to enemy ground units below the target.",
     item_names.PRIMAL_IGNITER_CONCENTRATED_FIRE: "Primal Igniters deal +15 damage vs light armor.",
     item_names.PRIMAL_IGNITER_PRIMAL_TENACITY: "Primal Igniters gain +100 health and +1 armor.",
     item_names.INFESTED_SCV_BUILD_CHARGES: "Starting Infested SCV charges increased to 3. Maximum charges increased to 5.",

--- a/worlds/sc2/item/item_names.py
+++ b/worlds/sc2/item/item_names.py
@@ -514,6 +514,7 @@ CORRUPTOR_MONSTROUS_RESILIENCE                    = "Monstrous Resilience (Corru
 CORRUPTOR_CONSTRUCT_REGENERATION                  = "Construct Regeneration (Corruptor)"
 CORRUPTOR_SCOURGE_INCUBATION                      = "Scourge Incubation (Corruptor)"
 CORRUPTOR_RESOURCE_EFFICIENCY                     = "Resource Efficiency (Corruptor)"
+CORRUPTOR_ACID_SPLASH                             = "Acid Splash (Corruptor)"
 PRIMAL_IGNITER_CONCENTRATED_FIRE                  = "Concentrated Fire (Primal Igniter)"
 PRIMAL_IGNITER_PRIMAL_TENACITY                    = "Primal Tenacity (Primal Igniter)"
 OVERLORD_IMPROVED_OVERLORDS                       = "Improved Overlords (Overlord)"

--- a/worlds/sc2/item/item_tables.py
+++ b/worlds/sc2/item/item_tables.py
@@ -1506,6 +1506,8 @@ item_table = {
         ItemData(390 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_5, 17, SC2Race.ZERG, parent=item_names.BULLFROG),
     item_names.SPORE_CRAWLER_BIO_BONUS: 
         ItemData(391 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_5, 18, SC2Race.ZERG, parent=item_names.SPORE_CRAWLER),
+    item_names.SPORE_CRAWLER_BIO_BONUS: 
+        ItemData(392 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_5, 19, SC2Race.ZERG, parent=item_names.CORRUPTOR),
 
     item_names.KERRIGAN_KINETIC_BLAST: ItemData(400 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Ability, 0, SC2Race.ZERG, classification=ItemClassification.progression),
     item_names.KERRIGAN_HEROIC_FORTITUDE: ItemData(401 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Ability, 1, SC2Race.ZERG, classification=ItemClassification.progression),

--- a/worlds/sc2/item/item_tables.py
+++ b/worlds/sc2/item/item_tables.py
@@ -1506,7 +1506,7 @@ item_table = {
         ItemData(390 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_5, 17, SC2Race.ZERG, parent=item_names.BULLFROG),
     item_names.SPORE_CRAWLER_BIO_BONUS: 
         ItemData(391 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_5, 18, SC2Race.ZERG, parent=item_names.SPORE_CRAWLER),
-    item_names.SPORE_CRAWLER_BIO_BONUS: 
+    item_names.CORRUPTOR_ACID_SPLASH: 
         ItemData(392 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_5, 19, SC2Race.ZERG, parent=item_names.CORRUPTOR),
 
     item_names.KERRIGAN_KINETIC_BLAST: ItemData(400 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Ability, 0, SC2Race.ZERG, classification=ItemClassification.progression),


### PR DESCRIPTION
## What is this fixing or adding?

Adds an item for the Corruptor:

### Acid Splash

<img width="750" height="85" alt="grafik" src="https://github.com/user-attachments/assets/a160f426-d030-49ae-99be-1f1fb2f6d9fd" />

Do note, that this item encourages attacking your own units, if you need to deal with ground units while there is no enemy air nearby. 

~~For this reason, it applies a 50% damage reduction behavior on friendly fire for 5 seconds, which I chose to not disclose in the tooltip.~~

This has been removed

```spoiler
It applies a visible behavior, which has a tooltip explaining this. But **neither the client item description nor the ingame button on the Corruptor has this information!**
<img width="497" height="157" alt="grafik" src="https://github.com/user-attachments/assets/6e8dcd8a-9e3c-4a88-9a38-1fcbdf147458" />

My reasoning is as follows:
- the main use for the item is getting additional benefits out of hitting enemy air units
- hitting your own units with it is possible, but should be a niche interaction for players to discover
- the behavior is not meant to encourage attacking your own units, more to reduce the penalty of having to do it if the situation calls for it
- I don't want to draw attention to attacking your own units as if it is the main intend of the item. If I add this to the main tooltip, it makes it sound like that's the intended use and players would feel forced to attack their own units constantly
```
## How was this tested?

Generated local campaign

## If this makes graphical changes, please attach screenshots.

![GIF 30 01 2026 09-24-20](https://github.com/user-attachments/assets/46e5a74f-b7b0-4964-9333-9fa5d3113a29)

[SC2Data PR](https://github.com/archipelago-sc2/Archipelago-SC2-data/pull/41)
