### PR TITLE
sc2: Trying to fix windows-specific encoding error with tasklist

### DIFF
--- a/worlds/sc2/apclient/banks.py
+++ b/worlds/sc2/apclient/banks.py
@@ -211,10 +211,10 @@ def file_cleanup() -> None | Error[str]:
     bank_folder = user_paths.get_bank_folder()
     if isinstance(bank_folder, Error):
         return bank_folder
-    Path(f"{user_paths.get_bank_folder()}/{BANK_CORE_OPTIONS_FILE_NAME}.SC2Bank").unlink(missing_ok=True)
-    Path(f"{user_paths.get_bank_folder()}/{BANK_LOCATIONS_FILE_NAME}.SC2Bank").unlink(missing_ok=True)
-    Path(f"{user_paths.get_bank_folder()}/{BANK_TRADE_RECEIVE_FILE_NAME}.SC2Bank").unlink(missing_ok=True)
-    Path(f"{user_paths.get_bank_folder()}/{BANK_MESSAGES_FILE_NAME}.SC2Bank").unlink(missing_ok=True)
+    Path(f"{bank_folder}/{BANK_CORE_OPTIONS_FILE_NAME}.SC2Bank").unlink(missing_ok=True)
+    Path(f"{bank_folder}/{BANK_LOCATIONS_FILE_NAME}.SC2Bank").unlink(missing_ok=True)
+    Path(f"{bank_folder}/{BANK_TRADE_RECEIVE_FILE_NAME}.SC2Bank").unlink(missing_ok=True)
+    Path(f"{bank_folder}/{BANK_MESSAGES_FILE_NAME}.SC2Bank").unlink(missing_ok=True)
     return None
 
 

--- a/worlds/sc2/apclient/game_client.py
+++ b/worlds/sc2/apclient/game_client.py
@@ -561,12 +561,26 @@ def linux_get_sc2_pid() -> int | None:
     return None
 
 
+def try_decode(line: bytes, encoding: str) -> str | None:
+    try:
+        return line.decode(encoding)
+    except UnicodeDecodeError:
+        return None
+
+
 def windows_get_sc2_pid() -> int | None:
     result_bytes = subprocess.check_output(["tasklist"])
-    lines = result_bytes.decode("utf-8").split("\n")
-    for line in lines:
-        if "SC2_x64.exe" not in line:
+    lines = result_bytes.split(b"\r\n")
+    for line_bytes in lines:
+        if b"SC2_x64.exe" not in line_bytes:
             continue
+        line = try_decode(line_bytes, "utf-8")
+        if line is None:
+            line = try_decode(line_bytes, "cp437")  # Windows why?
+        if line is None:
+            logger.warning(f"Unable to decode PID line {line_bytes!r}")
+            continue
+
         parts = [p for p in line.split() if p]
         # Format: Image Name, PID, Session Name, Session#, Mem Usage
         if len(parts) < 2:


### PR DESCRIPTION
## What is this fixing or adding?
Trying to fix the Unicode Decode error a couple of users have reported recently on map startup.

The hypothesis for the root cause is that when trying to get the sc2 pid, we call `tasklist`, which can return non-ascii characters. We decode the whole output before processing it, so if any process has any non-utf-8 character, it will cause a UnicodeDecodeError, and that's what the users are experiencing.

I reproduced a toy example of that on a Windows machine I have access to, but can't run Archipelago on it so can't test fully if this is the issue. From what I could tell trying things on that machine, `cp437` encoding gave the more correct results when decoding a tasklist line containing non-ascii characters (tested with ™ and ÿ). However, this codepage is apparently configurable with a registry setting, and we probably don't need the exact line so long as the numbers are correct and no new whitespaces are introduced, so I tried to keep using utf-8 and falling back to cp437 if that fails.

Some other minor fixes:
* adding `__init__.py` to the apclient package; some core unit tests complained about that when I ran them.
* Minor change to use the result of a function call in a function rather than assuming it wouldn't error if it didn't error the first time

## How was this tested?
It wasn't; I'm on Linux and don't have access to a Windows machine I can test on.

## If this makes graphical changes, please attach screenshots.
None