### PR TITLE
sc2: Options -> setting adjustments

### DIFF
--- a/worlds/sc2/__init__.py
+++ b/worlds/sc2/__init__.py
@@ -39,7 +39,7 @@ from .tables import NovaPresenceOptions
 from .regions import create_mission_order
 from .mission_order import SC2MissionOrder
 from worlds.LauncherComponents import components, Component, launch as launch_component
-from .mission_order.presets import sc2_options_presets
+from .presets import sc2_options_presets
 
 logger = logging.getLogger("Starcraft 2")
 
@@ -842,8 +842,11 @@ def flag_start_unit(world: SC2World, item_list: list[FilterItem], starter_unit: 
             first_race = world.random.choice(list(races))
 
     if first_race != SC2Race.ANY:
+        disqualifying_flags = (
+            ItemFilterFlags.Plando|ItemFilterFlags.UserExcluded|ItemFilterFlags.FilterExcluded
+        )
         possible_starter_items = {
-            item.name: item for item in item_list if (ItemFilterFlags.Plando|ItemFilterFlags.UserExcluded|ItemFilterFlags.FilterExcluded) & item.flags == 0
+            item.name: item for item in item_list if not (disqualifying_flags & item.flags)
         }
 
         # The race of the early unit has been chosen

--- a/worlds/sc2/apclient/game_client.py
+++ b/worlds/sc2/apclient/game_client.py
@@ -116,14 +116,16 @@ class MissionClient:
             game_speed = self.ctx.game_speed_override
         else:
             game_speed = self.ctx.game_speed
+        skip_cutscenes = 1 if SC2World.settings.game_skip_cutscenes else 0
+        disable_forced_camera = 1 if SC2World.settings.game_disable_forced_camera else 0
 
         error = banks.send_options(
             f" {difficulty}"
             f" {generic_upgrade_options}"
             f" {self.ctx.all_in_choice}"
             f" {game_speed}"
-            f" {self.ctx.disable_forced_camera}"
-            f" {self.ctx.skip_cutscenes}"
+            f" {disable_forced_camera}"
+            f" {skip_cutscenes}"
             f" {kerrigan_options}"
             f" {grant_story_tech}"
             f" {self.ctx.take_over_ai_allies}"
@@ -136,7 +138,7 @@ class MissionClient:
             f" {trade_options}"
             f" {self.ctx.difficulty_damage_modifier}"
             f" {self.ctx.mercenary_highlanders}" # TODO: Possibly rework into unit options
-            f" {self.ctx.war_council_nerfs}"
+            f" {self.ctx.show_war_council_nerfs}"
         )
         if isinstance(error, Error):
             logger.error(error.message)

--- a/worlds/sc2/client.py
+++ b/worlds/sc2/client.py
@@ -501,7 +501,10 @@ class StarcraftClientProcessor(ClientCommandProcessor):
         else:
             self.output(f"Unknown option value '{option_value}'")
         if isinstance(option, ConfigurableSettingInfo):
-            presentable_value = str(SC2World.settings.__dict__[option.setting_name]).lower()
+            presentable_value = str(SC2World.settings.__dict__.get(
+                option.setting_name,
+                Starcraft2Settings.__dict__[option.setting_name])
+            ).lower()
         elif issubclass(option.option_class, coreoptions.Toggle):
             # get_option_name() will return 'yes' and 'no' for Toggles, which looks wrong in the UI
             presentable_value = 'true' if self.ctx.__dict__[option.variable_name] else 'false'

--- a/worlds/sc2/client.py
+++ b/worlds/sc2/client.py
@@ -158,6 +158,7 @@ class StarcraftClientProcessor(ClientCommandProcessor):
         # without having to branch code from CommonClient
         self.ctx.on_print_json({"data": [{"text": text, "keep_markup": True}]})
 
+    @mark_raw
     def _cmd_difficulty(self, difficulty: str = "") -> bool:
         """Overrides the current difficulty set for the world.  Takes the argument casual, normal, hard, or brutal"""
         arguments = difficulty.split()
@@ -191,6 +192,7 @@ class StarcraftClientProcessor(ClientCommandProcessor):
             self.output("To change the difficulty, add the name of the difficulty after the command.")
             return False
 
+    @mark_raw
     def _cmd_game_speed(self, game_speed: str = "") -> bool:
         """Overrides the current game speed for the world.
          Takes the arguments default, slower, slow, normal, fast, faster"""
@@ -370,20 +372,15 @@ class StarcraftClientProcessor(ClientCommandProcessor):
         return True
 
     @mark_raw
-    def _cmd_option(self, args: str = "") -> None:
+    def _cmd_option(self, option_name: str = "", option_value: str = "") -> None:
         """Sets a Starcraft game option that can be changed after generation. Use "/option list" to see all options."""
 
         # Manually parse arguments so the user doesn't see a stack trace if they provide too many arguments
-        tokens = [t for t in args.split(" ") if t]
-        if len(tokens) > 2:
-            self.output(f"Too many arguments to /option, expected at most 2, got {len(tokens)}")
+        arguments = parse_client_cmd_args(option_name, 2, "/option")
+        if isinstance(arguments, Error):
+            self.output(arguments.message)
             return
-        option_name = ""
-        option_value = ""
-        if tokens:
-            option_name = tokens[0]
-        if len(tokens) > 1:
-            option_value = tokens[1]
+        option_name, option_value = arguments
 
         LOGIC_WARNING = "  *Note changing this may result in logically unbeatable games*\n"
 
@@ -515,8 +512,14 @@ class StarcraftClientProcessor(ClientCommandProcessor):
             # Some options, particularly those affecting scouting, require a redraw
             self.ctx.ui.pending_redraw = True
 
+    @mark_raw
     def _cmd_color(self, faction: str = "", color: str = "") -> None:
-        """Changes the player color for a given faction."""
+        """takes faction, color. Changes the player color for a given faction."""
+        arguments = parse_client_cmd_args(faction, 2, "/color")
+        if isinstance(arguments, Error):
+            self.output(arguments.message)
+            return
+        faction, color = arguments
         player_colors = [
             "White", "Red", "Blue", "Teal",
             "Purple", "Yellow", "Orange", "Green",
@@ -560,11 +563,11 @@ class StarcraftClientProcessor(ClientCommandProcessor):
             self.output(f"Color for {faction} set to " + player_colors[self.ctx.__dict__[var_names[faction]]])
 
     @mark_raw
-    def _cmd_windowed_mode(self, value="") -> None:
+    def _cmd_windowed_mode(self, true_or_false: str = "") -> None:
         """Controls whether sc2 will launch in Windowed mode. Persists across sessions."""
-        if not value:
+        if not true_or_false:
             sc2_logger.info("Use `/windowed_mode [true|false]` to set the windowed mode")
-        elif value.casefold() in ('t', 'true', 'yes', 'y'):
+        elif true_or_false.casefold() in ('t', 'true', 'yes', 'y', '+'):
             SC2World.settings.game_windowed_mode = True
             force_settings_save_on_close()
         else:
@@ -580,7 +583,7 @@ class StarcraftClientProcessor(ClientCommandProcessor):
         return True
 
     @mark_raw
-    def _cmd_set_path(self, path: str = '') -> bool:
+    def _cmd_set_path(self, path: str = "") -> bool:
         """Manually set the SC2 install directory (if the automatic detection fails)."""
         if path:
             SC2World.settings.sc2_install_path = SC2World.settings.Sc2InstallPath(path)
@@ -631,6 +634,23 @@ class StarcraftClientProcessor(ClientCommandProcessor):
             return False
         ctx.data_out_of_date = False
         return True
+
+
+def parse_client_cmd_args(args: str, num_args: int, command_name: str) -> Error[str] | list[str]:
+    """
+    Split arguments by spaces and return as a list.
+    Pads the list with empty strings if too few arguments are given.
+    Returns an error if too many arguments are given.
+    Use this with @mark_raw to make sure the user doesn't see a stack trace if they provide too many args.
+    """
+    result = [t for t in args.split(" ") if t]
+    if len(result) > num_args:
+        return Error(
+            f"Too many arguments provided to {command_name}. Expected {num_args}, got {len(result)}"
+        )
+    while len(result) < num_args:
+        result.append("")
+    return result
 
 
 class SC2JSONtoTextParser(JSONtoTextParser):

--- a/worlds/sc2/client.py
+++ b/worlds/sc2/client.py
@@ -18,12 +18,14 @@ import random
 import concurrent.futures
 import time
 import uuid
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, TYPE_CHECKING, NamedTuple, Type, Sequence, Iterable
 
 # CommonClient import first to trigger ModuleUpdater
 from CommonClient import CommonContext, server_loop, ClientCommandProcessor, gui_enabled, get_base_parser, handle_url_arg
 from Utils import init_logging, async_start
+import Options as coreoptions
 from .item import item_parents
 from .item.item_annotations import ITEM_NAME_ANNOTATIONS
 from .item.item_groups import item_name_groups, unlisted_item_name_groups
@@ -33,7 +35,7 @@ from .options import (
     GameSpeed, GenericUpgradeItems, GenericUpgradeResearch, ColorChoice, GenericUpgradeMissions, MaxUpgradeLevel,
     LocationInclusion, ExtraLocations, MasteryLocations, SpeedrunLocations, PreventativeLocations, ChallengeLocations,
     VanillaLocations, NovaPresence,
-    DisableForcedCamera, SkipCutscenes, GrantStoryTech, GrantStoryLevels, TakeOverAIAllies, RequiredTactics,
+    GrantStoryTech, GrantStoryLevels, TakeOverAIAllies, RequiredTactics,
     SpearOfAdunPresence, SpearOfAdunPresentInNoBuild, SpearOfAdunPassiveAbilityPresence,
     SpearOfAdunPassivesPresentInNoBuild, EnableVoidTrade, VoidTradeAgeLimit, void_trade_age_limits_ms, VoidTradeWorkers,
     DifficultyDamageModifier, MissionOrderScouting, GenericUpgradeResearchSpeedup, MercenaryHighlanders, WarCouncilNerfs,
@@ -45,6 +47,8 @@ from .apclient.transfer_data import worker_units
 from . import SC2World
 from .apclient import banks, user_paths, game_client
 from .apclient.failable import Error
+import settings as coresettings
+from .settings import Starcraft2Settings
 
 import nest_asyncio
 from .item import item_tables
@@ -60,9 +64,6 @@ from NetUtils import (
     NetworkItem, JSONtoTextParser, JSONMessagePart, add_json_item, add_json_location, add_json_text, JSONTypes
 )
 from MultiServer import mark_raw
-
-if TYPE_CHECKING:
-    from Options import Option
 
 
 sc2_logger = logging.getLogger("Starcraft2")
@@ -107,14 +108,20 @@ def _remap_color_option(slot_data_version: int, color: int) -> int:
 class ConfigurableOptionType(enum.Enum):
     INTEGER = enum.auto()
     ENUM = enum.auto()
+    SETTING = enum.auto()
 
 
 class ConfigurableOptionInfo(NamedTuple):
-    name: str
     variable_name: str
-    option_class: Type[Option]
+    option_class: Type[coreoptions.Option]
     option_type: ConfigurableOptionType = ConfigurableOptionType.ENUM
     can_break_logic: bool = False
+
+
+@dataclass
+class ConfigurableSettingInfo:
+    setting_name: str
+    option_class: Type[coresettings.Bool] | Type[str] | Type[int]
 
 
 class ColouredMessage:
@@ -362,85 +369,151 @@ class StarcraftClientProcessor(ClientCommandProcessor):
             ).send(self.ctx)
         return True
 
-    def _cmd_option(self, option_name: str = "", option_value: str = "") -> None:
+    @mark_raw
+    def _cmd_option(self, args: str = "") -> None:
         """Sets a Starcraft game option that can be changed after generation. Use "/option list" to see all options."""
+
+        # Manually parse arguments so the user doesn't see a stack trace if they provide too many arguments
+        tokens = [t for t in args.split(" ") if t]
+        if len(tokens) > 2:
+            self.output(f"Too many arguments to /option, expected at most 2, got {len(tokens)}")
+            return
+        option_name = ""
+        option_value = ""
+        if tokens:
+            option_name = tokens[0]
+        if len(tokens) > 1:
+            option_value = tokens[1]
 
         LOGIC_WARNING = "  *Note changing this may result in logically unbeatable games*\n"
 
-        configurable_options = (
-            ConfigurableOptionInfo('speed', 'game_speed', options.GameSpeed),
-            ConfigurableOptionInfo('kerrigan_presence', 'kerrigan_presence', options.KerriganPresence, can_break_logic=True),
-            ConfigurableOptionInfo('kerrigan_level_cap', 'kerrigan_total_level_cap', options.KerriganTotalLevelCap, ConfigurableOptionType.INTEGER, can_break_logic=True),
-            ConfigurableOptionInfo('kerrigan_mission_level_cap', 'kerrigan_levels_per_mission_completed_cap', options.KerriganLevelsPerMissionCompletedCap, ConfigurableOptionType.INTEGER),
-            ConfigurableOptionInfo('kerrigan_levels_per_mission', 'kerrigan_levels_per_mission_completed', options.KerriganLevelsPerMissionCompleted, ConfigurableOptionType.INTEGER),
-            ConfigurableOptionInfo('grant_story_levels', 'grant_story_levels', options.GrantStoryLevels, can_break_logic=True),
-            ConfigurableOptionInfo('grant_story_tech', 'grant_story_tech', options.GrantStoryTech, can_break_logic=True),
-            ConfigurableOptionInfo('control_ally', 'take_over_ai_allies', options.TakeOverAIAllies, can_break_logic=True),
-            ConfigurableOptionInfo('soa_presence', 'spear_of_adun_presence', options.SpearOfAdunPresence, can_break_logic=True),
-            ConfigurableOptionInfo('soa_in_nobuilds', 'spear_of_adun_present_in_no_build', options.SpearOfAdunPresentInNoBuild, can_break_logic=True),
-            # Note(mm): Technically SOA passive presence is in the logic for Amon's Fall if Takeover AI Allies is true,
-            # but that's edge case enough I don't think we should warn about it.
-            ConfigurableOptionInfo('soa_passive_presence', 'spear_of_adun_passive_ability_presence', options.SpearOfAdunPassiveAbilityPresence),
-            ConfigurableOptionInfo('soa_passives_in_nobuilds', 'spear_of_adun_passive_present_in_no_build', options.SpearOfAdunPassivesPresentInNoBuild),
-            ConfigurableOptionInfo('max_upgrade_level', 'max_upgrade_level', options.MaxUpgradeLevel, ConfigurableOptionType.INTEGER),
-            ConfigurableOptionInfo('generic_upgrade_research', 'generic_upgrade_research', options.GenericUpgradeResearch),
-            ConfigurableOptionInfo('generic_upgrade_research_speedup', 'generic_upgrade_research_speedup', options.GenericUpgradeResearchSpeedup),
-            ConfigurableOptionInfo('minerals_per_item', 'minerals_per_item', options.MineralsPerItem, ConfigurableOptionType.INTEGER),
-            ConfigurableOptionInfo('gas_per_item', 'vespene_per_item', options.VespenePerItem, ConfigurableOptionType.INTEGER),
-            ConfigurableOptionInfo('supply_per_item', 'starting_supply_per_item', options.StartingSupplyPerItem, ConfigurableOptionType.INTEGER),
-            ConfigurableOptionInfo('max_supply_per_item', 'maximum_supply_per_item', options.MaximumSupplyPerItem, ConfigurableOptionType.INTEGER),
-            ConfigurableOptionInfo('reduced_supply_per_item', 'maximum_supply_reduction_per_item', options.MaximumSupplyReductionPerItem, ConfigurableOptionType.INTEGER),
-            ConfigurableOptionInfo('lowest_max_supply', 'lowest_maximum_supply', options.LowestMaximumSupply, ConfigurableOptionType.INTEGER),
-            ConfigurableOptionInfo('research_cost_per_item', 'research_cost_reduction_per_item', options.ResearchCostReductionPerItem, ConfigurableOptionType.INTEGER),
-            ConfigurableOptionInfo('no_forced_camera', 'disable_forced_camera', options.DisableForcedCamera),
-            ConfigurableOptionInfo('skip_cutscenes', 'skip_cutscenes', options.SkipCutscenes),
-            ConfigurableOptionInfo('enable_morphling', 'enable_morphling', options.EnableMorphling, can_break_logic=True),
-            ConfigurableOptionInfo('difficulty_damage_modifier', 'difficulty_damage_modifier', options.DifficultyDamageModifier),
-            ConfigurableOptionInfo('void_trade_age_limit', 'trade_age_limit', options.VoidTradeAgeLimit),
-            ConfigurableOptionInfo('void_trade_workers', 'trade_workers_allowed', options.VoidTradeWorkers),
-            ConfigurableOptionInfo('mercenary_highlanders', 'mercenary_highlanders', options.MercenaryHighlanders),
-        )
+        configurable_options: dict[str, ConfigurableOptionInfo | ConfigurableSettingInfo] = {
+            # Kerrigan
+            'kerrigan_presence': ConfigurableOptionInfo('kerrigan_presence', options.KerriganPresence, can_break_logic=True),
+            'kerrigan_level_cap': ConfigurableOptionInfo('kerrigan_total_level_cap', options.KerriganTotalLevelCap, ConfigurableOptionType.INTEGER, can_break_logic=True),
+            'kerrigan_mission_level_cap': ConfigurableOptionInfo('kerrigan_levels_per_mission_completed_cap', options.KerriganLevelsPerMissionCompletedCap, ConfigurableOptionType.INTEGER),
+            'kerrigan_levels_per_mission': ConfigurableOptionInfo('kerrigan_levels_per_mission_completed', options.KerriganLevelsPerMissionCompleted, ConfigurableOptionType.INTEGER),
+            'grant_story_levels': ConfigurableOptionInfo('grant_story_levels', options.GrantStoryLevels, can_break_logic=True),
+
+            'grant_story_tech': ConfigurableOptionInfo('grant_story_tech', options.GrantStoryTech, can_break_logic=True),
+            'control_ally': ConfigurableOptionInfo('take_over_ai_allies', options.TakeOverAIAllies, can_break_logic=True),
+            # SoA
+            'soa_presence': ConfigurableOptionInfo('spear_of_adun_presence', options.SpearOfAdunPresence, can_break_logic=True),
+            'soa_in_nobuilds': ConfigurableOptionInfo('spear_of_adun_present_in_no_build', options.SpearOfAdunPresentInNoBuild, can_break_logic=True),
+            'soa_passive_presence': ConfigurableOptionInfo('spear_of_adun_passive_ability_presence', options.SpearOfAdunPassiveAbilityPresence, can_break_logic=True),
+            'soa_passives_in_nobuilds': ConfigurableOptionInfo('spear_of_adun_passive_present_in_no_build', options.SpearOfAdunPassivesPresentInNoBuild),
+            # Fillers
+            'minerals_per_item': ConfigurableOptionInfo('minerals_per_item', options.MineralsPerItem, ConfigurableOptionType.INTEGER),
+            'gas_per_item': ConfigurableOptionInfo('vespene_per_item', options.VespenePerItem, ConfigurableOptionType.INTEGER),
+            'supply_per_item': ConfigurableOptionInfo('starting_supply_per_item', options.StartingSupplyPerItem, ConfigurableOptionType.INTEGER),
+            'max_supply_per_item': ConfigurableOptionInfo('maximum_supply_per_item', options.MaximumSupplyPerItem, ConfigurableOptionType.INTEGER),
+            'reduced_supply_per_item': ConfigurableOptionInfo('maximum_supply_reduction_per_item', options.MaximumSupplyReductionPerItem, ConfigurableOptionType.INTEGER),
+            'lowest_max_supply': ConfigurableOptionInfo('lowest_maximum_supply', options.LowestMaximumSupply, ConfigurableOptionType.INTEGER),
+            'research_cost_per_item': ConfigurableOptionInfo('research_cost_reduction_per_item', options.ResearchCostReductionPerItem, ConfigurableOptionType.INTEGER),
+            # settings / adjustments
+            'speed': ConfigurableOptionInfo('game_speed', options.GameSpeed),
+            'difficulty': ConfigurableOptionInfo('game_difficulty', options.GameDifficulty),
+            'no_forced_camera': ConfigurableSettingInfo('game_disable_forced_camera', Starcraft2Settings.GameDisableForcedCamera),
+            'skip_cutscenes': ConfigurableSettingInfo('game_skip_cutscenes', Starcraft2Settings.GameSkipCutscenes),
+            'scouting': ConfigurableOptionInfo('mission_order_scouting', options.MissionOrderScouting),
+            'scouting_show_traps': ConfigurableSettingInfo('scouting_show_traps', Starcraft2Settings.ScoutingShowTraps),
+            'enable_morphling': ConfigurableOptionInfo('enable_morphling', options.EnableMorphling, can_break_logic=True),
+            'difficulty_damage_modifier': ConfigurableOptionInfo('difficulty_damage_modifier', options.DifficultyDamageModifier),
+            'void_trade_age_limit': ConfigurableOptionInfo('trade_age_limit', options.VoidTradeAgeLimit),
+            'void_trade_workers': ConfigurableOptionInfo('trade_workers_allowed', options.VoidTradeWorkers),
+            'mercenary_highlanders': ConfigurableOptionInfo('mercenary_highlanders', options.MercenaryHighlanders),
+            # Misc
+            'max_upgrade_level': ConfigurableOptionInfo('max_upgrade_level', options.MaxUpgradeLevel, ConfigurableOptionType.INTEGER),
+            'generic_upgrade_research': ConfigurableOptionInfo('generic_upgrade_research', options.GenericUpgradeResearch, can_break_logic=True),
+            'generic_upgrade_research_speedup': ConfigurableOptionInfo('generic_upgrade_research_speedup', options.GenericUpgradeResearchSpeedup),
+        }
 
         WARNING_COLOUR = "salmon"
         CMD_COLOUR = "slateblue"
+        LOGIC_WARNING = "**"
         boolean_option_map = {
-            'y': 'true', 'yes': 'true', 'n': 'false', 'no': 'false', 'true': 'true', 'false': 'false',
+            'true': 'true', 'y': 'true', 'yes': 'true', '+': 'true',
+            'false': 'false', 'n': 'false', 'no': 'false', '-': 'false',
         }
 
-        help_message = ColouredMessage(inspect.cleandoc("""
+        # Construct help text
+        help_message = (ColouredMessage(inspect.cleandoc("""
             Options
         --------------------
-        """))('\n')
-        for option in configurable_options:
+        """))
+            ("\n * Options marked with a ")
+            .coloured(LOGIC_WARNING, WARNING_COLOUR)
+            (" may break logic if changed.\n")
+        )
+        for this_option_name, option in configurable_options.items():
             option_help_text = inspect.cleandoc(option.option_class.__doc__ or "No description provided.").split('\n', 1)[0]
-            help_message.coloured(option.name, CMD_COLOUR)(": " + " | ".join(option.option_class.options)
-                + f" -- {option_help_text}\n")
-            if option.can_break_logic:
-                help_message.coloured(LOGIC_WARNING, WARNING_COLOUR)
+            if not option_help_text.endswith("."):
+                option_help_text += "."
+            help_message.coloured(this_option_name, CMD_COLOUR)
+            if isinstance(option, ConfigurableOptionInfo):
+                if option.can_break_logic:
+                    help_message.coloured(LOGIC_WARNING, WARNING_COLOUR)
+                help_message(": " + " | ".join(option.option_class.options) + f" -- {option_help_text}\n")
+            else:
+                if issubclass(option.option_class, int):
+                    help_message(f": integer -- {option_help_text}\n")
+                elif issubclass(option.option_class, coresettings.Bool):
+                    # Note(mm): Copying display order of choices in coreoptions.Toggle
+                    help_message(f": false | true -- {option_help_text}\n")
+                else:
+                    help_message(f": {option_help_text}\n")
         help_message("--------------------\nEnter an option without arguments to see its current value.\n")
 
+        # Display help text
         if not option_name or option_name == 'list' or option_name == 'help':
             help_message.send(self.ctx)
             return
-        for option in configurable_options:
-            if option_name == option.name:
-                option_value = boolean_option_map.get(option_value.lower(), option_value)
-                if not option_value:
-                    pass
-                elif option.option_type == ConfigurableOptionType.ENUM and option_value in option.option_class.options:
-                    self.ctx.__dict__[option.variable_name] = option.option_class.options[option_value]
-                elif option.option_type == ConfigurableOptionType.INTEGER:
-                    try:
-                        self.ctx.__dict__[option.variable_name] = int(option_value, base=0)
-                    except:
-                        self.output(f"{option_value} is not a valid integer")
-                else:
-                    self.output(f"Unknown option value '{option_value}'")
-                ColouredMessage(f"{option.name} is '{option.option_class.get_option_name(self.ctx.__dict__[option.variable_name])}'").send(self.ctx)
-                break
-        else:
-            self.output(f"Unknown option '{option_name}'")
+        option = configurable_options.get(option_name)
+        if not option:
             help_message.send(self.ctx)
+            self.output(f"Unknown option '{option_name}")
+            return
+
+        option_value = boolean_option_map.get(option_value.lower(), option_value)
+        if not option_value:
+            pass
+        elif isinstance(option, ConfigurableSettingInfo):
+            if issubclass(option.option_class, coresettings.Bool):
+                if option_value == 'true':
+                    SC2World.settings.__dict__[option.setting_name] = True
+                elif option_value == 'false':
+                    SC2World.settings.__dict__[option.setting_name] = False
+                else:
+                    self.output(f"{option_value} is not a valid true/false value")
+            elif issubclass(option.option_class, int):
+                try:
+                    int_value = int(option_value, base=0)
+                    SC2World.settings.__dict__[option.setting_name] = int_value
+                except ValueError:
+                    self.output(f"{option_value} is not a valid integer")
+            else:
+                SC2World.settings.__dict__[option.setting_name] = option_value
+            force_settings_save_on_close()
+        elif option.option_type == ConfigurableOptionType.ENUM and option_value in option.option_class.options:
+            self.ctx.__dict__[option.variable_name] = option.option_class.options[option_value]
+        elif option.option_type == ConfigurableOptionType.INTEGER:
+            try:
+                self.ctx.__dict__[option.variable_name] = int(option_value, base=0)
+            except:
+                self.output(f"{option_value} is not a valid integer")
+        else:
+            self.output(f"Unknown option value '{option_value}'")
+        if isinstance(option, ConfigurableSettingInfo):
+            presentable_value = str(SC2World.settings.__dict__[option.setting_name]).lower()
+        elif issubclass(option.option_class, coreoptions.Toggle):
+            # get_option_name() will return 'yes' and 'no' for Toggles, which looks wrong in the UI
+            presentable_value = 'true' if self.ctx.__dict__[option.variable_name] else 'false'
+        else:
+            presentable_value = option.option_class.get_option_name(self.ctx.__dict__[option.variable_name])
+        ColouredMessage(f"{option_name} is '{presentable_value}'").send(self.ctx)
+        if "scouting" in option_name and self.ctx.ui is not None:
+            # Some options, particularly those affecting scouting, require a redraw
+            self.ctx.ui.pending_redraw = True
 
     def _cmd_color(self, faction: str = "", color: str = "") -> None:
         """Changes the player color for a given faction."""
@@ -486,6 +559,7 @@ class StarcraftClientProcessor(ClientCommandProcessor):
             self.ctx.pending_color_update = True
             self.output(f"Color for {faction} set to " + player_colors[self.ctx.__dict__[var_names[faction]]])
 
+    @mark_raw
     def _cmd_windowed_mode(self, value="") -> None:
         """Controls whether sc2 will launch in Windowed mode. Persists across sessions."""
         if not value:
@@ -596,8 +670,6 @@ class SC2Context(CommonContext):
         self.data_out_of_date: bool = False
         self.difficulty = -1
         self.game_speed = -1
-        self.disable_forced_camera = 0
-        self.skip_cutscenes = 0
         self.all_in_choice = 0
         self.mission_order = 0
         self.player_color_raynor = ColorChoice.option_blue
@@ -658,7 +730,7 @@ class SC2Context(CommonContext):
         self.difficulty_damage_modifier: int = DifficultyDamageModifier.default
         self.mission_order_scouting = MissionOrderScouting.option_none
         self.mission_item_classification: dict[str, int] | None = None
-        self.war_council_nerfs: bool = False
+        self.show_war_council_nerfs: bool = False
 
     async def server_auth(self, password_requested: bool = False) -> None:
         self.game = STARCRAFT2
@@ -707,16 +779,6 @@ class SC2Context(CommonContext):
         elif str(SC2World.settings.game_speed).casefold() == 'faster':
             self.game_speed = GameSpeed.option_faster
 
-        if str(SC2World.settings.disable_forced_camera).casefold() == 'true':
-            self.disable_forced_camera = DisableForcedCamera.option_true
-        elif str(SC2World.settings.disable_forced_camera).casefold() == 'false':
-            self.disable_forced_camera = DisableForcedCamera.option_false
-
-        if str(SC2World.settings.skip_cutscenes).casefold() == 'true':
-            self.skip_cutscenes = SkipCutscenes.option_true
-        elif str(SC2World.settings.skip_cutscenes).casefold() == 'false':
-            self.skip_cutscenes = SkipCutscenes.option_false
-
     def on_package(self, cmd: str, args: dict) -> None:
         if cmd == "Connected":
             # Set up the trade storage
@@ -735,8 +797,6 @@ class SC2Context(CommonContext):
 
             self.difficulty = args["slot_data"]["game_difficulty"]
             self.game_speed = args["slot_data"].get("game_speed", GameSpeed.option_default)
-            self.disable_forced_camera = args["slot_data"].get("disable_forced_camera", DisableForcedCamera.default)
-            self.skip_cutscenes = args["slot_data"].get("skip_cutscenes", SkipCutscenes.default)
             self.all_in_choice = args["slot_data"]["all_in_map"]
             self.slot_data_version = args["slot_data"].get("version", 2)
 
@@ -820,7 +880,7 @@ class SC2Context(CommonContext):
                 self.slot_data_version,
                 args["slot_data"].get("player_color_nova", ColorChoice.option_dark_grey)
             )
-            self.war_council_nerfs = args["slot_data"].get("war_council_nerfs", WarCouncilNerfs.option_false)
+            self.show_war_council_nerfs = args["slot_data"].get("war_council_nerfs", WarCouncilNerfs.option_false)
             self.mercenary_highlanders = args["slot_data"].get("mercenary_highlanders", MercenaryHighlanders.option_false)
             self.generic_upgrade_missions = args["slot_data"].get("generic_upgrade_missions", GenericUpgradeMissions.default)
             self.max_upgrade_level = args["slot_data"].get("max_upgrade_level", MaxUpgradeLevel.default)

--- a/worlds/sc2/client.py
+++ b/worlds/sc2/client.py
@@ -575,11 +575,21 @@ class StarcraftClientProcessor(ClientCommandProcessor):
             force_settings_save_on_close()
         sc2_logger.info(f"Windowed mode is: {SC2World.settings.game_windowed_mode}")
 
-    def _cmd_disable_mission_check(self) -> bool:
-        """Disables the check to see if a mission is available to play.  Meant for co-op runs where one player can play
-        the next mission in a chain the other player is doing."""
-        self.ctx.missions_unlocked = True
-        sc2_logger.info("Mission check has been disabled")
+    @mark_raw
+    def _cmd_mission_check(self, enable_or_disable: str = "") -> bool:
+        """
+        If disabled, allows playing missions even if they are not unlocked.
+        """
+        if enable_or_disable.casefold() in ("n", "no", "f", "false", "-", "disable", "disabled"):
+            if (not self.ctx.missions_unlocked) and self.ctx.ui:
+                self.ctx.ui.pending_redraw = True
+            self.ctx.missions_unlocked = True
+            sc2_logger.info("Mission check has been disabled")
+        else:
+            if self.ctx.missions_unlocked and self.ctx.ui:
+                self.ctx.ui.pending_redraw = True
+            self.ctx.missions_unlocked = False
+            sc2_logger.info("Mission check has been enabled")
         return True
 
     @mark_raw

--- a/worlds/sc2/client_gui.py
+++ b/worlds/sc2/client_gui.py
@@ -23,8 +23,10 @@ from .client import SC2Context, calc_unfinished_nodes, is_mission_available, com
 from .item.item_descriptions import item_descriptions
 from .item.item_annotations import ITEM_NAME_ANNOTATIONS
 from .mission_order.entry_rules import RuleData, SubRuleRuleData, ItemRuleData
-from .mission_tables import lookup_id_to_mission, campaign_race_exceptions, \
-    SC2Mission, SC2Race
+from .mission_tables import (
+    lookup_id_to_mission, campaign_race_exceptions,
+    SC2Mission, SC2Race,
+)
 from .locations import LocationType, lookup_location_id_to_type, lookup_location_id_to_flags
 from .options import LocationInclusion, MissionOrderScouting
 from . import SC2World
@@ -140,7 +142,7 @@ class SC2Manager(GameManager):
     mission_buttons: List[MissionButton] = []
     launching: Union[bool, int] = False  # if int -> mission ID
     refresh_from_launching = True
-    first_check = True
+    pending_redraw = True
     first_mission = ""
     button_colors: Dict[SC2Race, Tuple[float, float, float]] = {}
     ctx: SC2Context
@@ -218,7 +220,7 @@ class SC2Manager(GameManager):
             and not hovering_tooltip
             or not self.refresh_from_launching
             or self.last_data_out_of_date != self.ctx.data_out_of_date
-            or self.first_check
+            or self.pending_redraw
         )
         self.last_shown_tooltip = shown_tooltip
         if not needs_redraw:
@@ -246,7 +248,7 @@ class SC2Manager(GameManager):
 
         self.last_checked_locations = self.ctx.checked_locations.copy()
         self.last_items_received = sorted_items_received
-        self.first_check = False
+        self.pending_redraw = False
 
         self.mission_buttons = []
 
@@ -667,7 +669,7 @@ class SC2Manager(GameManager):
             return " [color=AF99EF](Progression)[/color]"
         if ItemClassification.useful & item_classification_key:
             return " [color=6D8BE8](Useful)[/color]"
-        if SC2World.settings.show_traps and ItemClassification.trap & item_classification_key:
+        if SC2World.settings.scouting_show_traps and ItemClassification.trap & item_classification_key:
             return " [color=FA8072](Trap)[/color]"
         return " [color=00EEEE](Filler)[/color]"
 

--- a/worlds/sc2/options.py
+++ b/worlds/sc2/options.py
@@ -104,20 +104,6 @@ class GameSpeed(Choice):
     default = option_default
 
 
-class DisableForcedCamera(DefaultOnToggle):
-    """
-    Prevents the game from moving or locking the camera without the player's consent.
-    """
-    display_name = "Disable Forced Camera Movement"
-
-
-class SkipCutscenes(Toggle):
-    """
-    Skips all cutscenes and prevents dialog from blocking progress.
-    """
-    display_name = "Skip Cutscenes"
-
-
 class AllInMap(Choice):
     """Determines what version of All-In (WoL final map) that will be generated for the campaign."""
     display_name = "All In Map"
@@ -715,7 +701,7 @@ class KerriganMaxPassiveAbilities(Range):
     default = range_end
 
 
-class EnableMorphling(Toggle):
+class EnableMorphling(DefaultOnToggle):
     """
     Determines whether the player can build Morphlings, which allow for inefficient morphing of advanced units
     like Ravagers and Lurkers without requiring the base unit to be unlocked first.
@@ -857,7 +843,7 @@ class GrantStoryTech(Choice):
 
 class GrantStoryLevels(Choice):
     """
-    If enabled, grants Kerrigan the required minimum levels for the following missions:
+    If enabled, grants Kerrigan the required minimum levels for the following missions for Supreme and Infinite Cycle.
     Supreme: 35
     The Infinite Cycle: 70
     The bonus levels only apply during the listed missions, and can exceed the Total Level Cap.
@@ -1365,8 +1351,6 @@ class Starcraft2Options(PerGameCommonOptions):
     game_difficulty: GameDifficulty
     difficulty_damage_modifier: DifficultyDamageModifier
     game_speed: GameSpeed
-    disable_forced_camera: DisableForcedCamera
-    skip_cutscenes: SkipCutscenes
     all_in_map: AllInMap
     mission_order: MissionOrder
     maximum_campaign_size: MaximumCampaignSize

--- a/worlds/sc2/presets.py
+++ b/worlds/sc2/presets.py
@@ -1,15 +1,13 @@
 from typing import Any, Dict
 
-import Options as ap_options
-from .. import options
 from Options import Accessibility, ProgressionBalancing
-from .. import item_names
-from ..mission_tables import SC2Race, SC2Campaign
-from ..tables import NovaPresenceOptions
+from . import item_names
+from .mission_tables import SC2Race, SC2Campaign
+from .tables import NovaPresenceOptions
 
-from ..options import ( 
+from .options import ( 
     # avoid import *
-    GameDifficulty, DifficultyDamageModifier, GameSpeed, DisableForcedCamera, SkipCutscenes, AllInMap, MissionOrder, 
+    GameDifficulty, DifficultyDamageModifier, GameSpeed, AllInMap, MissionOrder, 
     MaximumCampaignSize, TwoStartPositions, KeyMode, PlayerColorTerranRaynor, PlayerColorProtoss, PlayerColorZerg, 
     PlayerColorZergPrimal, PlayerColorNova, SelectedRaces, EnabledCampaigns, EnableRaceSwapVariants, EnableMissionRaceBalancing, 
     ShuffleCampaigns, ShuffleNoBuild, StarterUnit, RequiredTactics, EnableVoidTrade, VoidTradeAgeLimit, VoidTradeWorkers, 

--- a/worlds/sc2/settings.py
+++ b/worlds/sc2/settings.py
@@ -21,9 +21,6 @@ class Starcraft2Settings(settings.Group):
     class WindowHeight(int):
         """The starting height the client window in pixels"""
 
-    class GameWindowedMode(settings.Bool):
-        """Controls whether the game should start in windowed mode"""
-
     class TerranButtonColor(list):
         """Defines the colour of terran mission buttons in the launcher in rgb format (3 elements ranging from 0 to 1)"""
 
@@ -33,11 +30,14 @@ class Starcraft2Settings(settings.Group):
     class ProtossButtonColor(list):
         """Defines the colour of protoss mission buttons in the launcher in rgb format (3 elements ranging from 0 to 1)"""
 
-    class DisableForcedCamera(str):
-        """Overrides the disable forced-camera slot option. Possible values: `true`, `false`, `default`. Default uses slot value"""
+    class GameWindowedMode(settings.Bool):
+        """Controls whether the game should start in windowed mode"""
 
-    class SkipCutscenes(str):
-        """Overrides the skip cutscenes slot option. Possible values: `true`, `false`, `default`. Default uses slot value"""
+    class GameDisableForcedCamera(settings.Bool):
+        """Stops the game from ever taking control over the player's camera"""
+
+    class GameSkipCutscenes(settings.Bool):
+        """Automatically skips all cutscenes except mission end cutscenes. Stops dialogue from halting progress"""
 
     class GameDifficulty(str):
         """Overrides the slot's difficulty setting. Possible values: `casual`, `normal`, `hard`, `brutal`, `default`. Default uses slot value"""
@@ -45,7 +45,7 @@ class Starcraft2Settings(settings.Group):
     class GameSpeed(str):
         """Overrides the slot's gamespeed setting. Possible values: `slower`, `slow`, `normal`, `fast`, `faster`, `default`. Default uses slot value"""
 
-    class ShowTraps(settings.Bool):
+    class ScoutingShowTraps(settings.Bool):
         """If set to true, in-client scouting will show traps as distinct from filler"""
 
     # Client options
@@ -55,15 +55,17 @@ class Starcraft2Settings(settings.Group):
     wine_prefix: WinePrefix = WinePrefix("")
     window_width: WindowWidth = WindowWidth(1080)
     window_height: WindowHeight = WindowHeight(720)
-    game_windowed_mode: Union[GameWindowedMode, bool] = False
-    show_traps: Union[ShowTraps, bool] = False
+    scouting_show_traps: ScoutingShowTraps | bool = False
 
     terran_button_color: TerranButtonColor = TerranButtonColor([0.0838, 0.2898, 0.2346])
     zerg_button_color: ZergButtonColor = ZergButtonColor([0.345, 0.22425, 0.12765])
     protoss_button_color: ProtossButtonColor = ProtossButtonColor([0.18975, 0.2415, 0.345])
 
+    # Game options
+    game_windowed_mode: GameWindowedMode | bool = False
+    game_disable_forced_camera: GameDisableForcedCamera | bool = True
+    game_skip_cutscenes: GameSkipCutscenes | bool = True
+
     # Options overrides
-    disable_forced_camera: DisableForcedCamera = DisableForcedCamera("default")
-    skip_cutscenes: SkipCutscenes = SkipCutscenes("default")
     game_difficulty: GameDifficulty = GameDifficulty("default")
     game_speed: GameSpeed = GameSpeed("default")


### PR DESCRIPTION
## What is this fixing or adding?
First pass of the great options refactor. This focuses on laying groundwork of moving some options to settings / host.yaml.

* Moved skip_cutscenes and no_force_camera from options to settings
* Support modifying settings from /option
* /option help text slightly condensed
* Morphlings now default on
* Some settings were renamed
  * show_traps -> scouting_show_traps
  * disable_forced_camera -> game_disable_forced_camera
  * skip_cutscenes -> game_skip_cutscenes
* `/disable_mission_check` changed to `/mission_check [disable|enable]` to allow re-enabling and to ensure a stack trace didn't show if any arguments were given
* All sc2 client commands were annotated `@mark_raw` to ensure a stack trace wouldn't show if too many arguments were given by the user

## How was this tested?
Ran `/option` a bunch:
* No arguments displays help text
* One argument shows the current state of that setting
* Second argument sets that setting
* Changing something in host.yaml persists the change
* Passing too many arguments now provides an error message rather than a stack trace

## If this makes graphical changes, please attach screenshots.
<img width="1789" height="1118" alt="image" src="https://github.com/user-attachments/assets/da886a96-4fd8-44f8-bdb8-d8f2c894fef4" />

<img width="488" height="507" alt="image" src="https://github.com/user-attachments/assets/65e4e1f3-00f3-4450-9d4f-b92bd0287257" />
