### PR TITLE
sc2: Rules cleanup 1

### DIFF
--- a/worlds/sc2/__init__.py
+++ b/worlds/sc2/__init__.py
@@ -160,7 +160,7 @@ class SC2World(World):
         # TODO (Snarky): Make work with Hero Presence
         # if (
         #     NovaPresenceOptions.GHOST_OF_A_CHANCE_AUTO in self.options.nova_presence
-        #     and MissionFlag.Nova in self.custom_mission_order.get_used_flags() 
+        #     and MissionFlag.Nova in self.custom_mission_order.get_used_flags()
         #     and not self.logic.nova_items_granted
         # ):
         #     # check if Nova is used anywhere and just modify the option
@@ -481,7 +481,7 @@ def create_and_flag_explicit_item_locks_and_excludes(world: SC2World) -> list[Fi
         if max_count and count > max_count:
             return max_count
         return count
-    
+
     auto_excludes = Counter({item_name: 1 for item_name in item_groups.legacy_items})
     if world.options.exclude_overpowered_items.value == ExcludeOverpoweredItems.option_true:
         for item_name in item_groups.overpowered_items:
@@ -722,6 +722,7 @@ def flag_mission_based_item_excludes(world: SC2World, item_list: list[FilterItem
     remove_kerrigan_items = (len(kerrigan_missions) <= 1) and not kerrigan_build_missions
     remove_nova_items =  (len(nova_missions) <= 1) and not nova_build_missions
     remove_artanis_items = (len(artanis_missions) <= 1) and not artanis_build_missions
+    assert world.logic is not None
     world.logic.kerrigan_items_granted = remove_kerrigan_items
     world.logic.kerrigan_levels_granted = remove_kerrigan_items
     world.logic.nova_items_granted = remove_nova_items
@@ -942,7 +943,7 @@ def flag_start_unit(world: SC2World, item_list: list[FilterItem], starter_unit: 
         #         support_item.flags |= ItemFilterFlags.StartInventory
         #     if item_names.NOVA_JUMP_SUIT_MODULE in possible_starter_items:
         #         possible_starter_items[item_names.NOVA_JUMP_SUIT_MODULE].flags |= ItemFilterFlags.StartInventory
-        # if ( MissionFlag.Nova in first_mission.flags 
+        # if ( MissionFlag.Nova in first_mission.flags
         #     and (
         #         MissionFlag.Terran in first_mission.flags and NovaPresenceOptions.NCO_TERRAN in world.options.nova_presence
         #             or MissionFlag.Zerg in first_mission.flags and NovaPresenceOptions.NCO_ZERG in world.options.nova_presence
@@ -1184,7 +1185,7 @@ def fill_pool_with_kerrigan_levels(world: SC2World, item_pool: list[StarcraftIte
         or (world.options.grant_story_levels and not world.logic.kerrigan_build_missions)
     ):
         return
-    
+
     def add_kerrigan_level_items(level_amount: int, item_amount: int):
         name = f"{level_amount} Kerrigan Level"
         if level_amount > 1:

--- a/worlds/sc2/__init__.py
+++ b/worlds/sc2/__init__.py
@@ -384,47 +384,47 @@ def pack_hero_presence(presence: dict[SC2Campaign, dict[SC2Race, HeroFlag]]) -> 
     return result
 
 
-def calculate_hero_presence(presence: HeroPresence, heroes: HeroFlag) -> dict[SC2Campaign, dict[SC2Race, HeroFlag]]:
-        races = [race for race in SC2Race if race != SC2Race.ANY]
-        campaigns = [campaign for campaign in SC2Campaign if campaign != SC2Campaign.GLOBAL]
-        kerrigan_flag = HeroFlag.KERRIGAN if HeroOptions.KERRIGAN in heroes else HeroFlag.NONE
-        nova_flag = HeroFlag.NOVA if HeroOptions.NOVA in heroes else HeroFlag.NONE
-        artanis_flag = HeroFlag.ARTANIS if HeroOptions.ARTANIS in heroes else HeroFlag.NONE
-        all_flag = kerrigan_flag | nova_flag | artanis_flag
-        race_flag = {
-            SC2Race.ZERG: kerrigan_flag,
-            SC2Race.TERRAN: nova_flag,
-            SC2Race.PROTOSS: artanis_flag,
-        }
-        result = {campaign: {race: HeroFlag.NONE for race in races} for campaign in campaigns}
-        if presence == HeroPresence.option_anywhere:
-            for campaign in campaigns:
-                for race in races:
-                    result[campaign][race] = all_flag
-        elif presence == HeroPresence.option_same_race:
-            for campaign in campaigns:
-                for race in races:
-                    result[campaign][race] = race_flag[race]
-        elif presence == HeroPresence.option_original_race:
+def calculate_hero_presence(presence: int, heroes: set[str]) -> dict[SC2Campaign, dict[SC2Race, HeroFlag]]:
+    races = [race for race in SC2Race if race != SC2Race.ANY]
+    campaigns = [campaign for campaign in SC2Campaign if campaign != SC2Campaign.GLOBAL]
+    kerrigan_flag = HeroFlag.KERRIGAN if HeroOptions.KERRIGAN in heroes else HeroFlag.NONE
+    nova_flag = HeroFlag.NOVA if HeroOptions.NOVA in heroes else HeroFlag.NONE
+    artanis_flag = HeroFlag.ARTANIS if HeroOptions.ARTANIS in heroes else HeroFlag.NONE
+    all_flag = kerrigan_flag | nova_flag | artanis_flag
+    race_flag = {
+        SC2Race.ZERG: kerrigan_flag,
+        SC2Race.TERRAN: nova_flag,
+        SC2Race.PROTOSS: artanis_flag,
+    }
+    result = {campaign: {race: HeroFlag.NONE for race in races} for campaign in campaigns}
+    if presence == HeroPresence.option_anywhere:
+        for campaign in campaigns:
             for race in races:
-                result[SC2Campaign.HOTS][race] = kerrigan_flag
-                result[SC2Campaign.WOL][race] = nova_flag
-                result[SC2Campaign.NCO][race] = nova_flag
-                result[SC2Campaign.LOTV][race] = artanis_flag
-                result[SC2Campaign.PROLOGUE][race] = artanis_flag
-                result[SC2Campaign.PROPHECY][race] = artanis_flag
-        elif presence == HeroPresence.option_vanilla:
-            result[SC2Campaign.HOTS][SC2Race.ZERG] = kerrigan_flag
-            result[SC2Campaign.NCO][SC2Race.TERRAN] = nova_flag
-        elif presence == HeroPresence.option_vanilla_raceswap:
+                result[campaign][race] = all_flag
+    elif presence == HeroPresence.option_same_race:
+        for campaign in campaigns:
             for race in races:
-                result[SC2Campaign.HOTS][race] = race_flag[race]
-                result[SC2Campaign.NCO][race] = race_flag[race]
-        elif presence == HeroPresence.option_vanilla_original_race:
-            for race in races:
-                result[SC2Campaign.HOTS][race] = kerrigan_flag
-                result[SC2Campaign.NCO][race] = nova_flag
-        return result
+                result[campaign][race] = race_flag[race]
+    elif presence == HeroPresence.option_original_race:
+        for race in races:
+            result[SC2Campaign.HOTS][race] = kerrigan_flag
+            result[SC2Campaign.WOL][race] = nova_flag
+            result[SC2Campaign.NCO][race] = nova_flag
+            result[SC2Campaign.LOTV][race] = artanis_flag
+            result[SC2Campaign.PROLOGUE][race] = artanis_flag
+            result[SC2Campaign.PROPHECY][race] = artanis_flag
+    elif presence == HeroPresence.option_vanilla:
+        result[SC2Campaign.HOTS][SC2Race.ZERG] = kerrigan_flag
+        result[SC2Campaign.NCO][SC2Race.TERRAN] = nova_flag
+    elif presence == HeroPresence.option_vanilla_raceswap:
+        for race in races:
+            result[SC2Campaign.HOTS][race] = race_flag[race]
+            result[SC2Campaign.NCO][race] = race_flag[race]
+    elif presence == HeroPresence.option_vanilla_original_race:
+        for race in races:
+            result[SC2Campaign.HOTS][race] = kerrigan_flag
+            result[SC2Campaign.NCO][race] = nova_flag
+    return result
 
 
 def _get_column_display(index: int, single_row_layout: bool) -> str:

--- a/worlds/sc2/item/item_tables.py
+++ b/worlds/sc2/item/item_tables.py
@@ -557,7 +557,7 @@ item_table = {
                  parent=item_names.WRAITH),
     item_names.WRAITH_RESOURCE_EFFICIENCY:
         ItemData(333 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Armory_4, 14, SC2Race.TERRAN,
-                 parent=item_names.WRAITH),
+                 classification=ItemClassification.progression, parent=item_names.WRAITH),
     item_names.VIKING_SHREDDER_ROUNDS:
         ItemData(334 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Armory_4, 15, SC2Race.TERRAN,
                  classification=ItemClassification.progression, parent=item_names.VIKING),
@@ -958,7 +958,7 @@ item_table = {
                  parent=item_names.GHOST),
     item_names.SPECTRE_BARGAIN_BIN_PRICES:
         ItemData(768 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Armory_7, 22, SC2Race.TERRAN,
-                 parent=item_names.SPECTRE), 
+                 parent=item_names.SPECTRE),
     item_names.WARHOUND_BRAWLER_CONFIGURATION:
         ItemData(769 + SC2WOL_ITEM_ID_OFFSET, TerranItemType.Armory_7, 23, SC2Race.TERRAN,
                  parent=item_names.WARHOUND),
@@ -1426,7 +1426,7 @@ item_table = {
         ItemData(309 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Morph, 3, SC2Race.ZERG,
                  classification=ItemClassification.progression, parent=parent_names.MORPH_SOURCE_AIR),
     item_names.SWARM_HOST_CARRION_STRAIN:
-        ItemData(310 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Strain, 10, SC2Race.ZERG, 
+        ItemData(310 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Strain, 10, SC2Race.ZERG,
                  classification=ItemClassification.progression, parent=item_names.SWARM_HOST),
     item_names.SWARM_HOST_CREEPER_STRAIN:
         ItemData(311 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Strain, 11, SC2Race.ZERG, parent=item_names.SWARM_HOST),
@@ -1520,17 +1520,17 @@ item_table = {
         ItemData(389 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_5, 16, SC2Race.ZERG, parent=item_names.BULLFROG),
     item_names.BULLFROG_RANGE:
         ItemData(390 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_5, 17, SC2Race.ZERG, parent=item_names.BULLFROG),
-    item_names.SPORE_CRAWLER_BIO_BONUS: 
+    item_names.SPORE_CRAWLER_BIO_BONUS:
         ItemData(391 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_5, 18, SC2Race.ZERG, parent=item_names.SPORE_CRAWLER),
-    item_names.CORRUPTOR_ACID_SPLASH: 
+    item_names.CORRUPTOR_ACID_SPLASH:
         ItemData(392 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_5, 19, SC2Race.ZERG, parent=item_names.CORRUPTOR),
-    item_names.IMPALER_DISTRIBUTED_ATTACK: 
+    item_names.IMPALER_DISTRIBUTED_ATTACK:
         ItemData(393 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_5, 20, SC2Race.ZERG, parent=item_names.IMPALER),
-    item_names.IMPALER_TENTACLE_EXTENSIONS: 
+    item_names.IMPALER_TENTACLE_EXTENSIONS:
         ItemData(394 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_5, 21, SC2Race.ZERG, parent=item_names.IMPALER),
-    item_names.IMPALER_DEEP_TUNNEL: 
+    item_names.IMPALER_DEEP_TUNNEL:
         ItemData(395 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_5, 22, SC2Race.ZERG, parent=item_names.IMPALER),
-    item_names.HIVE_QUEEN_PSIONIC_MITOCHONDRIA: 
+    item_names.HIVE_QUEEN_PSIONIC_MITOCHONDRIA:
         ItemData(396 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_5, 23, SC2Race.ZERG, parent=item_names.HIVE_QUEEN),
     item_names.HIVE_QUEEN_STRAIN_INJECTION:
         ItemData(397 + SC2HOTS_ITEM_ID_OFFSET, ZergItemType.Mutation_5, 24, SC2Race.ZERG, parent=item_names.HIVE_QUEEN),
@@ -1618,16 +1618,16 @@ item_table = {
     item_names.ZEALOT:
         ItemData(700 + SC2WOL_ITEM_ID_OFFSET, ProtossItemType.Unit, 0, SC2Race.PROTOSS,
                  classification=ItemClassification.progression),
-    item_names.STALKER: 
-        ItemData(701 + SC2WOL_ITEM_ID_OFFSET, ProtossItemType.Unit, 1, SC2Race.PROTOSS, 
+    item_names.STALKER:
+        ItemData(701 + SC2WOL_ITEM_ID_OFFSET, ProtossItemType.Unit, 1, SC2Race.PROTOSS,
                  classification=ItemClassification.progression),
-    item_names.HIGH_TEMPLAR: 
-        ItemData(702 + SC2WOL_ITEM_ID_OFFSET, ProtossItemType.Unit, 2, SC2Race.PROTOSS, 
+    item_names.HIGH_TEMPLAR:
+        ItemData(702 + SC2WOL_ITEM_ID_OFFSET, ProtossItemType.Unit, 2, SC2Race.PROTOSS,
                  classification=ItemClassification.progression),
-    item_names.DARK_TEMPLAR: 
-        ItemData(703 + SC2WOL_ITEM_ID_OFFSET, ProtossItemType.Unit, 3, SC2Race.PROTOSS, 
+    item_names.DARK_TEMPLAR:
+        ItemData(703 + SC2WOL_ITEM_ID_OFFSET, ProtossItemType.Unit, 3, SC2Race.PROTOSS,
                  classification=ItemClassification.progression),
-    item_names.IMMORTAL: 
+    item_names.IMMORTAL:
         ItemData(704 + SC2WOL_ITEM_ID_OFFSET, ProtossItemType.Unit, 4, SC2Race.PROTOSS,
                  classification=ItemClassification.progression),
     item_names.COLOSSUS:

--- a/worlds/sc2/locations.py
+++ b/worlds/sc2/locations.py
@@ -5084,9 +5084,6 @@ def get_locations(world: Optional["SC2World"]) -> Tuple[LocationData, ...]:
             "Gas Pickups",
             SC2NCO_LOC_ID_OFFSET + 204,
             LocationType.EXTRA,
-            lambda state: (
-                logic.advanced_tactics or logic.sudden_strike_requirement(state)
-            ),
         ),
         make_location_data(
             SC2Mission.SUDDEN_STRIKE.mission_name,
@@ -9725,10 +9722,7 @@ def get_locations(world: Optional["SC2World"]) -> Tuple[LocationData, ...]:
             "Victory",
             SC2_RACESWAP_LOC_ID_OFFSET + 6700,
             LocationType.VICTORY,
-            lambda state: (
-                logic.terran_common_unit(state)
-                and logic.terran_competent_anti_air(state)
-            ),
+            logic.terran_common_unit_competent_aa,
             hard_rule=logic.terran_any_anti_air,
         ),
         make_location_data(
@@ -9736,37 +9730,28 @@ def get_locations(world: Optional["SC2World"]) -> Tuple[LocationData, ...]:
             "East Stasis Chamber",
             SC2_RACESWAP_LOC_ID_OFFSET + 6701,
             LocationType.VANILLA,
-            lambda state: (
-                logic.terran_common_unit(state)
-                and logic.terran_competent_anti_air(state)
-            ),
+            logic.terran_common_unit_competent_aa,
         ),
         make_location_data(
             SC2Mission.SHOOT_THE_MESSENGER_T.mission_name,
             "Center Stasis Chamber",
             SC2_RACESWAP_LOC_ID_OFFSET + 6702,
             LocationType.VANILLA,
-            lambda state: logic.terran_common_unit(state) or adv_tactics,
+            logic.terran_common_unit_or_advanced_tactics,
         ),
         make_location_data(
             SC2Mission.SHOOT_THE_MESSENGER_T.mission_name,
             "West Stasis Chamber",
             SC2_RACESWAP_LOC_ID_OFFSET + 6703,
             LocationType.VANILLA,
-            lambda state: (
-                logic.terran_common_unit(state)
-                and logic.terran_competent_anti_air(state)
-            ),
+            logic.terran_common_unit_competent_aa,
         ),
         make_location_data(
             SC2Mission.SHOOT_THE_MESSENGER_T.mission_name,
             "Destroy 4 Shuttles",
             SC2_RACESWAP_LOC_ID_OFFSET + 6704,
             LocationType.EXTRA,
-            lambda state: (
-                logic.terran_common_unit(state)
-                and logic.terran_competent_anti_air(state)
-            ),
+            logic.terran_common_unit_competent_aa,
             hard_rule=logic.terran_any_anti_air,
         ),
         make_location_data(
@@ -9787,23 +9772,21 @@ def get_locations(world: Optional["SC2World"]) -> Tuple[LocationData, ...]:
             "Southeast Frozen Group",
             SC2_RACESWAP_LOC_ID_OFFSET + 6707,
             LocationType.EXTRA,
-            lambda state: logic.terran_common_unit(state) or adv_tactics,
+            logic.terran_common_unit_or_advanced_tactics,
         ),
         make_location_data(
             SC2Mission.SHOOT_THE_MESSENGER_T.mission_name,
             "West Frozen Group",
             SC2_RACESWAP_LOC_ID_OFFSET + 6708,
             LocationType.EXTRA,
-            lambda state: logic.terran_common_unit(state)
-            and logic.terran_competent_anti_air(state),
+            logic.terran_common_unit_competent_aa,
         ),
         make_location_data(
             SC2Mission.SHOOT_THE_MESSENGER_T.mission_name,
             "East Frozen Group",
             SC2_RACESWAP_LOC_ID_OFFSET + 6709,
             LocationType.EXTRA,
-            lambda state: logic.terran_common_unit(state)
-            and logic.terran_competent_anti_air(state),
+            logic.terran_common_unit_competent_aa,
         ),
         make_location_data(
             SC2Mission.SHOOT_THE_MESSENGER_T.mission_name,
@@ -9841,10 +9824,7 @@ def get_locations(world: Optional["SC2World"]) -> Tuple[LocationData, ...]:
             "Victory",
             SC2_RACESWAP_LOC_ID_OFFSET + 6800,
             LocationType.VICTORY,
-            lambda state: (
-                logic.protoss_common_unit(state)
-                and logic.protoss_anti_armor_anti_air(state)
-            ),
+            logic.protoss_common_unit_anti_armor_air,
             hard_rule=logic.protoss_any_anti_air_unit,
         ),
         make_location_data(
@@ -9852,37 +9832,28 @@ def get_locations(world: Optional["SC2World"]) -> Tuple[LocationData, ...]:
             "East Stasis Chamber",
             SC2_RACESWAP_LOC_ID_OFFSET + 6801,
             LocationType.VANILLA,
-            lambda state: (
-                logic.protoss_common_unit(state)
-                and logic.protoss_anti_armor_anti_air(state)
-            ),
+            logic.protoss_common_unit_anti_armor_air,
         ),
         make_location_data(
             SC2Mission.SHOOT_THE_MESSENGER_P.mission_name,
             "Center Stasis Chamber",
             SC2_RACESWAP_LOC_ID_OFFSET + 6802,
             LocationType.VANILLA,
-            lambda state: logic.protoss_common_unit(state) or adv_tactics,
+            logic.protoss_common_unit_or_advanced_tactics,
         ),
         make_location_data(
             SC2Mission.SHOOT_THE_MESSENGER_P.mission_name,
             "West Stasis Chamber",
             SC2_RACESWAP_LOC_ID_OFFSET + 6803,
             LocationType.VANILLA,
-            lambda state: (
-                logic.protoss_common_unit(state)
-                and logic.protoss_anti_armor_anti_air(state)
-            ),
+            logic.protoss_common_unit_anti_armor_air,
         ),
         make_location_data(
             SC2Mission.SHOOT_THE_MESSENGER_P.mission_name,
             "Destroy 4 Shuttles",
             SC2_RACESWAP_LOC_ID_OFFSET + 6804,
             LocationType.EXTRA,
-            lambda state: (
-                logic.protoss_common_unit(state)
-                and logic.protoss_anti_armor_anti_air(state)
-            ),
+            logic.protoss_common_unit_anti_armor_air,
             hard_rule=logic.protoss_any_anti_air_unit,
         ),
         make_location_data(
@@ -9903,27 +9874,21 @@ def get_locations(world: Optional["SC2World"]) -> Tuple[LocationData, ...]:
             "Southeast Frozen Group",
             SC2_RACESWAP_LOC_ID_OFFSET + 6807,
             LocationType.EXTRA,
-            lambda state: logic.protoss_common_unit(state) or adv_tactics,
+            logic.protoss_common_unit_or_advanced_tactics,
         ),
         make_location_data(
             SC2Mission.SHOOT_THE_MESSENGER_P.mission_name,
             "West Frozen Group",
             SC2_RACESWAP_LOC_ID_OFFSET + 6808,
             LocationType.EXTRA,
-            lambda state: (
-                logic.protoss_common_unit(state)
-                and logic.protoss_anti_armor_anti_air(state)
-            ),
+            logic.protoss_common_unit_anti_armor_air,
         ),
         make_location_data(
             SC2Mission.SHOOT_THE_MESSENGER_P.mission_name,
             "East Frozen Group",
             SC2_RACESWAP_LOC_ID_OFFSET + 6809,
             LocationType.EXTRA,
-            lambda state: (
-                logic.protoss_common_unit(state)
-                and logic.protoss_anti_armor_anti_air(state)
-            ),
+            logic.protoss_common_unit_anti_armor_air,
         ),
         make_location_data(
             SC2Mission.SHOOT_THE_MESSENGER_P.mission_name,
@@ -10069,8 +10034,7 @@ def get_locations(world: Optional["SC2World"]) -> Tuple[LocationData, ...]:
             "Victory",
             SC2_RACESWAP_LOC_ID_OFFSET + 7100,
             LocationType.VICTORY,
-            lambda state: logic.terran_common_unit(state)
-            and (logic.terran_basic_anti_air(state) or adv_tactics),
+            logic.terran_domination_requirement,
         ),
         make_location_data(
             SC2Mission.DOMINATION_T.mission_name,
@@ -10103,7 +10067,7 @@ def get_locations(world: Optional["SC2World"]) -> Tuple[LocationData, ...]:
             "South Bunker",
             SC2_RACESWAP_LOC_ID_OFFSET + 7105,
             LocationType.EXTRA,
-            lambda state: adv_tactics or logic.terran_common_unit(state),
+            logic.terran_common_unit_or_advanced_tactics,
         ),
         make_location_data(
             SC2Mission.DOMINATION_T.mission_name,
@@ -10117,8 +10081,7 @@ def get_locations(world: Optional["SC2World"]) -> Tuple[LocationData, ...]:
             "Southeast Bunker",
             SC2_RACESWAP_LOC_ID_OFFSET + 7107,
             LocationType.EXTRA,
-            lambda state: logic.terran_common_unit(state)
-            and (logic.terran_basic_anti_air(state) or adv_tactics),
+            logic.terran_domination_requirement,
         ),
         make_location_data(
             SC2Mission.DOMINATION_T.mission_name,
@@ -10132,8 +10095,7 @@ def get_locations(world: Optional["SC2World"]) -> Tuple[LocationData, ...]:
             "Northeast Bunker",
             SC2_RACESWAP_LOC_ID_OFFSET + 7109,
             LocationType.EXTRA,
-            lambda state: logic.terran_common_unit(state)
-            and (logic.terran_basic_anti_air(state) or adv_tactics),
+            logic.terran_domination_requirement,
         ),
         make_location_data(
             SC2Mission.DOMINATION_T.mission_name,
@@ -10148,8 +10110,7 @@ def get_locations(world: Optional["SC2World"]) -> Tuple[LocationData, ...]:
             "Victory",
             SC2_RACESWAP_LOC_ID_OFFSET + 7200,
             LocationType.VICTORY,
-            lambda state: logic.protoss_common_unit(state)
-            and (adv_tactics or logic.protoss_basic_anti_air(state)),
+            logic.protoss_domination_requirement,
         ),
         make_location_data(
             SC2Mission.DOMINATION_P.mission_name,
@@ -10182,7 +10143,7 @@ def get_locations(world: Optional["SC2World"]) -> Tuple[LocationData, ...]:
             "South Templar",
             SC2_RACESWAP_LOC_ID_OFFSET + 7205,
             LocationType.EXTRA,
-            lambda state: adv_tactics or logic.protoss_common_unit(state),
+            logic.protoss_common_unit_or_advanced_tactics,
         ),
         make_location_data(
             SC2Mission.DOMINATION_P.mission_name,
@@ -10196,8 +10157,7 @@ def get_locations(world: Optional["SC2World"]) -> Tuple[LocationData, ...]:
             "Southeast Templar",
             SC2_RACESWAP_LOC_ID_OFFSET + 7207,
             LocationType.EXTRA,
-            lambda state: logic.protoss_common_unit(state)
-            and (adv_tactics or logic.protoss_basic_anti_air(state)),
+            logic.protoss_domination_requirement,
         ),
         make_location_data(
             SC2Mission.DOMINATION_P.mission_name,
@@ -10211,8 +10171,7 @@ def get_locations(world: Optional["SC2World"]) -> Tuple[LocationData, ...]:
             "Northeast Templar",
             SC2_RACESWAP_LOC_ID_OFFSET + 7209,
             LocationType.EXTRA,
-            lambda state: logic.protoss_common_unit(state)
-            and (adv_tactics or logic.protoss_basic_anti_air(state)),
+            logic.protoss_domination_requirement,
         ),
         make_location_data(
             SC2Mission.DOMINATION_P.mission_name,
@@ -10227,9 +10186,7 @@ def get_locations(world: Optional["SC2World"]) -> Tuple[LocationData, ...]:
             "Victory",
             SC2_RACESWAP_LOC_ID_OFFSET + 7300,
             LocationType.VICTORY,
-            lambda state: (
-                logic.terran_common_unit(state) and logic.terran_competent_comp(state)
-            ),
+            logic.terran_competent_comp,
         ),
         make_location_data(
             SC2Mission.FIRE_IN_THE_SKY_T.mission_name,
@@ -10242,27 +10199,21 @@ def get_locations(world: Optional["SC2World"]) -> Tuple[LocationData, ...]:
             "North Biomass",
             SC2_RACESWAP_LOC_ID_OFFSET + 7302,
             LocationType.VANILLA,
-            lambda state: (
-                logic.terran_common_unit(state) and logic.terran_competent_comp(state)
-            ),
+            logic.terran_competent_comp,
         ),
         make_location_data(
             SC2Mission.FIRE_IN_THE_SKY_T.mission_name,
             "South Biomass",
             SC2_RACESWAP_LOC_ID_OFFSET + 7303,
             LocationType.VANILLA,
-            lambda state: (
-                logic.terran_common_unit(state) and logic.terran_competent_comp(state)
-            ),
+            logic.terran_competent_comp,
         ),
         make_location_data(
             SC2Mission.FIRE_IN_THE_SKY_T.mission_name,
             "Destroy 3 Gorgons",
             SC2_RACESWAP_LOC_ID_OFFSET + 7304,
             LocationType.EXTRA,
-            lambda state: (
-                logic.terran_common_unit(state) and logic.terran_competent_comp(state)
-            ),
+            logic.terran_competent_comp,
         ),
         make_location_data(
             SC2Mission.FIRE_IN_THE_SKY_T.mission_name,
@@ -10282,36 +10233,28 @@ def get_locations(world: Optional["SC2World"]) -> Tuple[LocationData, ...]:
             "North Rescue",
             SC2_RACESWAP_LOC_ID_OFFSET + 7307,
             LocationType.EXTRA,
-            lambda state: (
-                logic.terran_common_unit(state) and logic.terran_competent_comp(state)
-            ),
+            logic.terran_competent_comp,
         ),
         make_location_data(
             SC2Mission.FIRE_IN_THE_SKY_T.mission_name,
             "West Medic Rescue",
             SC2_RACESWAP_LOC_ID_OFFSET + 7308,
             LocationType.EXTRA,
-            lambda state: (
-                logic.terran_common_unit(state) and logic.terran_competent_comp(state)
-            ),
+            logic.terran_competent_comp,
         ),
         make_location_data(
             SC2Mission.FIRE_IN_THE_SKY_T.mission_name,
             "East Medic Rescue",
             SC2_RACESWAP_LOC_ID_OFFSET + 7309,
             LocationType.EXTRA,
-            lambda state: (
-                logic.terran_common_unit(state) and logic.terran_competent_comp(state)
-            ),
+            logic.terran_competent_comp,
         ),
         make_location_data(
             SC2Mission.FIRE_IN_THE_SKY_T.mission_name,
             "South Orbital Command Center",
             SC2_RACESWAP_LOC_ID_OFFSET + 7310,
             LocationType.CHALLENGE,
-            lambda state: (
-                logic.terran_common_unit(state) and logic.terran_competent_comp(state)
-            ),
+            logic.terran_competent_comp,
             flags=LocationFlag.BASEBUST,
         ),
         make_location_data(
@@ -10319,9 +10262,7 @@ def get_locations(world: Optional["SC2World"]) -> Tuple[LocationData, ...]:
             "Northwest Orbital Command Center",
             SC2_RACESWAP_LOC_ID_OFFSET + 7311,
             LocationType.CHALLENGE,
-            lambda state: (
-                logic.terran_common_unit(state) and logic.terran_competent_comp(state)
-            ),
+            logic.terran_competent_comp,
             flags=LocationFlag.BASEBUST,
         ),
         make_location_data(
@@ -10329,9 +10270,7 @@ def get_locations(world: Optional["SC2World"]) -> Tuple[LocationData, ...]:
             "Southeast Orbital Command Center",
             SC2_RACESWAP_LOC_ID_OFFSET + 7312,
             LocationType.CHALLENGE,
-            lambda state: (
-                logic.terran_common_unit(state) and logic.terran_competent_comp(state)
-            ),
+            logic.terran_competent_comp,
             flags=LocationFlag.BASEBUST,
         ),
         make_location_data(
@@ -10339,9 +10278,7 @@ def get_locations(world: Optional["SC2World"]) -> Tuple[LocationData, ...]:
             "Victory",
             SC2_RACESWAP_LOC_ID_OFFSET + 7400,
             LocationType.VICTORY,
-            lambda state: (
-                logic.protoss_common_unit(state) and logic.protoss_competent_comp(state)
-            ),
+            logic.protoss_competent_comp,
         ),
         make_location_data(
             SC2Mission.FIRE_IN_THE_SKY_P.mission_name,
@@ -10354,27 +10291,21 @@ def get_locations(world: Optional["SC2World"]) -> Tuple[LocationData, ...]:
             "North Biomass",
             SC2_RACESWAP_LOC_ID_OFFSET + 7402,
             LocationType.VANILLA,
-            lambda state: (
-                logic.protoss_common_unit(state) and logic.protoss_competent_comp(state)
-            ),
+            logic.protoss_competent_comp,
         ),
         make_location_data(
             SC2Mission.FIRE_IN_THE_SKY_P.mission_name,
             "South Biomass",
             SC2_RACESWAP_LOC_ID_OFFSET + 7403,
             LocationType.VANILLA,
-            lambda state: (
-                logic.protoss_common_unit(state) and logic.protoss_competent_comp(state)
-            ),
+            logic.protoss_competent_comp,
         ),
         make_location_data(
             SC2Mission.FIRE_IN_THE_SKY_P.mission_name,
             "Destroy 3 Gorgons",
             SC2_RACESWAP_LOC_ID_OFFSET + 7404,
             LocationType.EXTRA,
-            lambda state: (
-                logic.protoss_common_unit(state) and logic.protoss_competent_comp(state)
-            ),
+            logic.protoss_competent_comp,
         ),
         make_location_data(
             SC2Mission.FIRE_IN_THE_SKY_P.mission_name,
@@ -10394,36 +10325,28 @@ def get_locations(world: Optional["SC2World"]) -> Tuple[LocationData, ...]:
             "North Rescue",
             SC2_RACESWAP_LOC_ID_OFFSET + 7407,
             LocationType.EXTRA,
-            lambda state: (
-                logic.protoss_common_unit(state) and logic.protoss_competent_comp(state)
-            ),
+            logic.protoss_competent_comp,
         ),
         make_location_data(
             SC2Mission.FIRE_IN_THE_SKY_P.mission_name,
             "West Energizer Rescue",
             SC2_RACESWAP_LOC_ID_OFFSET + 7408,
             LocationType.EXTRA,
-            lambda state: (
-                logic.protoss_common_unit(state) and logic.protoss_competent_comp(state)
-            ),
+            logic.protoss_competent_comp,
         ),
         make_location_data(
             SC2Mission.FIRE_IN_THE_SKY_P.mission_name,
             "East Energizer Rescue",
             SC2_RACESWAP_LOC_ID_OFFSET + 7409,
             LocationType.EXTRA,
-            lambda state: (
-                logic.protoss_common_unit(state) and logic.protoss_competent_comp(state)
-            ),
+            logic.protoss_competent_comp,
         ),
         make_location_data(
             SC2Mission.FIRE_IN_THE_SKY_P.mission_name,
             "South Orbital Command Center",
             SC2_RACESWAP_LOC_ID_OFFSET + 7410,
             LocationType.CHALLENGE,
-            lambda state: (
-                logic.protoss_common_unit(state) and logic.protoss_competent_comp(state)
-            ),
+            logic.protoss_competent_comp,
             flags=LocationFlag.BASEBUST,
         ),
         make_location_data(
@@ -10431,9 +10354,7 @@ def get_locations(world: Optional["SC2World"]) -> Tuple[LocationData, ...]:
             "Northwest Orbital Command Center",
             SC2_RACESWAP_LOC_ID_OFFSET + 7411,
             LocationType.CHALLENGE,
-            lambda state: (
-                logic.protoss_common_unit(state) and logic.protoss_competent_comp(state)
-            ),
+            logic.protoss_competent_comp,
             flags=LocationFlag.BASEBUST,
         ),
         make_location_data(
@@ -10441,9 +10362,7 @@ def get_locations(world: Optional["SC2World"]) -> Tuple[LocationData, ...]:
             "Southeast Orbital Command Center",
             SC2_RACESWAP_LOC_ID_OFFSET + 7412,
             LocationType.CHALLENGE,
-            lambda state: (
-                logic.protoss_common_unit(state) and logic.protoss_competent_comp(state)
-            ),
+            logic.protoss_competent_comp,
             flags=LocationFlag.BASEBUST,
         ),
         make_location_data(
@@ -10557,9 +10476,7 @@ def get_locations(world: Optional["SC2World"]) -> Tuple[LocationData, ...]:
             "Victory",
             SC2_RACESWAP_LOC_ID_OFFSET + 7700,
             LocationType.VICTORY,
-            lambda state: (
-                logic.terran_competent_comp(state) and logic.terran_common_unit(state)
-            ),
+            logic.terran_competent_comp,
             hard_rule=logic.terran_any_anti_air,
         ),
         make_location_data(
@@ -10573,37 +10490,21 @@ def get_locations(world: Optional["SC2World"]) -> Tuple[LocationData, ...]:
             "East Essence Pool",
             SC2_RACESWAP_LOC_ID_OFFSET + 7702,
             LocationType.VANILLA,
-            lambda state: (
-                logic.terran_common_unit(state)
-                and (
-                    adv_tactics
-                    and logic.terran_basic_anti_air(state)
-                    or logic.terran_competent_anti_air(state)
-                )
-            ),
+            logic.terran_waking_the_ancient_requirement,
         ),
         make_location_data(
             SC2Mission.WAKING_THE_ANCIENT_T.mission_name,
             "South Essence Pool",
             SC2_RACESWAP_LOC_ID_OFFSET + 7703,
             LocationType.VANILLA,
-            lambda state: (
-                logic.terran_common_unit(state)
-                and (
-                    adv_tactics
-                    and logic.terran_basic_anti_air(state)
-                    or logic.terran_competent_anti_air(state)
-                )
-            ),
+            logic.terran_waking_the_ancient_requirement,
         ),
         make_location_data(
             SC2Mission.WAKING_THE_ANCIENT_T.mission_name,
             "Finish Feeding",
             SC2_RACESWAP_LOC_ID_OFFSET + 7704,
             LocationType.EXTRA,
-            lambda state: (
-                logic.terran_competent_comp(state) and logic.terran_common_unit(state)
-            ),
+            logic.terran_competent_comp,
             hard_rule=logic.terran_any_anti_air,
         ),
         make_location_data(
@@ -10611,27 +10512,21 @@ def get_locations(world: Optional["SC2World"]) -> Tuple[LocationData, ...]:
             "South Proxy Primal Hive",
             SC2_RACESWAP_LOC_ID_OFFSET + 7705,
             LocationType.CHALLENGE,
-            lambda state: (
-                logic.terran_competent_comp(state) and logic.terran_common_unit(state)
-            ),
+            logic.terran_competent_comp,
         ),
         make_location_data(
             SC2Mission.WAKING_THE_ANCIENT_T.mission_name,
             "East Proxy Primal Hive",
             SC2_RACESWAP_LOC_ID_OFFSET + 7706,
             LocationType.CHALLENGE,
-            lambda state: (
-                logic.terran_competent_comp(state) and logic.terran_common_unit(state)
-            ),
+            logic.terran_competent_comp,
         ),
         make_location_data(
             SC2Mission.WAKING_THE_ANCIENT_T.mission_name,
             "South Main Primal Hive",
             SC2_RACESWAP_LOC_ID_OFFSET + 7707,
             LocationType.CHALLENGE,
-            lambda state: (
-                logic.terran_competent_comp(state) and logic.terran_common_unit(state)
-            ),
+            logic.terran_competent_comp,
             flags=LocationFlag.BASEBUST,
             hard_rule=logic.terran_any_anti_air,
         ),
@@ -10640,9 +10535,7 @@ def get_locations(world: Optional["SC2World"]) -> Tuple[LocationData, ...]:
             "East Main Primal Hive",
             SC2_RACESWAP_LOC_ID_OFFSET + 7708,
             LocationType.CHALLENGE,
-            lambda state: (
-                logic.terran_competent_comp(state) and logic.terran_common_unit(state)
-            ),
+            logic.terran_competent_comp,
             flags=LocationFlag.BASEBUST,
             hard_rule=logic.terran_any_anti_air,
         ),
@@ -10651,34 +10544,7 @@ def get_locations(world: Optional["SC2World"]) -> Tuple[LocationData, ...]:
             "Flawless",
             SC2_RACESWAP_LOC_ID_OFFSET + 7709,
             LocationType.CHALLENGE,
-            lambda state: (
-                logic.terran_competent_comp(state)
-                and logic.terran_common_unit(state)
-                and (
-                    # Fast unit
-                    state.has_any(
-                        (
-                            item_names.BANSHEE,
-                            item_names.VULTURE,
-                            item_names.DIAMONDBACK,
-                            item_names.WARHOUND,
-                            item_names.CYCLONE,
-                        ),
-                        player,
-                    )
-                    or state.has_all(
-                        (item_names.VALKYRIE, item_names.VALKYRIE_FLECHETTE_MISSILES),
-                        player,
-                    )
-                    or state.has_all(
-                        (
-                            item_names.WRAITH,
-                            item_names.WRAITH_ADVANCED_LASER_TECHNOLOGY,
-                        ),
-                        player,
-                    )
-                )
-            ),
+            logic.terran_waking_the_ancient_flawless,
             flags=LocationFlag.PREVENTATIVE,
             hard_rule=logic.terran_any_anti_air,
         ),
@@ -10701,20 +10567,14 @@ def get_locations(world: Optional["SC2World"]) -> Tuple[LocationData, ...]:
             "East Essence Pool",
             SC2_RACESWAP_LOC_ID_OFFSET + 7802,
             LocationType.VANILLA,
-            lambda state: (
-                logic.protoss_common_unit(state)
-                and logic.protoss_anti_light_anti_air(state)
-            ),
+            logic.protoss_common_unit_anti_light_air,
         ),
         make_location_data(
             SC2Mission.WAKING_THE_ANCIENT_P.mission_name,
             "South Essence Pool",
             SC2_RACESWAP_LOC_ID_OFFSET + 7803,
             LocationType.VANILLA,
-            lambda state: (
-                logic.protoss_common_unit(state)
-                and logic.protoss_anti_light_anti_air(state)
-            ),
+            logic.protoss_common_unit_anti_light_air,
         ),
         make_location_data(
             SC2Mission.WAKING_THE_ANCIENT_P.mission_name,
@@ -10770,22 +10630,14 @@ def get_locations(world: Optional["SC2World"]) -> Tuple[LocationData, ...]:
             "Victory",
             SC2_RACESWAP_LOC_ID_OFFSET + 7900,
             LocationType.VICTORY,
-            lambda state: (
-                logic.terran_common_unit(state)
-                and logic.terran_defense_rating(state, True, True) >= 7
-                and logic.terran_competent_anti_air(state)
-            ),
+            logic.terran_crucible_requirement,
         ),
         make_location_data(
             SC2Mission.THE_CRUCIBLE_T.mission_name,
             "Tyrannozor",
             SC2_RACESWAP_LOC_ID_OFFSET + 7901,
             LocationType.VANILLA,
-            lambda state: (
-                logic.terran_common_unit(state)
-                and logic.terran_defense_rating(state, True, True) >= 7
-                and logic.terran_competent_anti_air(state)
-            ),
+            logic.terran_crucible_requirement,
         ),
         make_location_data(
             SC2Mission.THE_CRUCIBLE_T.mission_name,
@@ -10798,44 +10650,28 @@ def get_locations(world: Optional["SC2World"]) -> Tuple[LocationData, ...]:
             "15 Minutes Remaining",
             SC2_RACESWAP_LOC_ID_OFFSET + 7903,
             LocationType.EXTRA,
-            lambda state: (
-                logic.terran_common_unit(state)
-                and logic.terran_defense_rating(state, True, True) >= 7
-                and logic.terran_competent_anti_air(state)
-            ),
+            logic.terran_crucible_requirement,
         ),
         make_location_data(
             SC2Mission.THE_CRUCIBLE_T.mission_name,
             "5 Minutes Remaining",
             SC2_RACESWAP_LOC_ID_OFFSET + 7904,
             LocationType.EXTRA,
-            lambda state: (
-                logic.terran_common_unit(state)
-                and logic.terran_defense_rating(state, True, True) >= 7
-                and logic.terran_competent_anti_air(state)
-            ),
+            logic.terran_crucible_requirement,
         ),
         make_location_data(
             SC2Mission.THE_CRUCIBLE_T.mission_name,
             "Pincer Attack",
             SC2_RACESWAP_LOC_ID_OFFSET + 7905,
             LocationType.EXTRA,
-            lambda state: (
-                logic.terran_common_unit(state)
-                and logic.terran_defense_rating(state, True, True) >= 7
-                and logic.terran_competent_anti_air(state)
-            ),
+            logic.terran_crucible_requirement,
         ),
         make_location_data(
             SC2Mission.THE_CRUCIBLE_T.mission_name,
             "Yagdra Claims Brakk's Pack",
             SC2_RACESWAP_LOC_ID_OFFSET + 7906,
             LocationType.EXTRA,
-            lambda state: (
-                logic.terran_common_unit(state)
-                and logic.terran_defense_rating(state, True, True) >= 7
-                and logic.terran_competent_anti_air(state)
-            ),
+            logic.terran_crucible_requirement,
         ),
         make_location_data(
             SC2Mission.THE_CRUCIBLE_P.mission_name,
@@ -10853,11 +10689,7 @@ def get_locations(world: Optional["SC2World"]) -> Tuple[LocationData, ...]:
             "Tyrannozor",
             SC2_RACESWAP_LOC_ID_OFFSET + 8001,
             LocationType.VANILLA,
-            lambda state: (
-                logic.protoss_common_unit(state)
-                and logic.protoss_defense_rating(state, True) >= 7
-                and logic.protoss_competent_anti_air(state)
-            ),
+            logic.protoss_crucible_requirement,
         ),
         make_location_data(
             SC2Mission.THE_CRUCIBLE_P.mission_name,
@@ -10870,53 +10702,35 @@ def get_locations(world: Optional["SC2World"]) -> Tuple[LocationData, ...]:
             "15 Minutes Remaining",
             SC2_RACESWAP_LOC_ID_OFFSET + 8003,
             LocationType.EXTRA,
-            lambda state: (
-                logic.protoss_common_unit(state)
-                and logic.protoss_defense_rating(state, True) >= 7
-                and logic.protoss_competent_anti_air(state)
-            ),
+            logic.protoss_crucible_requirement,
         ),
         make_location_data(
             SC2Mission.THE_CRUCIBLE_P.mission_name,
             "5 Minutes Remaining",
             SC2_RACESWAP_LOC_ID_OFFSET + 8004,
             LocationType.EXTRA,
-            lambda state: (
-                logic.protoss_common_unit(state)
-                and logic.protoss_defense_rating(state, True) >= 7
-                and logic.protoss_competent_anti_air(state)
-            ),
+            logic.protoss_crucible_requirement,
         ),
         make_location_data(
             SC2Mission.THE_CRUCIBLE_P.mission_name,
             "Pincer Attack",
             SC2_RACESWAP_LOC_ID_OFFSET + 8005,
             LocationType.EXTRA,
-            lambda state: (
-                logic.protoss_common_unit(state)
-                and logic.protoss_defense_rating(state, True) >= 7
-                and logic.protoss_competent_anti_air(state)
-            ),
+            logic.protoss_crucible_requirement,
         ),
         make_location_data(
             SC2Mission.THE_CRUCIBLE_P.mission_name,
             "Yagdra Claims Brakk's Pack",
             SC2_RACESWAP_LOC_ID_OFFSET + 8006,
             LocationType.EXTRA,
-            lambda state: (
-                logic.protoss_common_unit(state)
-                and logic.protoss_defense_rating(state, True) >= 7
-                and logic.protoss_competent_anti_air(state)
-            ),
+            logic.protoss_crucible_requirement,
         ),
         make_location_data(
             SC2Mission.INFESTED_T.mission_name,
             "Victory",
             SC2_RACESWAP_LOC_ID_OFFSET + 8300,
             LocationType.VICTORY,
-            lambda state: (
-                logic.terran_common_unit(state) and logic.terran_competent_comp(state)
-            ),
+            logic.terran_competent_comp,
             hard_rule=logic.terran_any_anti_air,
         ),
         make_location_data(
@@ -10924,28 +10738,21 @@ def get_locations(world: Optional["SC2World"]) -> Tuple[LocationData, ...]:
             "East Science Facility",
             SC2_RACESWAP_LOC_ID_OFFSET + 8301,
             LocationType.VANILLA,
-            lambda state: (
-                logic.terran_common_unit(state)
-                and logic.terran_moderate_anti_air(state)
-            ),
+            logic.terran_common_unit_moderate_aa,
         ),
         make_location_data(
             SC2Mission.INFESTED_T.mission_name,
             "Center Science Facility",
             SC2_RACESWAP_LOC_ID_OFFSET + 8302,
             LocationType.VANILLA,
-            lambda state: (
-                logic.terran_common_unit(state) and logic.terran_competent_comp(state)
-            ),
+            logic.terran_competent_comp,
         ),
         make_location_data(
             SC2Mission.INFESTED_T.mission_name,
             "West Science Facility",
             SC2_RACESWAP_LOC_ID_OFFSET + 8303,
             LocationType.VANILLA,
-            lambda state: (
-                logic.terran_common_unit(state) and logic.terran_competent_comp(state)
-            ),
+            logic.terran_competent_comp,
         ),
         make_location_data(
             SC2Mission.INFESTED_T.mission_name,
@@ -10970,55 +10777,35 @@ def get_locations(world: Optional["SC2World"]) -> Tuple[LocationData, ...]:
             "East Garrison",
             SC2_RACESWAP_LOC_ID_OFFSET + 8307,
             LocationType.EXTRA,
-            lambda state: (
-                logic.terran_common_unit(state)
-                and logic.terran_moderate_anti_air(state)
-                and (adv_tactics or logic.terran_infested_garrison_claimer(state))
-            ),
+            logic.terran_infested_requirement,
         ),
         make_location_data(
             SC2Mission.INFESTED_T.mission_name,
             "Mid Garrison",
             SC2_RACESWAP_LOC_ID_OFFSET + 8308,
             LocationType.EXTRA,
-            lambda state: (
-                logic.terran_common_unit(state)
-                and logic.terran_moderate_anti_air(state)
-                and (adv_tactics or logic.terran_infested_garrison_claimer(state))
-            ),
+            logic.terran_infested_requirement,
         ),
         make_location_data(
             SC2Mission.INFESTED_T.mission_name,
             "North Garrison",
             SC2_RACESWAP_LOC_ID_OFFSET + 8309,
             LocationType.EXTRA,
-            lambda state: (
-                logic.terran_common_unit(state)
-                and logic.terran_competent_comp(state)
-                and (adv_tactics or logic.terran_infested_garrison_claimer(state))
-            ),
+            logic.terran_infested_requirement,
         ),
         make_location_data(
             SC2Mission.INFESTED_T.mission_name,
             "Close Southwest Garrison",
             SC2_RACESWAP_LOC_ID_OFFSET + 8310,
             LocationType.EXTRA,
-            lambda state: (
-                logic.terran_common_unit(state)
-                and logic.terran_competent_comp(state)
-                and (adv_tactics or logic.terran_infested_garrison_claimer(state))
-            ),
+            logic.terran_infested_requirement,
         ),
         make_location_data(
             SC2Mission.INFESTED_T.mission_name,
             "Far Southwest Garrison",
             SC2_RACESWAP_LOC_ID_OFFSET + 8311,
             LocationType.EXTRA,
-            lambda state: (
-                logic.terran_common_unit(state)
-                and logic.terran_competent_comp(state)
-                and (adv_tactics or logic.terran_infested_garrison_claimer(state))
-            ),
+            logic.terran_infested_far_garrison,
         ),
         make_location_data(
             SC2Mission.INFESTED_P.mission_name,
@@ -11033,9 +10820,7 @@ def get_locations(world: Optional["SC2World"]) -> Tuple[LocationData, ...]:
             "East Science Facility",
             SC2_RACESWAP_LOC_ID_OFFSET + 8401,
             LocationType.VANILLA,
-            lambda state: (
-                logic.protoss_common_unit(state) and logic.protoss_basic_anti_air(state)
-            ),
+            logic.protoss_common_unit_basic_aa,
         ),
         make_location_data(
             SC2Mission.INFESTED_P.mission_name,
@@ -11074,53 +10859,35 @@ def get_locations(world: Optional["SC2World"]) -> Tuple[LocationData, ...]:
             "East Garrison",
             SC2_RACESWAP_LOC_ID_OFFSET + 8407,
             LocationType.EXTRA,
-            lambda state: (
-                logic.protoss_common_unit(state)
-                and logic.protoss_basic_anti_air(state)
-                and (adv_tactics or logic.protoss_infested_garrison_claimer(state))
-            ),
+            logic.protoss_infested_requirement,
         ),
         make_location_data(
             SC2Mission.INFESTED_P.mission_name,
             "Mid Garrison",
             SC2_RACESWAP_LOC_ID_OFFSET + 8408,
             LocationType.EXTRA,
-            lambda state: (
-                logic.protoss_common_unit(state)
-                and logic.protoss_basic_anti_air(state)
-                and (adv_tactics or logic.protoss_infested_garrison_claimer(state))
-            ),
+            logic.protoss_infested_requirement,
         ),
         make_location_data(
             SC2Mission.INFESTED_P.mission_name,
             "North Garrison",
             SC2_RACESWAP_LOC_ID_OFFSET + 8409,
             LocationType.EXTRA,
-            lambda state: (
-                logic.protoss_common_unit(state)
-                and logic.protoss_competent_anti_air(state)
-                and (adv_tactics or logic.protoss_infested_garrison_claimer(state))
-            ),
+            logic.protoss_infested_requirement,
         ),
         make_location_data(
             SC2Mission.INFESTED_P.mission_name,
             "Close Southwest Garrison",
             SC2_RACESWAP_LOC_ID_OFFSET + 8410,
             LocationType.EXTRA,
-            lambda state: (
-                logic.protoss_competent_comp(state)
-                and (adv_tactics or logic.protoss_infested_garrison_claimer(state))
-            ),
+            logic.protoss_infested_requirement,
         ),
         make_location_data(
             SC2Mission.INFESTED_P.mission_name,
             "Far Southwest Garrison",
             SC2_RACESWAP_LOC_ID_OFFSET + 8411,
             LocationType.EXTRA,
-            lambda state: (
-                logic.protoss_competent_comp(state)
-                and (adv_tactics or logic.protoss_infested_garrison_claimer(state))
-            ),
+            logic.protoss_infested_far_garrison,
         ),
         make_location_data(
             SC2Mission.HAND_OF_DARKNESS_T.mission_name,
@@ -11638,8 +11405,7 @@ def get_locations(world: Optional["SC2World"]) -> Tuple[LocationData, ...]:
             "Victory",
             SC2_RACESWAP_LOC_ID_OFFSET + 9600,
             LocationType.VICTORY,
-            lambda state: logic.protoss_deathball(state)
-            or (adv_tactics and logic.protoss_competent_comp(state)),
+            logic.protoss_deathball_or_advanced_competent_comp,
         ),
         make_location_data(
             SC2Mission.DEATH_FROM_ABOVE_P.mission_name,
@@ -11673,8 +11439,7 @@ def get_locations(world: Optional["SC2World"]) -> Tuple[LocationData, ...]:
             "Main Path Command Center",
             SC2_RACESWAP_LOC_ID_OFFSET + 9605,
             LocationType.EXTRA,
-            lambda state: logic.protoss_deathball(state)
-            or (adv_tactics and logic.protoss_competent_comp(state)),
+            logic.protoss_deathball_or_advanced_competent_comp,
         ),
         make_location_data(
             SC2Mission.THE_RECKONING_T.mission_name,
@@ -14288,9 +14053,6 @@ def get_locations(world: Optional["SC2World"]) -> Tuple[LocationData, ...]:
             "Gas Pickups",
             SC2_RACESWAP_LOC_ID_OFFSET + 15104,
             LocationType.EXTRA,
-            lambda state: (
-                logic.advanced_tactics or logic.zerg_sudden_strike_requirement(state)
-            ),
         ),
         make_location_data(
             SC2Mission.SUDDEN_STRIKE_Z.mission_name,
@@ -14345,9 +14107,6 @@ def get_locations(world: Optional["SC2World"]) -> Tuple[LocationData, ...]:
             "Gas Pickups",
             SC2_RACESWAP_LOC_ID_OFFSET + 15204,
             LocationType.EXTRA,
-            lambda state: (
-                logic.advanced_tactics or logic.protoss_sudden_strike_requirement(state)
-            ),
         ),
         make_location_data(
             SC2Mission.SUDDEN_STRIKE_P.mission_name,
@@ -14908,7 +14667,7 @@ def get_locations(world: Optional["SC2World"]) -> Tuple[LocationData, ...]:
             SC2Mission.FLASHPOINT_Z.mission_name,
             "Expansion Hatchery",
             SC2_RACESWAP_LOC_ID_OFFSET + 15909,
-            LocationType.EXTRA, 
+            LocationType.EXTRA,
         ),
         make_location_data(
             SC2Mission.FLASHPOINT_Z.mission_name,

--- a/worlds/sc2/locations.py
+++ b/worlds/sc2/locations.py
@@ -328,10 +328,7 @@ def get_locations(world: Optional["SC2World"]) -> Tuple[LocationData, ...]:
             "Cavalry's on the Way",
             SC2WOL_LOC_ID_OFFSET + 310,
             LocationType.EXTRA,
-            lambda state: (
-                logic.terran_common_unit(state)
-                and logic.terran_defense_rating(state, True) >= 2
-            ),
+            logic.terran_zero_hour_stage_2_requirement,
         ),
         make_location_data(
             SC2Mission.EVACUATION.mission_name,
@@ -3427,17 +3424,7 @@ def get_locations(world: Optional["SC2World"]) -> Tuple[LocationData, ...]:
             "Trash the Odin Early",
             SC2HOTS_LOC_ID_OFFSET + 2005,
             LocationType.MASTERY,
-            lambda state: (
-                logic.zerg_the_reckoning_requirement(state)
-                and (
-                    kerriganless
-                    or (
-                        logic.kerrigan_levels(state, 50, False)
-                        and state.has_any(kerrigan_logic_ultimates, player)
-                    )
-                )
-                and logic.zerg_power_rating(state) >= 10
-            ),
+            logic.zerg_the_reckoning_odin_speedrun,
             flags=LocationFlag.SPEEDRUN,
         ),
         # LotV Prologue
@@ -3829,11 +3816,7 @@ def get_locations(world: Optional["SC2World"]) -> Tuple[LocationData, ...]:
             "Win in under 15 minutes",
             SC2LOTV_LOC_ID_OFFSET + 806,
             LocationType.CHALLENGE,
-            lambda state: (
-                logic.protoss_brothers_in_arms_requirement(state)
-                and logic.protoss_deathball(state)
-                and logic.protoss_power_rating(state) >= 8
-            ),
+            logic.protoss_brothers_in_arms_speedrun,
             flags=LocationFlag.SPEEDRUN,
         ),
         make_location_data(
@@ -3931,24 +3914,7 @@ def get_locations(world: Optional["SC2World"]) -> Tuple[LocationData, ...]:
             "1.5 Billion Zerg",
             SC2LOTV_LOC_ID_OFFSET + 1005,
             LocationType.VANILLA,
-            lambda state: (
-                logic.protoss_last_stand_requirement(state)
-                and (
-                    state.has_all(
-                        {
-                            item_names.KHAYDARIN_MONOLITH,
-                            item_names.PHOTON_CANNON,
-                            item_names.SHIELD_BATTERY,
-                        },
-                        player,
-                    )
-                    or state.has_any(
-                        {item_names.SOA_SOLAR_LANCE, item_names.SOA_DEPLOY_FENIX},
-                        player,
-                    )
-                )
-                and logic.protoss_defense_rating(state, False) >= 13
-            ),
+            logic.protoss_last_stand_1p5_billion,
         ),
         make_location_data(
             SC2Mission.FORBIDDEN_WEAPON.mission_name,
@@ -4166,10 +4132,7 @@ def get_locations(world: Optional["SC2World"]) -> Tuple[LocationData, ...]:
             "Victory",
             SC2LOTV_LOC_ID_OFFSET + 1500,
             LocationType.VICTORY,
-            lambda state: (
-                logic.protoss_deathball(state)
-                and logic.protoss_power_rating(state) >= 6
-            ),
+            logic.protoss_unsealing_the_past_requirement,
         ),
         make_location_data(
             SC2Mission.UNSEALING_THE_PAST.mission_name,
@@ -4182,62 +4145,42 @@ def get_locations(world: Optional["SC2World"]) -> Tuple[LocationData, ...]:
             "First Stasis Lock",
             SC2LOTV_LOC_ID_OFFSET + 1502,
             LocationType.EXTRA,
-            lambda state: (
-                logic.protoss_deathball(state)
-                and logic.protoss_power_rating(state) >= 6
-            ),
+            logic.protoss_unsealing_the_past_requirement,
         ),
         make_location_data(
             SC2Mission.UNSEALING_THE_PAST.mission_name,
             "Second Stasis Lock",
             SC2LOTV_LOC_ID_OFFSET + 1503,
             LocationType.EXTRA,
-            lambda state: (
-                logic.protoss_deathball(state)
-                and logic.protoss_power_rating(state) >= 6
-            ),
+            logic.protoss_unsealing_the_past_requirement,
         ),
         make_location_data(
             SC2Mission.UNSEALING_THE_PAST.mission_name,
             "Third Stasis Lock",
             SC2LOTV_LOC_ID_OFFSET + 1504,
             LocationType.EXTRA,
-            lambda state: (
-                logic.protoss_deathball(state)
-                and logic.protoss_power_rating(state) >= 6
-            ),
+            logic.protoss_unsealing_the_past_requirement,
         ),
         make_location_data(
             SC2Mission.UNSEALING_THE_PAST.mission_name,
             "Fourth Stasis Lock",
             SC2LOTV_LOC_ID_OFFSET + 1505,
             LocationType.EXTRA,
-            lambda state: (
-                logic.protoss_deathball(state)
-                and logic.protoss_power_rating(state) >= 6
-            ),
+            logic.protoss_unsealing_the_past_requirement,
         ),
         make_location_data(
             SC2Mission.UNSEALING_THE_PAST.mission_name,
             "South Power Core",
             SC2LOTV_LOC_ID_OFFSET + 1506,
             LocationType.VANILLA,
-            lambda state: (
-                logic.protoss_deathball(state)
-                and logic.protoss_power_rating(state) >= 6
-                and (adv_tactics or logic.protoss_unsealing_the_past_ledge_requirement(state))
-            ),
+            logic.protoss_unsealing_the_past_ledge_requirement,
         ),
         make_location_data(
             SC2Mission.UNSEALING_THE_PAST.mission_name,
             "East Power Core",
             SC2LOTV_LOC_ID_OFFSET + 1507,
             LocationType.VANILLA,
-            lambda state: (
-                logic.protoss_deathball(state)
-                and logic.protoss_power_rating(state) >= 6
-                and (adv_tactics or logic.protoss_unsealing_the_past_ledge_requirement(state))
-            ),
+            logic.protoss_unsealing_the_past_ledge_requirement,
         ),
         make_location_data(
             SC2Mission.PURIFICATION.mission_name,
@@ -4892,12 +4835,7 @@ def get_locations(world: Optional["SC2World"]) -> Tuple[LocationData, ...]:
             "Zerg Base",
             SC2NCO_LOC_ID_OFFSET + 206,
             LocationType.MASTERY,
-            lambda state: (
-                logic.terran_sudden_strike_requirement(state)
-                and logic.terran_competent_comp(state)
-                and logic.terran_base_trasher(state)
-                and logic.terran_power_rating(state) >= 8
-            ),
+            logic.terran_sudden_strike_zerg_base,
             flags=LocationFlag.BASEBUST,
         ),
         make_location_data(
@@ -9015,8 +8953,7 @@ def get_locations(world: Optional["SC2World"]) -> Tuple[LocationData, ...]:
             "Victory",
             SC2_RACESWAP_LOC_ID_OFFSET + 5600,
             LocationType.VICTORY,
-            lambda state: logic.protoss_competent_comp(state)
-            and logic.protoss_army_weapon_armor_upgrade_min_level(state) >= 2,
+            logic.protoss_competent_comp_wa2,
         ),
         make_location_data(
             SC2Mission.SHATTER_THE_SKY_P.mission_name,
@@ -9037,24 +8974,21 @@ def get_locations(world: Optional["SC2World"]) -> Tuple[LocationData, ...]:
             "Southeast Coolant Tower",
             SC2_RACESWAP_LOC_ID_OFFSET + 5603,
             LocationType.VANILLA,
-            lambda state: logic.protoss_competent_comp(state)
-            and logic.protoss_army_weapon_armor_upgrade_min_level(state) >= 2,
+            logic.protoss_competent_comp_wa2,
         ),
         make_location_data(
             SC2Mission.SHATTER_THE_SKY_P.mission_name,
             "Southwest Coolant Tower",
             SC2_RACESWAP_LOC_ID_OFFSET + 5604,
             LocationType.VANILLA,
-            lambda state: logic.protoss_competent_comp(state)
-            and logic.protoss_army_weapon_armor_upgrade_min_level(state) >= 2,
+            logic.protoss_competent_comp_wa2,
         ),
         make_location_data(
             SC2Mission.SHATTER_THE_SKY_P.mission_name,
             "Leviathan",
             SC2_RACESWAP_LOC_ID_OFFSET + 5605,
             LocationType.VANILLA,
-            lambda state: logic.protoss_competent_comp(state)
-            and logic.protoss_army_weapon_armor_upgrade_min_level(state) >= 2,
+            logic.protoss_competent_comp_wa2,
             hard_rule=logic.protoss_any_anti_air_unit_or_soa_any_protoss,
         ),
         make_location_data(
@@ -10472,11 +10406,7 @@ def get_locations(world: Optional["SC2World"]) -> Tuple[LocationData, ...]:
             "Victory",
             SC2_RACESWAP_LOC_ID_OFFSET + 8000,
             LocationType.VICTORY,
-            lambda state: (
-                logic.protoss_common_unit(state)
-                and logic.protoss_defense_rating(state, True) >= 7
-                and logic.protoss_competent_anti_air(state)
-            ),
+            logic.protoss_crucible_requirement,
         ),
         make_location_data(
             SC2Mission.THE_CRUCIBLE_P.mission_name,
@@ -11275,10 +11205,7 @@ def get_locations(world: Optional["SC2World"]) -> Tuple[LocationData, ...]:
             "Trash the Odin Early",
             SC2_RACESWAP_LOC_ID_OFFSET + 9705,
             LocationType.MASTERY,
-            lambda state: (
-                logic.terran_the_reckoning_requirement(state)
-                and logic.terran_power_rating(state) >= 10
-            ),
+            logic.terran_the_reckoning_odin_speedrun,
             flags=LocationFlag.SPEEDRUN,
         ),
         make_location_data(
@@ -11321,13 +11248,7 @@ def get_locations(world: Optional["SC2World"]) -> Tuple[LocationData, ...]:
             "Trash the Odin Early",
             SC2_RACESWAP_LOC_ID_OFFSET + 9805,
             LocationType.MASTERY,
-            lambda state: (
-                logic.protoss_the_reckoning_requirement(state)
-                and (
-                    logic.protoss_fleet(state)
-                    or logic.protoss_power_rating(state) >= 10
-                )
-            ),
+            logic.protoss_the_reckoning_odin_speedrun,
             flags=LocationFlag.SPEEDRUN,
         ),
         make_location_data(
@@ -11370,11 +11291,7 @@ def get_locations(world: Optional["SC2World"]) -> Tuple[LocationData, ...]:
             "Zerg Base",
             SC2_RACESWAP_LOC_ID_OFFSET + 9905,
             LocationType.MASTERY,
-            lambda state: (
-                logic.terran_competent_comp(state)
-                and logic.terran_base_trasher(state)
-                and logic.terran_power_rating(state) >= 6
-            ),
+            logic.terran_dark_whispers_zerg_base,
             flags=LocationFlag.BASEBUST,
         ),
         make_location_data(
@@ -11382,52 +11299,42 @@ def get_locations(world: Optional["SC2World"]) -> Tuple[LocationData, ...]:
             "Victory",
             SC2_RACESWAP_LOC_ID_OFFSET + 10000,
             LocationType.VICTORY,
-            lambda state: logic.zerg_competent_comp(state)
-            and logic.zerg_moderate_anti_air(state),
+            logic.zerg_competent_comp_moderate_aa,
         ),
         make_location_data(
             SC2Mission.DARK_WHISPERS_Z.mission_name,
             "First Prisoner Group",
             SC2_RACESWAP_LOC_ID_OFFSET + 10001,
             LocationType.VANILLA,
-            lambda state: logic.zerg_competent_comp(state)
-            and logic.zerg_moderate_anti_air(state),
+            logic.zerg_competent_comp_moderate_aa,
         ),
         make_location_data(
             SC2Mission.DARK_WHISPERS_Z.mission_name,
             "Second Prisoner Group",
             SC2_RACESWAP_LOC_ID_OFFSET + 10002,
             LocationType.VANILLA,
-            lambda state: logic.zerg_competent_comp(state)
-            and logic.zerg_moderate_anti_air(state),
+            logic.zerg_competent_comp_moderate_aa,
         ),
         make_location_data(
             SC2Mission.DARK_WHISPERS_Z.mission_name,
             "First Pylon",
             SC2_RACESWAP_LOC_ID_OFFSET + 10003,
             LocationType.VANILLA,
-            lambda state: logic.zerg_competent_comp(state)
-            and logic.zerg_moderate_anti_air(state),
+            logic.zerg_competent_comp_moderate_aa,
         ),
         make_location_data(
             SC2Mission.DARK_WHISPERS_Z.mission_name,
             "Second Pylon",
             SC2_RACESWAP_LOC_ID_OFFSET + 10004,
             LocationType.VANILLA,
-            lambda state: logic.zerg_competent_comp(state)
-            and logic.zerg_moderate_anti_air(state),
+            logic.zerg_competent_comp_moderate_aa,
         ),
         make_location_data(
             SC2Mission.DARK_WHISPERS_Z.mission_name,
             "Zerg Base",
             SC2_RACESWAP_LOC_ID_OFFSET + 10005,
             LocationType.MASTERY,
-            lambda state: (
-                logic.zerg_competent_comp(state)
-                and logic.zerg_moderate_anti_air(state)
-                and logic.zerg_base_buster(state)
-                and logic.zerg_power_rating(state) >= 6
-            ),
+            logic.zerg_dark_whispers_zerg_base,
             flags=LocationFlag.BASEBUST,
         ),
         make_location_data(
@@ -11959,9 +11866,7 @@ def get_locations(world: Optional["SC2World"]) -> Tuple[LocationData, ...]:
             "Victory",
             SC2_RACESWAP_LOC_ID_OFFSET + 11300,
             LocationType.VICTORY,
-            lambda state: (
-                logic.terran_common_unit(state) and logic.terran_competent_comp(state)
-            ),
+            logic.terran_competent_comp,
         ),
         make_location_data(
             SC2Mission.BROTHERS_IN_ARMS_T.mission_name,
@@ -11975,8 +11880,7 @@ def get_locations(world: Optional["SC2World"]) -> Tuple[LocationData, ...]:
             SC2_RACESWAP_LOC_ID_OFFSET + 11302,
             LocationType.VANILLA,
             lambda state: (
-                logic.terran_common_unit(state)
-                and logic.terran_competent_comp(state)
+                logic.terran_competent_comp(state)
                 or (
                     logic.take_over_ai_allies
                     and logic.advanced_tactics
@@ -11989,38 +11893,28 @@ def get_locations(world: Optional["SC2World"]) -> Tuple[LocationData, ...]:
             "South Science Facility",
             SC2_RACESWAP_LOC_ID_OFFSET + 11303,
             LocationType.VANILLA,
-            lambda state: (
-                logic.terran_common_unit(state) and logic.terran_competent_comp(state)
-            ),
+            logic.terran_competent_comp,
         ),
         make_location_data(
             SC2Mission.BROTHERS_IN_ARMS_T.mission_name,
             "Raynor Forward Positions",
             SC2_RACESWAP_LOC_ID_OFFSET + 11304,
             LocationType.EXTRA,
-            lambda state: (
-                logic.terran_common_unit(state) and logic.terran_competent_comp(state)
-            ),
+            logic.terran_competent_comp,
         ),
         make_location_data(
             SC2Mission.BROTHERS_IN_ARMS_T.mission_name,
             "Valerian Forward Positions",
             SC2_RACESWAP_LOC_ID_OFFSET + 11305,
             LocationType.EXTRA,
-            lambda state: (
-                logic.terran_common_unit(state) and logic.terran_competent_comp(state)
-            ),
+            logic.terran_competent_comp,
         ),
         make_location_data(
             SC2Mission.BROTHERS_IN_ARMS_T.mission_name,
             "Win in under 15 Minutes",
             SC2_RACESWAP_LOC_ID_OFFSET + 11306,
             LocationType.CHALLENGE,
-            lambda state: (
-                logic.terran_common_unit(state)
-                and logic.terran_base_trasher(state)
-                and logic.terran_power_rating(state) >= 8
-            ),
+            logic.terran_brothers_in_arms_speedrun,
             flags=LocationFlag.SPEEDRUN,
         ),
         make_location_data(
@@ -12078,11 +11972,7 @@ def get_locations(world: Optional["SC2World"]) -> Tuple[LocationData, ...]:
             "Win in under 15 Minutes",
             SC2_RACESWAP_LOC_ID_OFFSET + 11406,
             LocationType.CHALLENGE,
-            lambda state: (
-                logic.zerg_brothers_in_arms_requirement(state)
-                and logic.zerg_base_buster(state)
-                and logic.zerg_power_rating(state) >= 8
-            ),
+            logic.zerg_brothers_in_arms_speedrun,
             flags=LocationFlag.SPEEDRUN,
         ),
         make_location_data(
@@ -12090,7 +11980,7 @@ def get_locations(world: Optional["SC2World"]) -> Tuple[LocationData, ...]:
             "Victory",
             SC2_RACESWAP_LOC_ID_OFFSET + 11500,
             LocationType.VICTORY,
-            lambda state: (logic.terran_competent_comp(state)),
+            logic.terran_competent_comp,
         ),
         make_location_data(
             SC2Mission.AMON_S_REACH_T.mission_name,
@@ -12103,42 +11993,42 @@ def get_locations(world: Optional["SC2World"]) -> Tuple[LocationData, ...]:
             "North Solarite Reserve",
             SC2_RACESWAP_LOC_ID_OFFSET + 11502,
             LocationType.VANILLA,
-            lambda state: (logic.terran_competent_comp(state)),
+            logic.terran_competent_comp,
         ),
         make_location_data(
             SC2Mission.AMON_S_REACH_T.mission_name,
             "East Solarite Reserve",
             SC2_RACESWAP_LOC_ID_OFFSET + 11503,
             LocationType.VANILLA,
-            lambda state: (logic.terran_competent_comp(state)),
+            logic.terran_competent_comp,
         ),
         make_location_data(
             SC2Mission.AMON_S_REACH_T.mission_name,
             "West Launch Bay",
             SC2_RACESWAP_LOC_ID_OFFSET + 11504,
             LocationType.EXTRA,
-            lambda state: (logic.terran_competent_comp(state)),
+            logic.terran_competent_comp,
         ),
         make_location_data(
             SC2Mission.AMON_S_REACH_T.mission_name,
             "South Launch Bay",
             SC2_RACESWAP_LOC_ID_OFFSET + 11505,
             LocationType.EXTRA,
-            lambda state: (logic.terran_competent_comp(state)),
+            logic.terran_competent_comp,
         ),
         make_location_data(
             SC2Mission.AMON_S_REACH_T.mission_name,
             "Northwest Launch Bay",
             SC2_RACESWAP_LOC_ID_OFFSET + 11506,
             LocationType.EXTRA,
-            lambda state: (logic.terran_competent_comp(state)),
+            logic.terran_competent_comp,
         ),
         make_location_data(
             SC2Mission.AMON_S_REACH_T.mission_name,
             "East Launch Bay",
             SC2_RACESWAP_LOC_ID_OFFSET + 11507,
             LocationType.EXTRA,
-            lambda state: (logic.terran_competent_comp(state)),
+            logic.terran_competent_comp,
         ),
         make_location_data(
             SC2Mission.AMON_S_REACH_Z.mission_name,
@@ -12256,8 +12146,7 @@ def get_locations(world: Optional["SC2World"]) -> Tuple[LocationData, ...]:
             "1.5 Billion Zerg",
             SC2_RACESWAP_LOC_ID_OFFSET + 11705,
             LocationType.VANILLA,
-            lambda state: logic.terran_last_stand_requirement(state)
-            and logic.terran_defense_rating(state, True, True) >= 13,
+            logic.terran_last_stand_1p5_billion,
         ),
         make_location_data(
             SC2Mission.LAST_STAND_Z.mission_name,
@@ -13862,11 +13751,7 @@ def get_locations(world: Optional["SC2World"]) -> Tuple[LocationData, ...]:
             "Zerg Base",
             SC2_RACESWAP_LOC_ID_OFFSET + 15106,
             LocationType.MASTERY,
-            lambda state: (
-                logic.zerg_sudden_strike_requirement(state)
-                and logic.zerg_base_buster(state)
-                and logic.zerg_power_rating(state) >= 8
-            ),
+            logic.zerg_sudden_strike_zerg_base,
             flags=LocationFlag.BASEBUST,
         ),
         make_location_data(
@@ -13916,11 +13801,7 @@ def get_locations(world: Optional["SC2World"]) -> Tuple[LocationData, ...]:
             "Zerg Base",
             SC2_RACESWAP_LOC_ID_OFFSET + 15206,
             LocationType.MASTERY,
-            lambda state: (
-                logic.protoss_sudden_strike_requirement(state)
-                and logic.protoss_deathball(state)
-                and logic.protoss_power_rating(state) >= 8
-            ),
+            logic.protoss_sudden_strike_zerg_base,
             flags=LocationFlag.BASEBUST,
         ),
         make_location_data(

--- a/worlds/sc2/locations.py
+++ b/worlds/sc2/locations.py
@@ -551,7 +551,7 @@ def get_locations(world: Optional["SC2World"]) -> Tuple[LocationData, ...]:
             "Northeast Colony Base",
             SC2WOL_LOC_ID_OFFSET + 704,
             LocationType.CHALLENGE,
-            logic.terran_respond_to_colony_infestations,
+            logic.terran_havens_fall_respond_to_colony_infestations,
             hard_rule=logic.terran_any_anti_air_or_science_vessels,
         ),
         make_location_data(
@@ -559,7 +559,7 @@ def get_locations(world: Optional["SC2World"]) -> Tuple[LocationData, ...]:
             "East Colony Base",
             SC2WOL_LOC_ID_OFFSET + 705,
             LocationType.CHALLENGE,
-            logic.terran_respond_to_colony_infestations,
+            logic.terran_havens_fall_respond_to_colony_infestations,
             hard_rule=logic.terran_any_anti_air_or_science_vessels,
         ),
         make_location_data(
@@ -567,7 +567,7 @@ def get_locations(world: Optional["SC2World"]) -> Tuple[LocationData, ...]:
             "Middle Colony Base",
             SC2WOL_LOC_ID_OFFSET + 706,
             LocationType.CHALLENGE,
-            logic.terran_respond_to_colony_infestations,
+            logic.terran_havens_fall_respond_to_colony_infestations,
             hard_rule=logic.terran_any_anti_air_or_science_vessels,
         ),
         make_location_data(
@@ -575,7 +575,7 @@ def get_locations(world: Optional["SC2World"]) -> Tuple[LocationData, ...]:
             "Southeast Colony Base",
             SC2WOL_LOC_ID_OFFSET + 707,
             LocationType.CHALLENGE,
-            logic.terran_respond_to_colony_infestations,
+            logic.terran_havens_fall_respond_to_colony_infestations,
             hard_rule=logic.terran_any_anti_air_or_science_vessels,
         ),
         make_location_data(
@@ -583,7 +583,7 @@ def get_locations(world: Optional["SC2World"]) -> Tuple[LocationData, ...]:
             "Southwest Colony Base",
             SC2WOL_LOC_ID_OFFSET + 708,
             LocationType.CHALLENGE,
-            logic.terran_respond_to_colony_infestations,
+            logic.terran_havens_fall_respond_to_colony_infestations,
             hard_rule=logic.terran_any_anti_air_or_science_vessels,
         ),
         make_location_data(
@@ -775,7 +775,6 @@ def get_locations(world: Optional["SC2World"]) -> Tuple[LocationData, ...]:
             "Northeastern Protoss Base",
             SC2WOL_LOC_ID_OFFSET + 910,
             LocationType.MASTERY,
-            lambda state: 
             logic.terran_the_dig_bases_requirement,
             flags=LocationFlag.BASEBUST,
         ),
@@ -784,7 +783,6 @@ def get_locations(world: Optional["SC2World"]) -> Tuple[LocationData, ...]:
             "Eastern Protoss Base",
             SC2WOL_LOC_ID_OFFSET + 911,
             LocationType.MASTERY,
-            lambda state: 
             logic.terran_the_dig_bases_requirement,
             flags=LocationFlag.BASEBUST,
         ),
@@ -830,35 +828,35 @@ def get_locations(world: Optional["SC2World"]) -> Tuple[LocationData, ...]:
             "South Rescue",
             SC2WOL_LOC_ID_OFFSET + 1003,
             LocationType.EXTRA,
-            logic.terran_can_rescue,
+            logic.terran_moebius_factor_can_rescue,
         ),
         make_location_data(
             SC2Mission.THE_MOEBIUS_FACTOR.mission_name,
             "Wall Rescue",
             SC2WOL_LOC_ID_OFFSET + 1004,
             LocationType.EXTRA,
-            logic.terran_can_rescue,
+            logic.terran_moebius_factor_can_rescue,
         ),
         make_location_data(
             SC2Mission.THE_MOEBIUS_FACTOR.mission_name,
             "Mid Rescue",
             SC2WOL_LOC_ID_OFFSET + 1005,
             LocationType.EXTRA,
-            logic.terran_can_rescue,
+            logic.terran_moebius_factor_can_rescue,
         ),
         make_location_data(
             SC2Mission.THE_MOEBIUS_FACTOR.mission_name,
             "Nydus Roof Rescue",
             SC2WOL_LOC_ID_OFFSET + 1006,
             LocationType.EXTRA,
-            logic.terran_can_rescue,
+            logic.terran_moebius_factor_can_rescue,
         ),
         make_location_data(
             SC2Mission.THE_MOEBIUS_FACTOR.mission_name,
             "Alive Inside Rescue",
             SC2WOL_LOC_ID_OFFSET + 1007,
             LocationType.EXTRA,
-            logic.terran_can_rescue,
+            logic.terran_moebius_factor_can_rescue,
         ),
         make_location_data(
             SC2Mission.THE_MOEBIUS_FACTOR.mission_name,
@@ -1846,7 +1844,7 @@ def get_locations(world: Optional["SC2World"]) -> Tuple[LocationData, ...]:
             "West Obelisk",
             SC2WOL_LOC_ID_OFFSET + 2402,
             LocationType.VANILLA,
-            lambda state: adv_tactics or logic.protoss_common_unit(state),
+            logic.protoss_common_unit_or_advanced_tactics,
         ),
         make_location_data(
             SC2Mission.ECHOES_OF_THE_FUTURE.mission_name,
@@ -2524,54 +2522,54 @@ def get_locations(world: Optional["SC2World"]) -> Tuple[LocationData, ...]:
             SC2HOTS_LOC_ID_OFFSET + 600,
             LocationType.VICTORY,
             logic.zerg_enemy_within_victory_requirement,
-            hard_rule=logic.zerg_pass_vents,
+            hard_rule=logic.zerg_enemy_within_pass_vents,
         ),
         make_location_data(
             SC2Mission.ENEMY_WITHIN.mission_name,
             "Infest Giant Ursadon",
             SC2HOTS_LOC_ID_OFFSET + 601,
             LocationType.VANILLA,
-            logic.zerg_pass_vents,
-            hard_rule=logic.zerg_pass_vents,
+            logic.zerg_enemy_within_pass_vents,
+            hard_rule=logic.zerg_enemy_within_pass_vents,
         ),
         make_location_data(
             SC2Mission.ENEMY_WITHIN.mission_name,
             "First Niadra Evolution",
             SC2HOTS_LOC_ID_OFFSET + 602,
             LocationType.VANILLA,
-            logic.zerg_pass_vents,
+            logic.zerg_enemy_within_pass_vents,
         ),
         make_location_data(
             SC2Mission.ENEMY_WITHIN.mission_name,
             "Second Niadra Evolution",
             SC2HOTS_LOC_ID_OFFSET + 603,
             LocationType.VANILLA,
-            logic.zerg_pass_vents,
-            hard_rule=logic.zerg_pass_vents,
+            logic.zerg_enemy_within_pass_vents,
+            hard_rule=logic.zerg_enemy_within_pass_vents,
         ),
         make_location_data(
             SC2Mission.ENEMY_WITHIN.mission_name,
             "Third Niadra Evolution",
             SC2HOTS_LOC_ID_OFFSET + 604,
             LocationType.VANILLA,
-            logic.zerg_pass_vents,
-            hard_rule=logic.zerg_pass_vents,
+            logic.zerg_enemy_within_pass_vents,
+            hard_rule=logic.zerg_enemy_within_pass_vents,
         ),
         make_location_data(
             SC2Mission.ENEMY_WITHIN.mission_name,
             "Warp Drive",
             SC2HOTS_LOC_ID_OFFSET + 605,
             LocationType.EXTRA,
-            logic.zerg_pass_vents,
-            hard_rule=logic.zerg_pass_vents,
+            logic.zerg_enemy_within_pass_vents,
+            hard_rule=logic.zerg_enemy_within_pass_vents,
         ),
         make_location_data(
             SC2Mission.ENEMY_WITHIN.mission_name,
             "Stasis Quadrant",
             SC2HOTS_LOC_ID_OFFSET + 606,
             LocationType.EXTRA,
-            logic.zerg_pass_vents,
-            hard_rule=logic.zerg_pass_vents,
+            logic.zerg_enemy_within_pass_vents,
+            hard_rule=logic.zerg_enemy_within_pass_vents,
         ),
         make_location_data(
             SC2Mission.DOMINATION.mission_name,
@@ -3686,8 +3684,7 @@ def get_locations(world: Optional["SC2World"]) -> Tuple[LocationData, ...]:
             "Zerg Base",
             SC2LOTV_LOC_ID_OFFSET + 105,
             LocationType.MASTERY,
-            lambda state: logic.protoss_deathball(state)
-            and logic.protoss_power_rating(state) >= 6,
+            logic.protoss_dark_whispers_zerg_base,
             flags=LocationFlag.BASEBUST,
         ),
         make_location_data(
@@ -3695,47 +3692,35 @@ def get_locations(world: Optional["SC2World"]) -> Tuple[LocationData, ...]:
             "Victory",
             SC2LOTV_LOC_ID_OFFSET + 200,
             LocationType.VICTORY,
-            lambda state: logic.protoss_competent_comp(state)
-            and logic.protoss_mineral_dump(state),
+            logic.protoss_ghosts_in_the_fog_requirement,
         ),
         make_location_data(
             SC2Mission.GHOSTS_IN_THE_FOG.mission_name,
             "South Rock Formation",
             SC2LOTV_LOC_ID_OFFSET + 201,
             LocationType.VANILLA,
-            lambda state: logic.protoss_competent_comp(state)
-            and logic.protoss_mineral_dump(state),
+            logic.protoss_ghosts_in_the_fog_requirement,
         ),
         make_location_data(
             SC2Mission.GHOSTS_IN_THE_FOG.mission_name,
             "West Rock Formation",
             SC2LOTV_LOC_ID_OFFSET + 202,
             LocationType.VANILLA,
-            lambda state: logic.protoss_competent_comp(state)
-            and logic.protoss_mineral_dump(state),
+            logic.protoss_ghosts_in_the_fog_requirement,
         ),
         make_location_data(
             SC2Mission.GHOSTS_IN_THE_FOG.mission_name,
             "East Rock Formation",
             SC2LOTV_LOC_ID_OFFSET + 203,
             LocationType.VANILLA,
-            lambda state: (
-                logic.protoss_competent_comp(state)
-                and logic.protoss_mineral_dump(state)
-                and logic.protoss_can_attack_behind_chasm(state)
-            ),
+            logic.protoss_ghosts_in_the_fog_east_rock_formation,
         ),
         make_location_data(
             SC2Mission.EVIL_AWOKEN.mission_name,
             "Victory",
             SC2LOTV_LOC_ID_OFFSET + 300,
             LocationType.VICTORY,
-            lambda state: adv_tactics
-            or state.has_any((
-                item_names.STALKER_PHASE_REACTOR,
-                item_names.STALKER_INSTIGATOR_SLAYER_DISINTEGRATING_PARTICLES,
-                item_names.STALKER_INSTIGATOR_SLAYER_PARTICLE_REFLECTION,
-            ), player),
+            logic.protoss_evil_awoken_requirement,
         ),
         make_location_data(
             SC2Mission.EVIL_AWOKEN.mission_name,
@@ -5138,7 +5123,7 @@ def get_locations(world: Optional["SC2World"]) -> Tuple[LocationData, ...]:
             SC2NCO_LOC_ID_OFFSET + 301,
             LocationType.EXTRA,
             logic.enemy_intelligence_first_stage_requirement,
-            hard_rule=logic.enemy_intelligence_garrisonable_unit,
+            hard_rule=logic.terran_enemy_intelligence_garrisonable_unit,
         ),
         make_location_data(
             SC2Mission.ENEMY_INTELLIGENCE.mission_name,
@@ -5146,7 +5131,7 @@ def get_locations(world: Optional["SC2World"]) -> Tuple[LocationData, ...]:
             SC2NCO_LOC_ID_OFFSET + 302,
             LocationType.EXTRA,
             logic.enemy_intelligence_first_stage_requirement,
-            hard_rule=logic.enemy_intelligence_garrisonable_unit,
+            hard_rule=logic.terran_enemy_intelligence_garrisonable_unit,
         ),
         make_location_data(
             SC2Mission.ENEMY_INTELLIGENCE.mission_name,
@@ -5154,7 +5139,7 @@ def get_locations(world: Optional["SC2World"]) -> Tuple[LocationData, ...]:
             SC2NCO_LOC_ID_OFFSET + 303,
             LocationType.EXTRA,
             logic.enemy_intelligence_first_stage_requirement,
-            hard_rule=logic.enemy_intelligence_garrisonable_unit,
+            hard_rule=logic.terran_enemy_intelligence_garrisonable_unit,
         ),
         make_location_data(
             SC2Mission.ENEMY_INTELLIGENCE.mission_name,
@@ -5173,7 +5158,7 @@ def get_locations(world: Optional["SC2World"]) -> Tuple[LocationData, ...]:
             SC2NCO_LOC_ID_OFFSET + 305,
             LocationType.EXTRA,
             logic.enemy_intelligence_first_stage_requirement,
-            hard_rule=logic.enemy_intelligence_garrisonable_unit,
+            hard_rule=logic.terran_enemy_intelligence_garrisonable_unit,
         ),
         make_location_data(
             SC2Mission.ENEMY_INTELLIGENCE.mission_name,
@@ -5516,8 +5501,7 @@ def get_locations(world: Optional["SC2World"]) -> Tuple[LocationData, ...]:
             SC2NCO_LOC_ID_OFFSET + 700,
             LocationType.VICTORY,
             logic.enemy_shadow_victory,
-            hard_rule=lambda state: logic.nova_beat_stone(state)
-                and logic.enemy_shadow_door_unlocks_tool(state),
+            hard_rule=logic.enemy_shadow_victory_hard_rule,
         ),
         make_location_data(
             SC2Mission.IN_THE_ENEMY_S_SHADOW.mission_name,
@@ -5548,18 +5532,16 @@ def get_locations(world: Optional["SC2World"]) -> Tuple[LocationData, ...]:
             "Facility: Northwest Door Lock",
             SC2NCO_LOC_ID_OFFSET + 704,
             LocationType.VANILLA,
-            logic.enemy_shadow_door_controls,
-            hard_rule=lambda state: logic.enemy_shadow_hard_rule(state)
-            and logic.enemy_shadow_door_unlocks_tool(state),
+            logic.enemy_shadow_can_reach_stone,
+            hard_rule=logic.enemy_shadow_can_reach_stone_hard_rule,
         ),
         make_location_data(
             SC2Mission.IN_THE_ENEMY_S_SHADOW.mission_name,
             "Facility: Southeast Door Lock",
             SC2NCO_LOC_ID_OFFSET + 705,
             LocationType.VANILLA,
-            logic.enemy_shadow_door_controls,
-            hard_rule=lambda state: logic.enemy_shadow_hard_rule(state)
-            and logic.enemy_shadow_door_unlocks_tool(state),
+            logic.enemy_shadow_can_reach_stone,
+            hard_rule=logic.enemy_shadow_can_reach_stone_hard_rule,
         ),
         make_location_data(
             SC2Mission.IN_THE_ENEMY_S_SHADOW.mission_name,
@@ -6331,8 +6313,7 @@ def get_locations(world: Optional["SC2World"]) -> Tuple[LocationData, ...]:
             "Victory",
             SC2_RACESWAP_LOC_ID_OFFSET + 1100,
             LocationType.VICTORY,
-            lambda state: logic.zerg_common_unit(state)
-            and logic.zerg_competent_anti_air(state),
+            logic.zerg_common_unit_competent_aa,
             hard_rule=logic.zerg_any_anti_air,
         ),
         make_location_data(
@@ -6340,32 +6321,28 @@ def get_locations(world: Optional["SC2World"]) -> Tuple[LocationData, ...]:
             "North Nexus",
             SC2_RACESWAP_LOC_ID_OFFSET + 1101,
             LocationType.EXTRA,
-            lambda state: logic.zerg_common_unit(state)
-            and logic.zerg_competent_anti_air(state),
+            logic.zerg_common_unit_competent_aa,
         ),
         make_location_data(
             SC2Mission.SAFE_HAVEN_Z.mission_name,
             "East Nexus",
             SC2_RACESWAP_LOC_ID_OFFSET + 1102,
             LocationType.EXTRA,
-            lambda state: logic.zerg_common_unit(state)
-            and logic.zerg_competent_anti_air(state),
+            logic.zerg_common_unit_competent_aa,
         ),
         make_location_data(
             SC2Mission.SAFE_HAVEN_Z.mission_name,
             "South Nexus",
             SC2_RACESWAP_LOC_ID_OFFSET + 1103,
             LocationType.EXTRA,
-            lambda state: logic.zerg_common_unit(state)
-            and logic.zerg_competent_anti_air(state),
+            logic.zerg_common_unit_competent_aa,
         ),
         make_location_data(
             SC2Mission.SAFE_HAVEN_Z.mission_name,
             "First Terror Fleet",
             SC2_RACESWAP_LOC_ID_OFFSET + 1104,
             LocationType.VANILLA,
-            lambda state: logic.zerg_common_unit(state)
-            and logic.zerg_competent_anti_air(state),
+            logic.zerg_common_unit_competent_aa,
             hard_rule=logic.zerg_any_anti_air,
         ),
         make_location_data(
@@ -6373,8 +6350,7 @@ def get_locations(world: Optional["SC2World"]) -> Tuple[LocationData, ...]:
             "Second Terror Fleet",
             SC2_RACESWAP_LOC_ID_OFFSET + 1105,
             LocationType.VANILLA,
-            lambda state: logic.zerg_common_unit(state)
-            and logic.zerg_competent_anti_air(state),
+            logic.zerg_common_unit_competent_aa,
             hard_rule=logic.zerg_any_anti_air,
         ),
         make_location_data(
@@ -6382,8 +6358,7 @@ def get_locations(world: Optional["SC2World"]) -> Tuple[LocationData, ...]:
             "Third Terror Fleet",
             SC2_RACESWAP_LOC_ID_OFFSET + 1106,
             LocationType.VANILLA,
-            lambda state: logic.zerg_common_unit(state)
-            and logic.zerg_competent_anti_air(state),
+            logic.zerg_common_unit_competent_aa,
             hard_rule=logic.zerg_any_anti_air,
         ),
         make_location_data(
@@ -6391,8 +6366,7 @@ def get_locations(world: Optional["SC2World"]) -> Tuple[LocationData, ...]:
             "Victory",
             SC2_RACESWAP_LOC_ID_OFFSET + 1200,
             LocationType.VICTORY,
-            lambda state: logic.protoss_common_unit(state)
-            and logic.protoss_anti_armor_anti_air(state),
+            logic.protoss_common_unit_anti_armor_air,
             hard_rule=logic.protoss_any_anti_air_unit_or_soa_any_protoss,
         ),
         make_location_data(
@@ -6400,32 +6374,28 @@ def get_locations(world: Optional["SC2World"]) -> Tuple[LocationData, ...]:
             "North Nexus",
             SC2_RACESWAP_LOC_ID_OFFSET + 1201,
             LocationType.EXTRA,
-            lambda state: logic.protoss_common_unit(state)
-            and logic.protoss_anti_armor_anti_air(state),
+            logic.protoss_common_unit_anti_armor_air,
         ),
         make_location_data(
             SC2Mission.SAFE_HAVEN_P.mission_name,
             "East Nexus",
             SC2_RACESWAP_LOC_ID_OFFSET + 1202,
             LocationType.EXTRA,
-            lambda state: logic.protoss_common_unit(state)
-            and logic.protoss_anti_armor_anti_air(state),
+            logic.protoss_common_unit_anti_armor_air,
         ),
         make_location_data(
             SC2Mission.SAFE_HAVEN_P.mission_name,
             "South Nexus",
             SC2_RACESWAP_LOC_ID_OFFSET + 1203,
             LocationType.EXTRA,
-            lambda state: logic.protoss_common_unit(state)
-            and logic.protoss_anti_armor_anti_air(state),
+            logic.protoss_common_unit_anti_armor_air,
         ),
         make_location_data(
             SC2Mission.SAFE_HAVEN_P.mission_name,
             "First Terror Fleet",
             SC2_RACESWAP_LOC_ID_OFFSET + 1204,
             LocationType.VANILLA,
-            lambda state: logic.protoss_common_unit(state)
-            and logic.protoss_anti_armor_anti_air(state),
+            logic.protoss_common_unit_anti_armor_air,
             hard_rule=logic.protoss_any_anti_air_unit_or_soa_any_protoss,
         ),
         make_location_data(
@@ -6433,8 +6403,7 @@ def get_locations(world: Optional["SC2World"]) -> Tuple[LocationData, ...]:
             "Second Terror Fleet",
             SC2_RACESWAP_LOC_ID_OFFSET + 1205,
             LocationType.VANILLA,
-            lambda state: logic.protoss_common_unit(state)
-            and logic.protoss_anti_armor_anti_air(state),
+            logic.protoss_common_unit_anti_armor_air,
             hard_rule=logic.protoss_any_anti_air_unit_or_soa_any_protoss,
         ),
         make_location_data(
@@ -6442,8 +6411,7 @@ def get_locations(world: Optional["SC2World"]) -> Tuple[LocationData, ...]:
             "Third Terror Fleet",
             SC2_RACESWAP_LOC_ID_OFFSET + 1206,
             LocationType.VANILLA,
-            lambda state: logic.protoss_common_unit(state)
-            and logic.protoss_anti_armor_anti_air(state),
+            logic.protoss_common_unit_anti_armor_air,
             hard_rule=logic.protoss_any_anti_air_unit_or_soa_any_protoss,
         ),
         make_location_data(
@@ -6459,9 +6427,7 @@ def get_locations(world: Optional["SC2World"]) -> Tuple[LocationData, ...]:
             "North Hive",
             SC2_RACESWAP_LOC_ID_OFFSET + 1301,
             LocationType.VANILLA,
-            lambda state: (
-                logic.zerg_common_unit(state) and logic.zerg_competent_anti_air(state)
-            ),
+            logic.zerg_common_unit_competent_aa,
         ),
         make_location_data(
             SC2Mission.HAVENS_FALL_Z.mission_name,
@@ -6594,10 +6560,7 @@ def get_locations(world: Optional["SC2World"]) -> Tuple[LocationData, ...]:
             "North Hive",
             SC2_RACESWAP_LOC_ID_OFFSET + 1401,
             LocationType.VANILLA,
-            lambda state: (
-                logic.protoss_common_unit(state)
-                and logic.protoss_competent_anti_air(state)
-            ),
+            logic.protoss_common_unit_competent_anti_air,
         ),
         make_location_data(
             SC2Mission.HAVENS_FALL_P.mission_name,
@@ -6618,7 +6581,7 @@ def get_locations(world: Optional["SC2World"]) -> Tuple[LocationData, ...]:
             "Northeast Colony Base",
             SC2_RACESWAP_LOC_ID_OFFSET + 1404,
             LocationType.CHALLENGE,
-            logic.protoss_respond_to_colony_infestations,
+            logic.protoss_havens_fall_respond_to_colony_infestations,
             hard_rule=logic.protoss_any_anti_air_unit_or_soa_any_protoss,
         ),
         make_location_data(
@@ -6626,7 +6589,7 @@ def get_locations(world: Optional["SC2World"]) -> Tuple[LocationData, ...]:
             "East Colony Base",
             SC2_RACESWAP_LOC_ID_OFFSET + 1405,
             LocationType.CHALLENGE,
-            logic.protoss_respond_to_colony_infestations,
+            logic.protoss_havens_fall_respond_to_colony_infestations,
             hard_rule=logic.protoss_any_anti_air_unit_or_soa_any_protoss,
         ),
         make_location_data(
@@ -6634,7 +6597,7 @@ def get_locations(world: Optional["SC2World"]) -> Tuple[LocationData, ...]:
             "Middle Colony Base",
             SC2_RACESWAP_LOC_ID_OFFSET + 1406,
             LocationType.CHALLENGE,
-            logic.protoss_respond_to_colony_infestations,
+            logic.protoss_havens_fall_respond_to_colony_infestations,
             hard_rule=logic.protoss_any_anti_air_unit_or_soa_any_protoss,
         ),
         make_location_data(
@@ -6642,7 +6605,7 @@ def get_locations(world: Optional["SC2World"]) -> Tuple[LocationData, ...]:
             "Southeast Colony Base",
             SC2_RACESWAP_LOC_ID_OFFSET + 1407,
             LocationType.CHALLENGE,
-            logic.protoss_respond_to_colony_infestations,
+            logic.protoss_havens_fall_respond_to_colony_infestations,
             hard_rule=logic.protoss_any_anti_air_unit_or_soa_any_protoss,
         ),
         make_location_data(
@@ -6650,7 +6613,7 @@ def get_locations(world: Optional["SC2World"]) -> Tuple[LocationData, ...]:
             "Southwest Colony Base",
             SC2_RACESWAP_LOC_ID_OFFSET + 1408,
             LocationType.CHALLENGE,
-            logic.protoss_respond_to_colony_infestations,
+            logic.protoss_havens_fall_respond_to_colony_infestations,
             hard_rule=logic.protoss_any_anti_air_unit_or_soa_any_protoss,
         ),
         make_location_data(
@@ -6824,7 +6787,7 @@ def get_locations(world: Optional["SC2World"]) -> Tuple[LocationData, ...]:
             "Second Relic",
             SC2_RACESWAP_LOC_ID_OFFSET + 1602,
             LocationType.VANILLA,
-            lambda state: adv_tactics or logic.protoss_common_unit(state),
+            logic.protoss_common_unit_or_advanced_tactics,
         ),
         make_location_data(
             SC2Mission.SMASH_AND_GRAB_P.mission_name,
@@ -7112,75 +7075,35 @@ def get_locations(world: Optional["SC2World"]) -> Tuple[LocationData, ...]:
             "South Rescue",
             SC2_RACESWAP_LOC_ID_OFFSET + 1903,
             LocationType.EXTRA,
-            lambda state: state.has_any(
-                {
-                    item_names.YGGDRASIL,
-                    item_names.OVERLORD_VENTRAL_SACS,
-                    item_names.NYDUS_WORM,
-                    item_names.BULLFROG,
-                },
-                player,
-            ),
+            logic.zerg_moebius_factor_can_rescue,
         ),
         make_location_data(
             SC2Mission.THE_MOEBIUS_FACTOR_Z.mission_name,
             "Wall Rescue",
             SC2_RACESWAP_LOC_ID_OFFSET + 1904,
             LocationType.EXTRA,
-            lambda state: state.has_any(
-                {
-                    item_names.YGGDRASIL,
-                    item_names.OVERLORD_VENTRAL_SACS,
-                    item_names.NYDUS_WORM,
-                    item_names.BULLFROG,
-                },
-                player,
-            ),
+            logic.zerg_moebius_factor_can_rescue,
         ),
         make_location_data(
             SC2Mission.THE_MOEBIUS_FACTOR_Z.mission_name,
             "Mid Rescue",
             SC2_RACESWAP_LOC_ID_OFFSET + 1905,
             LocationType.EXTRA,
-            lambda state: state.has_any(
-                {
-                    item_names.YGGDRASIL,
-                    item_names.OVERLORD_VENTRAL_SACS,
-                    item_names.NYDUS_WORM,
-                    item_names.BULLFROG,
-                },
-                player,
-            ),
+            logic.zerg_moebius_factor_can_rescue,
         ),
         make_location_data(
             SC2Mission.THE_MOEBIUS_FACTOR_Z.mission_name,
             "Nydus Roof Rescue",
             SC2_RACESWAP_LOC_ID_OFFSET + 1906,
             LocationType.EXTRA,
-            lambda state: state.has_any(
-                {
-                    item_names.YGGDRASIL,
-                    item_names.OVERLORD_VENTRAL_SACS,
-                    item_names.NYDUS_WORM,
-                    item_names.BULLFROG,
-                },
-                player,
-            ),
+            logic.zerg_moebius_factor_can_rescue,
         ),
         make_location_data(
             SC2Mission.THE_MOEBIUS_FACTOR_Z.mission_name,
             "Alive Inside Rescue",
             SC2_RACESWAP_LOC_ID_OFFSET + 1907,
             LocationType.EXTRA,
-            lambda state: state.has_any(
-                {
-                    item_names.YGGDRASIL,
-                    item_names.OVERLORD_VENTRAL_SACS,
-                    item_names.NYDUS_WORM,
-                    item_names.BULLFROG,
-                },
-                player,
-            ),
+            logic.zerg_moebius_factor_can_rescue,
         ),
         make_location_data(
             SC2Mission.THE_MOEBIUS_FACTOR_Z.mission_name,
@@ -7264,35 +7187,35 @@ def get_locations(world: Optional["SC2World"]) -> Tuple[LocationData, ...]:
             "South Rescue",
             SC2_RACESWAP_LOC_ID_OFFSET + 2003,
             LocationType.EXTRA,
-            lambda state: adv_tactics or state.has(item_names.WARP_PRISM, player),
+            logic.protoss_moebius_factor_can_rescue,
         ),
         make_location_data(
             SC2Mission.THE_MOEBIUS_FACTOR_P.mission_name,
             "Wall Rescue",
             SC2_RACESWAP_LOC_ID_OFFSET + 2004,
             LocationType.EXTRA,
-            lambda state: adv_tactics or state.has(item_names.WARP_PRISM, player),
+            logic.protoss_moebius_factor_can_rescue,
         ),
         make_location_data(
             SC2Mission.THE_MOEBIUS_FACTOR_P.mission_name,
             "Mid Rescue",
             SC2_RACESWAP_LOC_ID_OFFSET + 2005,
             LocationType.EXTRA,
-            lambda state: adv_tactics or state.has(item_names.WARP_PRISM, player),
+            logic.protoss_moebius_factor_can_rescue,
         ),
         make_location_data(
             SC2Mission.THE_MOEBIUS_FACTOR_P.mission_name,
             "Nydus Roof Rescue",
             SC2_RACESWAP_LOC_ID_OFFSET + 2006,
             LocationType.EXTRA,
-            lambda state: adv_tactics or state.has(item_names.WARP_PRISM, player),
+            logic.protoss_moebius_factor_can_rescue,
         ),
         make_location_data(
             SC2Mission.THE_MOEBIUS_FACTOR_P.mission_name,
             "Alive Inside Rescue",
             SC2_RACESWAP_LOC_ID_OFFSET + 2007,
             LocationType.EXTRA,
-            lambda state: adv_tactics or state.has(item_names.WARP_PRISM, player),
+            logic.protoss_moebius_factor_can_rescue,
         ),
         make_location_data(
             SC2Mission.THE_MOEBIUS_FACTOR_P.mission_name,
@@ -7544,14 +7467,14 @@ def get_locations(world: Optional["SC2World"]) -> Tuple[LocationData, ...]:
             "Expansion Prisoners",
             SC2_RACESWAP_LOC_ID_OFFSET + 2402,
             LocationType.VANILLA,
-            lambda state: adv_tactics or logic.protoss_maw_requirement(state),
+            logic.protoss_maw_snipeable_locations,
         ),
         make_location_data(
             SC2Mission.MAW_OF_THE_VOID_P.mission_name,
             "South Close Prisoners",
             SC2_RACESWAP_LOC_ID_OFFSET + 2403,
             LocationType.VANILLA,
-            lambda state: adv_tactics or logic.protoss_maw_requirement(state),
+            logic.protoss_maw_snipeable_locations,
         ),
         make_location_data(
             SC2Mission.MAW_OF_THE_VOID_P.mission_name,
@@ -7580,7 +7503,7 @@ def get_locations(world: Optional["SC2World"]) -> Tuple[LocationData, ...]:
             "Expansion Rip Field Generator",
             SC2_RACESWAP_LOC_ID_OFFSET + 2407,
             LocationType.EXTRA,
-            lambda state: adv_tactics or logic.protoss_maw_requirement(state),
+            logic.protoss_maw_snipeable_locations,
         ),
         make_location_data(
             SC2Mission.MAW_OF_THE_VOID_P.mission_name,
@@ -7645,7 +7568,7 @@ def get_locations(world: Optional["SC2World"]) -> Tuple[LocationData, ...]:
             "Brutalisk",
             SC2_RACESWAP_LOC_ID_OFFSET + 2502,
             LocationType.VANILLA,
-            lambda state: logic.zerg_common_unit(state),
+            logic.zerg_common_unit,
         ),
         make_location_data(
             SC2Mission.DEVILS_PLAYGROUND_Z.mission_name,
@@ -7664,7 +7587,7 @@ def get_locations(world: Optional["SC2World"]) -> Tuple[LocationData, ...]:
             "Southwest Reinforcements",
             SC2_RACESWAP_LOC_ID_OFFSET + 2505,
             LocationType.EXTRA,
-            lambda state: logic.zerg_common_unit(state),
+            logic.zerg_common_unit,
         ),
         make_location_data(
             SC2Mission.DEVILS_PLAYGROUND_Z.mission_name,
@@ -9654,7 +9577,7 @@ def get_locations(world: Optional["SC2World"]) -> Tuple[LocationData, ...]:
             "Kill All Buildings Before Reinforcements",
             SC2_RACESWAP_LOC_ID_OFFSET + 6405,
             LocationType.MASTERY,
-            logic.protoss_rendezvous_requirement,
+            logic.protoss_rendezvous_speedrun_requirement,
             flags=LocationFlag.SPEEDRUN,
         ),
         make_location_data(
@@ -11983,11 +11906,7 @@ def get_locations(world: Optional["SC2World"]) -> Tuple[LocationData, ...]:
             "East Rock Formation",
             SC2_RACESWAP_LOC_ID_OFFSET + 10103,
             LocationType.VANILLA,
-            lambda state: (
-                logic.terran_beats_protoss_deathball(state)
-                and logic.terran_mineral_dump(state)
-                and logic.terran_can_grab_ghosts_in_the_fog_east_rock_formation(state)
-            ),
+            logic.terran_ghosts_in_the_fog_east_rock_formation_requirement,
         ),
         make_location_data(
             SC2Mission.GHOSTS_IN_THE_FOG_Z.mission_name,
@@ -12027,12 +11946,7 @@ def get_locations(world: Optional["SC2World"]) -> Tuple[LocationData, ...]:
             "East Rock Formation",
             SC2_RACESWAP_LOC_ID_OFFSET + 10203,
             LocationType.VANILLA,
-            lambda state: (
-                logic.zerg_competent_comp(state)
-                and logic.zerg_competent_anti_air(state)
-                and logic.zerg_mineral_dump(state)
-                and logic.zerg_can_grab_ghosts_in_the_fog_east_rock_formation(state)
-            ),
+            logic.zerg_ghosts_in_the_fog_east_rock_formation_requirement,
         ),
         make_location_data(
             SC2Mission.FOR_AIUR_T.mission_name,

--- a/worlds/sc2/locations.py
+++ b/worlds/sc2/locations.py
@@ -1328,10 +1328,7 @@ def get_locations(world: Optional["SC2World"]) -> Tuple[LocationData, ...]:
             "Victory",
             SC2WOL_LOC_ID_OFFSET + 1700,
             LocationType.VICTORY,
-            lambda state: (
-                logic.terran_great_train_robbery_train_stopper(state)
-                and logic.terran_basic_anti_air(state)
-            ),
+            logic.terran_great_train_robbery_requirement,
         ),
         make_location_data(
             SC2Mission.THE_GREAT_TRAIN_ROBBERY.mission_name,
@@ -1392,21 +1389,14 @@ def get_locations(world: Optional["SC2World"]) -> Tuple[LocationData, ...]:
             "Kill Team",
             SC2WOL_LOC_ID_OFFSET + 1710,
             LocationType.CHALLENGE,
-            lambda state: (
-                (adv_tactics or logic.terran_common_unit(state))
-                and logic.terran_great_train_robbery_train_stopper(state)
-                and logic.terran_basic_anti_air(state)
-            ),
+            logic.terran_great_train_robbery_kill_team,
         ),
         make_location_data(
             SC2Mission.THE_GREAT_TRAIN_ROBBERY.mission_name,
             "Flawless",
             SC2WOL_LOC_ID_OFFSET + 1711,
             LocationType.CHALLENGE,
-            lambda state: (
-                logic.terran_great_train_robbery_train_stopper(state)
-                and logic.terran_basic_anti_air(state)
-            ),
+            logic.terran_great_train_robbery_requirement,
             flags=LocationFlag.PREVENTATIVE,
         ),
         make_location_data(
@@ -1421,30 +1411,21 @@ def get_locations(world: Optional["SC2World"]) -> Tuple[LocationData, ...]:
             "4 Trains Destroyed",
             SC2WOL_LOC_ID_OFFSET + 1713,
             LocationType.EXTRA,
-            lambda state: (
-                logic.terran_great_train_robbery_train_stopper(state)
-                and logic.terran_basic_anti_air(state)
-            ),
+            logic.terran_great_train_robbery_requirement,
         ),
         make_location_data(
             SC2Mission.THE_GREAT_TRAIN_ROBBERY.mission_name,
             "6 Trains Destroyed",
             SC2WOL_LOC_ID_OFFSET + 1714,
             LocationType.EXTRA,
-            lambda state: (
-                logic.terran_great_train_robbery_train_stopper(state)
-                and logic.terran_basic_anti_air(state)
-            ),
+            logic.terran_great_train_robbery_requirement,
         ),
         make_location_data(
             SC2Mission.CUTTHROAT.mission_name,
             "Victory",
             SC2WOL_LOC_ID_OFFSET + 1800,
             LocationType.VICTORY,
-            lambda state: (
-                logic.terran_common_unit(state)
-                and (adv_tactics or logic.terran_moderate_anti_air(state))
-            ),
+            logic.terran_cutthroat_victory,
         ),
         make_location_data(
             SC2Mission.CUTTHROAT.mission_name,
@@ -1597,7 +1578,7 @@ def get_locations(world: Optional["SC2World"]) -> Tuple[LocationData, ...]:
             "Science Facility",
             SC2WOL_LOC_ID_OFFSET + 2004,
             LocationType.VANILLA,
-            lambda state: adv_tactics or logic.terran_competent_comp(state),
+            logic.terran_competent_comp_or_advanced_tactics,
         ),
         make_location_data(
             SC2Mission.MEDIA_BLITZ.mission_name,
@@ -1618,7 +1599,7 @@ def get_locations(world: Optional["SC2World"]) -> Tuple[LocationData, ...]:
             "All Starports",
             SC2WOL_LOC_ID_OFFSET + 2007,
             LocationType.EXTRA,
-            lambda state: adv_tactics or logic.terran_competent_comp(state),
+            logic.terran_competent_comp_or_advanced_tactics,
         ),
         make_location_data(
             SC2Mission.MEDIA_BLITZ.mission_name,
@@ -1747,46 +1728,42 @@ def get_locations(world: Optional["SC2World"]) -> Tuple[LocationData, ...]:
             "Victory",
             SC2WOL_LOC_ID_OFFSET + 2300,
             LocationType.VICTORY,
-            lambda state: logic.protoss_common_unit(state)
-            and logic.protoss_competent_anti_air(state),
+            logic.protoss_common_unit_competent_anti_air,
         ),
         make_location_data(
             SC2Mission.A_SINISTER_TURN.mission_name,
             "Robotics Facility",
             SC2WOL_LOC_ID_OFFSET + 2301,
             LocationType.VANILLA,
-            lambda state: adv_tactics or logic.protoss_common_unit(state),
+            logic.protoss_common_unit_or_advanced_tactics,
         ),
         make_location_data(
             SC2Mission.A_SINISTER_TURN.mission_name,
             "Dark Shrine",
             SC2WOL_LOC_ID_OFFSET + 2302,
             LocationType.VANILLA,
-            lambda state: adv_tactics or logic.protoss_common_unit(state),
+            logic.protoss_common_unit_or_advanced_tactics,
         ),
         make_location_data(
             SC2Mission.A_SINISTER_TURN.mission_name,
             "Templar Archives",
             SC2WOL_LOC_ID_OFFSET + 2303,
             LocationType.VANILLA,
-            lambda state: logic.protoss_common_unit(state)
-            and logic.protoss_competent_anti_air(state),
+            logic.protoss_common_unit_competent_anti_air,
         ),
         make_location_data(
             SC2Mission.A_SINISTER_TURN.mission_name,
             "Northeast Base",
             SC2WOL_LOC_ID_OFFSET + 2304,
             LocationType.EXTRA,
-            lambda state: logic.protoss_common_unit(state)
-            and logic.protoss_competent_anti_air(state),
+            logic.protoss_common_unit_competent_anti_air,
         ),
         make_location_data(
             SC2Mission.A_SINISTER_TURN.mission_name,
             "Southwest Base",
             SC2WOL_LOC_ID_OFFSET + 2305,
             LocationType.CHALLENGE,
-            lambda state: logic.protoss_common_unit(state)
-            and logic.protoss_competent_anti_air(state),
+            logic.protoss_common_unit_competent_anti_air,
             flags=LocationFlag.BASEBUST,
         ),
         make_location_data(
@@ -1801,37 +1778,28 @@ def get_locations(world: Optional["SC2World"]) -> Tuple[LocationData, ...]:
             "Northwest Preserver",
             SC2WOL_LOC_ID_OFFSET + 2307,
             LocationType.EXTRA,
-            lambda state: logic.protoss_common_unit(state)
-            and logic.protoss_competent_anti_air(state),
+            logic.protoss_common_unit_competent_anti_air,
         ),
         make_location_data(
             SC2Mission.A_SINISTER_TURN.mission_name,
             "Southwest Preserver",
             SC2WOL_LOC_ID_OFFSET + 2308,
             LocationType.EXTRA,
-            lambda state: logic.protoss_common_unit(state)
-            and logic.protoss_competent_anti_air(state),
+            logic.protoss_common_unit_competent_anti_air,
         ),
         make_location_data(
             SC2Mission.A_SINISTER_TURN.mission_name,
             "East Preserver",
             SC2WOL_LOC_ID_OFFSET + 2309,
             LocationType.EXTRA,
-            lambda state: logic.protoss_common_unit(state)
-            and logic.protoss_competent_anti_air(state),
+            logic.protoss_common_unit_competent_anti_air,
         ),
         make_location_data(
             SC2Mission.ECHOES_OF_THE_FUTURE.mission_name,
             "Victory",
             SC2WOL_LOC_ID_OFFSET + 2400,
             LocationType.VICTORY,
-            lambda state: (
-                (adv_tactics and logic.protoss_static_defense(state))
-                or (
-                    logic.protoss_common_unit(state)
-                    and logic.protoss_competent_anti_air(state)
-                )
-            ),
+            logic.protoss_common_unit_competent_anti_air,
         ),
         make_location_data(
             SC2Mission.ECHOES_OF_THE_FUTURE.mission_name,
@@ -1863,27 +1831,21 @@ def get_locations(world: Optional["SC2World"]) -> Tuple[LocationData, ...]:
             "Southeast Tendril",
             SC2WOL_LOC_ID_OFFSET + 2405,
             LocationType.EXTRA,
-            lambda state: adv_tactics
-            and logic.protoss_static_defense(state)
-            or logic.protoss_common_unit(state),
+            logic.protoss_common_unit,
         ),
         make_location_data(
             SC2Mission.ECHOES_OF_THE_FUTURE.mission_name,
             "Northeast Tendril",
             SC2WOL_LOC_ID_OFFSET + 2406,
             LocationType.EXTRA,
-            lambda state: adv_tactics
-            and logic.protoss_static_defense(state)
-            or logic.protoss_common_unit(state),
+            logic.protoss_common_unit,
         ),
         make_location_data(
             SC2Mission.ECHOES_OF_THE_FUTURE.mission_name,
             "Northwest Tendril",
             SC2WOL_LOC_ID_OFFSET + 2407,
             LocationType.EXTRA,
-            lambda state: adv_tactics
-            and logic.protoss_static_defense(state)
-            or logic.protoss_common_unit(state),
+            logic.protoss_common_unit,
         ),
         make_location_data(
             SC2Mission.IN_UTTER_DARKNESS.mission_name,
@@ -2021,7 +1983,7 @@ def get_locations(world: Optional["SC2World"]) -> Tuple[LocationData, ...]:
             "Victory",
             SC2WOL_LOC_ID_OFFSET + 2700,
             LocationType.VICTORY,
-            lambda state: adv_tactics or logic.marine_medic_firebat_upgrade(state),
+            logic.terran_belly_of_the_beast_requirement,
         ),
         make_location_data(
             SC2Mission.BELLY_OF_THE_BEAST.mission_name,
@@ -2034,14 +1996,14 @@ def get_locations(world: Optional["SC2World"]) -> Tuple[LocationData, ...]:
             "Second Charge",
             SC2WOL_LOC_ID_OFFSET + 2702,
             LocationType.EXTRA,
-            lambda state: adv_tactics or logic.marine_medic_firebat_upgrade(state),
+            logic.terran_belly_of_the_beast_requirement,
         ),
         make_location_data(
             SC2Mission.BELLY_OF_THE_BEAST.mission_name,
             "Third Charge",
             SC2WOL_LOC_ID_OFFSET + 2703,
             LocationType.EXTRA,
-            lambda state: adv_tactics or logic.marine_medic_firebat_upgrade(state),
+            logic.terran_belly_of_the_beast_requirement,
         ),
         make_location_data(
             SC2Mission.BELLY_OF_THE_BEAST.mission_name,
@@ -2060,14 +2022,14 @@ def get_locations(world: Optional["SC2World"]) -> Tuple[LocationData, ...]:
             "Third Group Rescued",
             SC2WOL_LOC_ID_OFFSET + 2706,
             LocationType.VANILLA,
-            lambda state: adv_tactics or logic.marine_medic_firebat_upgrade(state),
+            logic.terran_belly_of_the_beast_requirement,
         ),
         make_location_data(
             SC2Mission.SHATTER_THE_SKY.mission_name,
             "Victory",
             SC2WOL_LOC_ID_OFFSET + 2800,
             LocationType.VICTORY,
-            lambda state: logic.terran_competent_comp(state, 2),
+            logic.terran_competent_comp_wa2,
         ),
         make_location_data(
             SC2Mission.SHATTER_THE_SKY.mission_name,
@@ -2088,21 +2050,21 @@ def get_locations(world: Optional["SC2World"]) -> Tuple[LocationData, ...]:
             "Southeast Coolant Tower",
             SC2WOL_LOC_ID_OFFSET + 2803,
             LocationType.VANILLA,
-            lambda state: logic.terran_competent_comp(state, 2),
+            logic.terran_competent_comp_wa2,
         ),
         make_location_data(
             SC2Mission.SHATTER_THE_SKY.mission_name,
             "Southwest Coolant Tower",
             SC2WOL_LOC_ID_OFFSET + 2804,
             LocationType.VANILLA,
-            lambda state: logic.terran_competent_comp(state, 2),
+            logic.terran_competent_comp_wa2,
         ),
         make_location_data(
             SC2Mission.SHATTER_THE_SKY.mission_name,
             "Leviathan",
             SC2WOL_LOC_ID_OFFSET + 2805,
             LocationType.VANILLA,
-            lambda state: logic.terran_competent_comp(state, 2),
+            logic.terran_competent_comp_wa2,
             hard_rule=logic.terran_any_anti_air,
         ),
         make_location_data(
@@ -2174,10 +2136,7 @@ def get_locations(world: Optional["SC2World"]) -> Tuple[LocationData, ...]:
             "Victory",
             SC2HOTS_LOC_ID_OFFSET + 100,
             LocationType.VICTORY,
-            lambda state: (
-                logic.zerg_common_unit(state)
-                or state.has_any((item_names.ZERGLING, item_names.PYGALISK), player)
-            ),
+            logic.zerg_lab_rat_requirement,
         ),
         make_location_data(
             SC2Mission.LAB_RAT.mission_name,
@@ -2190,33 +2149,21 @@ def get_locations(world: Optional["SC2World"]) -> Tuple[LocationData, ...]:
             "South Zergling Group",
             SC2HOTS_LOC_ID_OFFSET + 102,
             LocationType.VANILLA,
-            lambda state: adv_tactics
-            or (
-                logic.zerg_common_unit(state)
-                or state.has_any((item_names.ZERGLING, item_names.PYGALISK), player)
-            ),
+            logic.zerg_lab_rat_progress,
         ),
         make_location_data(
             SC2Mission.LAB_RAT.mission_name,
             "East Zergling Group",
             SC2HOTS_LOC_ID_OFFSET + 103,
             LocationType.VANILLA,
-            lambda state: adv_tactics
-            or (
-                logic.zerg_common_unit(state)
-                or state.has_any((item_names.ZERGLING, item_names.PYGALISK), player)
-            ),
+            logic.zerg_lab_rat_progress,
         ),
         make_location_data(
             SC2Mission.LAB_RAT.mission_name,
             "West Zergling Group",
             SC2HOTS_LOC_ID_OFFSET + 104,
             LocationType.VANILLA,
-            lambda state: adv_tactics
-            or (
-                logic.zerg_common_unit(state)
-                or state.has_any((item_names.ZERGLING, item_names.PYGALISK), player)
-            ),
+            logic.zerg_lab_rat_requirement,
         ),
         make_location_data(
             SC2Mission.LAB_RAT.mission_name,
@@ -2235,21 +2182,14 @@ def get_locations(world: Optional["SC2World"]) -> Tuple[LocationData, ...]:
             "Gas Turrets",
             SC2HOTS_LOC_ID_OFFSET + 107,
             LocationType.EXTRA,
-            lambda state: adv_tactics
-            or (
-                logic.zerg_common_unit(state)
-                or state.has_any((item_names.ZERGLING, item_names.PYGALISK), player)
-            ),
+            logic.zerg_lab_rat_progress,
         ),
         make_location_data(
             SC2Mission.LAB_RAT.mission_name,
             "Win In Under 10 Minutes",
             SC2HOTS_LOC_ID_OFFSET + 108,
             LocationType.CHALLENGE,
-            lambda state: (
-                logic.zerg_common_unit(state)
-                or state.has_any((item_names.ZERGLING, item_names.PYGALISK), player)
-            ),
+            logic.zerg_lab_rat_requirement,
             flags=LocationFlag.SPEEDRUN,
         ),
         make_location_data(
@@ -2257,8 +2197,7 @@ def get_locations(world: Optional["SC2World"]) -> Tuple[LocationData, ...]:
             "Victory",
             SC2HOTS_LOC_ID_OFFSET + 200,
             LocationType.VICTORY,
-            lambda state: logic.basic_kerrigan(state)
-                or kerriganless,
+            logic.basic_kerrigan,
             hard_rule=logic.zerg_any_units_back_in_the_saddle_requirement,
         ),
         make_location_data(
@@ -2266,8 +2205,7 @@ def get_locations(world: Optional["SC2World"]) -> Tuple[LocationData, ...]:
             "Defend the Tram",
             SC2HOTS_LOC_ID_OFFSET + 201,
             LocationType.EXTRA,
-            lambda state: logic.basic_kerrigan(state)
-                or kerriganless,
+            logic.basic_kerrigan,
             hard_rule=logic.zerg_any_units_back_in_the_saddle_requirement,
         ),
         make_location_data(
@@ -2293,8 +2231,7 @@ def get_locations(world: Optional["SC2World"]) -> Tuple[LocationData, ...]:
             "Door Section Cleared",
             SC2HOTS_LOC_ID_OFFSET + 205,
             LocationType.EXTRA,
-            lambda state: logic.basic_kerrigan(state)
-                or kerriganless,
+            logic.basic_kerrigan,
             hard_rule=logic.zerg_any_units_back_in_the_saddle_requirement,
         ),
         make_location_data(
@@ -2415,9 +2352,7 @@ def get_locations(world: Optional["SC2World"]) -> Tuple[LocationData, ...]:
             "Victory",
             SC2HOTS_LOC_ID_OFFSET + 500,
             LocationType.VICTORY,
-            lambda state: (
-                logic.zerg_common_unit(state) and logic.zerg_competent_anti_air(state)
-            ),
+            logic.zerg_common_unit_competent_aa,
             hard_rule=logic.zerg_any_anti_air,
         ),
         make_location_data(
@@ -2425,34 +2360,28 @@ def get_locations(world: Optional["SC2World"]) -> Tuple[LocationData, ...]:
             "East Stasis Chamber",
             SC2HOTS_LOC_ID_OFFSET + 501,
             LocationType.VANILLA,
-            lambda state: (
-                logic.zerg_common_unit(state) and logic.zerg_competent_anti_air(state)
-            ),
+            logic.zerg_common_unit_competent_aa,
         ),
         make_location_data(
             SC2Mission.SHOOT_THE_MESSENGER.mission_name,
             "Center Stasis Chamber",
             SC2HOTS_LOC_ID_OFFSET + 502,
             LocationType.VANILLA,
-            lambda state: logic.zerg_common_unit(state) or adv_tactics,
+            logic.zerg_common_unit_or_advanced_tactics,
         ),
         make_location_data(
             SC2Mission.SHOOT_THE_MESSENGER.mission_name,
             "West Stasis Chamber",
             SC2HOTS_LOC_ID_OFFSET + 503,
             LocationType.VANILLA,
-            lambda state: (
-                logic.zerg_common_unit(state) and logic.zerg_competent_anti_air(state)
-            ),
+            logic.zerg_common_unit_competent_aa,
         ),
         make_location_data(
             SC2Mission.SHOOT_THE_MESSENGER.mission_name,
             "Destroy 4 Shuttles",
             SC2HOTS_LOC_ID_OFFSET + 504,
             LocationType.EXTRA,
-            lambda state: (
-                logic.zerg_common_unit(state) and logic.zerg_competent_anti_air(state)
-            ),
+            logic.zerg_common_unit_competent_aa,
             hard_rule=logic.zerg_any_anti_air,
         ),
         make_location_data(
@@ -2473,7 +2402,7 @@ def get_locations(world: Optional["SC2World"]) -> Tuple[LocationData, ...]:
             "Southeast Frozen Zerg",
             SC2HOTS_LOC_ID_OFFSET + 507,
             LocationType.EXTRA,
-            lambda state: logic.zerg_common_unit(state) or adv_tactics,
+            logic.zerg_common_unit_or_advanced_tactics,
         ),
         make_location_data(
             SC2Mission.SHOOT_THE_MESSENGER.mission_name,
@@ -2609,7 +2538,7 @@ def get_locations(world: Optional["SC2World"]) -> Tuple[LocationData, ...]:
             "South Baneling Nest",
             SC2HOTS_LOC_ID_OFFSET + 705,
             LocationType.EXTRA,
-            lambda state: adv_tactics or logic.zerg_common_unit(state),
+            logic.zerg_common_unit_or_advanced_tactics,
         ),
         make_location_data(
             SC2Mission.DOMINATION.mission_name,
@@ -2652,11 +2581,7 @@ def get_locations(world: Optional["SC2World"]) -> Tuple[LocationData, ...]:
             "Victory",
             SC2HOTS_LOC_ID_OFFSET + 800,
             LocationType.VICTORY,
-            lambda state: (
-                logic.zerg_competent_comp(state)
-                and logic.zerg_moderate_anti_air(state)
-                and logic.spread_creep(state)
-            ),
+            logic.zerg_fire_in_the_sky_requirement,
         ),
         make_location_data(
             SC2Mission.FIRE_IN_THE_SKY.mission_name,
@@ -2669,33 +2594,21 @@ def get_locations(world: Optional["SC2World"]) -> Tuple[LocationData, ...]:
             "North Biomass",
             SC2HOTS_LOC_ID_OFFSET + 802,
             LocationType.VANILLA,
-            lambda state: (
-                logic.zerg_competent_comp(state)
-                and logic.zerg_moderate_anti_air(state)
-                and logic.spread_creep(state)
-            ),
+            logic.zerg_fire_in_the_sky_requirement,
         ),
         make_location_data(
             SC2Mission.FIRE_IN_THE_SKY.mission_name,
             "South Biomass",
             SC2HOTS_LOC_ID_OFFSET + 803,
             LocationType.VANILLA,
-            lambda state: (
-                logic.zerg_competent_comp(state)
-                and logic.zerg_moderate_anti_air(state)
-                and logic.spread_creep(state)
-            ),
+            logic.zerg_fire_in_the_sky_requirement,
         ),
         make_location_data(
             SC2Mission.FIRE_IN_THE_SKY.mission_name,
             "Destroy 3 Gorgons",
             SC2HOTS_LOC_ID_OFFSET + 804,
             LocationType.EXTRA,
-            lambda state: (
-                logic.zerg_competent_comp(state)
-                and logic.zerg_moderate_anti_air(state)
-                and logic.spread_creep(state)
-            ),
+            logic.zerg_fire_in_the_sky_requirement,
         ),
         make_location_data(
             SC2Mission.FIRE_IN_THE_SKY.mission_name,
@@ -2715,42 +2628,28 @@ def get_locations(world: Optional["SC2World"]) -> Tuple[LocationData, ...]:
             "North Zerg Rescue",
             SC2HOTS_LOC_ID_OFFSET + 807,
             LocationType.EXTRA,
-            lambda state: (
-                logic.zerg_competent_comp(state)
-                and logic.zerg_moderate_anti_air(state)
-                and logic.spread_creep(state)
-            ),
+            logic.zerg_fire_in_the_sky_requirement,
         ),
         make_location_data(
             SC2Mission.FIRE_IN_THE_SKY.mission_name,
             "West Queen Rescue",
             SC2HOTS_LOC_ID_OFFSET + 808,
             LocationType.EXTRA,
-            lambda state: (
-                logic.zerg_competent_comp(state)
-                and logic.zerg_moderate_anti_air(state)
-                and logic.spread_creep(state)
-            ),
+            logic.zerg_fire_in_the_sky_requirement,
         ),
         make_location_data(
             SC2Mission.FIRE_IN_THE_SKY.mission_name,
             "East Queen Rescue",
             SC2HOTS_LOC_ID_OFFSET + 809,
             LocationType.EXTRA,
-            lambda state: (
-                logic.zerg_competent_comp(state)
-                and logic.zerg_moderate_anti_air(state)
-                and logic.spread_creep(state)
-            ),
+            logic.zerg_fire_in_the_sky_requirement,
         ),
         make_location_data(
             SC2Mission.FIRE_IN_THE_SKY.mission_name,
             "South Orbital Command Center",
             SC2HOTS_LOC_ID_OFFSET + 810,
             LocationType.CHALLENGE,
-            lambda state: (
-                logic.zerg_competent_comp(state) and logic.zerg_moderate_anti_air(state)
-            ),
+            logic.zerg_competent_comp_moderate_aa,
             flags=LocationFlag.BASEBUST,
         ),
         make_location_data(
@@ -2758,9 +2657,7 @@ def get_locations(world: Optional["SC2World"]) -> Tuple[LocationData, ...]:
             "Northwest Orbital Command Center",
             SC2HOTS_LOC_ID_OFFSET + 811,
             LocationType.CHALLENGE,
-            lambda state: (
-                logic.zerg_competent_comp(state) and logic.zerg_moderate_anti_air(state)
-            ),
+            logic.zerg_competent_comp_moderate_aa,
             flags=LocationFlag.BASEBUST,
         ),
         make_location_data(
@@ -2768,9 +2665,7 @@ def get_locations(world: Optional["SC2World"]) -> Tuple[LocationData, ...]:
             "Southeast Orbital Command Center",
             SC2HOTS_LOC_ID_OFFSET + 812,
             LocationType.CHALLENGE,
-            lambda state: (
-                logic.zerg_competent_comp(state) and logic.zerg_moderate_anti_air(state)
-            ),
+            logic.zerg_competent_comp_moderate_aa,
             flags=LocationFlag.BASEBUST,
         ),
         make_location_data(
@@ -2845,28 +2740,14 @@ def get_locations(world: Optional["SC2World"]) -> Tuple[LocationData, ...]:
             "East Essence Pool",
             SC2HOTS_LOC_ID_OFFSET + 1002,
             LocationType.VANILLA,
-            lambda state: (
-                logic.zerg_common_unit(state)
-                and (
-                    adv_tactics
-                    and logic.zerg_basic_anti_air(state)
-                    or logic.zerg_competent_anti_air(state)
-                )
-            ),
+            logic.zerg_waking_the_ancient_easy_pools,
         ),
         make_location_data(
             SC2Mission.WAKING_THE_ANCIENT.mission_name,
             "South Essence Pool",
             SC2HOTS_LOC_ID_OFFSET + 1003,
             LocationType.VANILLA,
-            lambda state: (
-                logic.zerg_common_unit(state)
-                and (
-                    adv_tactics
-                    and logic.zerg_basic_anti_air(state)
-                    or logic.zerg_competent_anti_air(state)
-                )
-            ),
+            logic.zerg_waking_the_ancient_easy_pools,
         ),
         make_location_data(
             SC2Mission.WAKING_THE_ANCIENT.mission_name,
@@ -2922,22 +2803,14 @@ def get_locations(world: Optional["SC2World"]) -> Tuple[LocationData, ...]:
             "Victory",
             SC2HOTS_LOC_ID_OFFSET + 1100,
             LocationType.VICTORY,
-            lambda state: (
-                logic.zerg_common_unit(state)
-                and logic.zerg_defense_rating(state, True, True) >= 7
-                and logic.zerg_competent_anti_air(state)
-            ),
+            logic.zerg_crucible_requirement,
         ),
         make_location_data(
             SC2Mission.THE_CRUCIBLE.mission_name,
             "Tyrannozor",
             SC2HOTS_LOC_ID_OFFSET + 1101,
             LocationType.VANILLA,
-            lambda state: (
-                logic.zerg_common_unit(state)
-                and logic.zerg_defense_rating(state, True, True) >= 7
-                and logic.zerg_competent_anti_air(state)
-            ),
+            logic.zerg_crucible_requirement,
         ),
         make_location_data(
             SC2Mission.THE_CRUCIBLE.mission_name,
@@ -2950,44 +2823,28 @@ def get_locations(world: Optional["SC2World"]) -> Tuple[LocationData, ...]:
             "15 Minutes Remaining",
             SC2HOTS_LOC_ID_OFFSET + 1103,
             LocationType.EXTRA,
-            lambda state: (
-                logic.zerg_common_unit(state)
-                and logic.zerg_defense_rating(state, True, True) >= 7
-                and logic.zerg_competent_anti_air(state)
-            ),
+            logic.zerg_crucible_requirement,
         ),
         make_location_data(
             SC2Mission.THE_CRUCIBLE.mission_name,
             "5 Minutes Remaining",
             SC2HOTS_LOC_ID_OFFSET + 1104,
             LocationType.EXTRA,
-            lambda state: (
-                logic.zerg_common_unit(state)
-                and logic.zerg_defense_rating(state, True, True) >= 7
-                and logic.zerg_competent_anti_air(state)
-            ),
+            logic.zerg_crucible_requirement,
         ),
         make_location_data(
             SC2Mission.THE_CRUCIBLE.mission_name,
             "Pincer Attack",
             SC2HOTS_LOC_ID_OFFSET + 1105,
             LocationType.EXTRA,
-            lambda state: (
-                logic.zerg_common_unit(state)
-                and logic.zerg_defense_rating(state, True, True) >= 7
-                and logic.zerg_competent_anti_air(state)
-            ),
+            logic.zerg_crucible_requirement,
         ),
         make_location_data(
             SC2Mission.THE_CRUCIBLE.mission_name,
             "Yagdra Claims Brakk's Pack",
             SC2HOTS_LOC_ID_OFFSET + 1106,
             LocationType.EXTRA,
-            lambda state: (
-                logic.zerg_common_unit(state)
-                and logic.zerg_defense_rating(state, True, True) >= 7
-                and logic.zerg_competent_anti_air(state)
-            ),
+            logic.zerg_crucible_requirement,
         ),
         make_location_data(
             SC2Mission.SUPREME.mission_name,
@@ -3075,33 +2932,21 @@ def get_locations(world: Optional["SC2World"]) -> Tuple[LocationData, ...]:
             "East Science Facility",
             SC2HOTS_LOC_ID_OFFSET + 1301,
             LocationType.VANILLA,
-            lambda state: (
-                logic.zerg_common_unit(state)
-                and logic.zerg_moderate_anti_air(state)
-                and logic.spread_creep(state)
-            ),
+            logic.zerg_infested_science_facilities,
         ),
         make_location_data(
             SC2Mission.INFESTED.mission_name,
             "Center Science Facility",
             SC2HOTS_LOC_ID_OFFSET + 1302,
             LocationType.VANILLA,
-            lambda state: (
-                logic.zerg_common_unit(state)
-                and logic.zerg_moderate_anti_air(state)
-                and logic.spread_creep(state)
-            ),
+            logic.zerg_infested_science_facilities,
         ),
         make_location_data(
             SC2Mission.INFESTED.mission_name,
             "West Science Facility",
             SC2HOTS_LOC_ID_OFFSET + 1303,
             LocationType.VANILLA,
-            lambda state: (
-                logic.zerg_common_unit(state)
-                and logic.zerg_moderate_anti_air(state)
-                and logic.spread_creep(state)
-            ),
+            logic.zerg_infested_science_facilities,
         ),
         make_location_data(
             SC2Mission.INFESTED.mission_name,
@@ -3251,39 +3096,21 @@ def get_locations(world: Optional["SC2World"]) -> Tuple[LocationData, ...]:
             "Victory",
             SC2HOTS_LOC_ID_OFFSET + 1500,
             LocationType.VICTORY,
-            lambda state: (
-                logic.zerg_competent_comp(state)
-                and (
-                    logic.zerg_competent_anti_air(state)
-                    or (adv_tactics and logic.zerg_moderate_anti_air(state))
-                )
-            ),
+            logic.zerg_phantoms_of_the_void_requirement,
         ),
         make_location_data(
             SC2Mission.PHANTOMS_OF_THE_VOID.mission_name,
             "Northwest Crystal",
             SC2HOTS_LOC_ID_OFFSET + 1501,
             LocationType.VANILLA,
-            lambda state: (
-                logic.zerg_competent_comp(state)
-                and (
-                    logic.zerg_competent_anti_air(state)
-                    or (adv_tactics and logic.zerg_moderate_anti_air(state))
-                )
-            ),
+            logic.zerg_phantoms_of_the_void_requirement,
         ),
         make_location_data(
             SC2Mission.PHANTOMS_OF_THE_VOID.mission_name,
             "Northeast Crystal",
             SC2HOTS_LOC_ID_OFFSET + 1502,
             LocationType.VANILLA,
-            lambda state: (
-                logic.zerg_competent_comp(state)
-                and (
-                    logic.zerg_competent_anti_air(state)
-                    or (adv_tactics and logic.zerg_moderate_anti_air(state))
-                )
-            ),
+            logic.zerg_phantoms_of_the_void_requirement,
         ),
         make_location_data(
             SC2Mission.PHANTOMS_OF_THE_VOID.mission_name,
@@ -3302,65 +3129,35 @@ def get_locations(world: Optional["SC2World"]) -> Tuple[LocationData, ...]:
             "Close Temple",
             SC2HOTS_LOC_ID_OFFSET + 1505,
             LocationType.EXTRA,
-            lambda state: (
-                logic.zerg_competent_comp(state)
-                and (
-                    logic.zerg_competent_anti_air(state)
-                    or (adv_tactics and logic.zerg_moderate_anti_air(state))
-                )
-            ),
+            logic.zerg_phantoms_of_the_void_requirement,
         ),
         make_location_data(
             SC2Mission.PHANTOMS_OF_THE_VOID.mission_name,
             "Mid Temple",
             SC2HOTS_LOC_ID_OFFSET + 1506,
             LocationType.EXTRA,
-            lambda state: (
-                logic.zerg_competent_comp(state)
-                and (
-                    logic.zerg_competent_anti_air(state)
-                    or (adv_tactics and logic.zerg_moderate_anti_air(state))
-                )
-            ),
+            logic.zerg_phantoms_of_the_void_requirement,
         ),
         make_location_data(
             SC2Mission.PHANTOMS_OF_THE_VOID.mission_name,
             "Southeast Temple",
             SC2HOTS_LOC_ID_OFFSET + 1507,
             LocationType.EXTRA,
-            lambda state: (
-                logic.zerg_competent_comp(state)
-                and (
-                    logic.zerg_competent_anti_air(state)
-                    or (adv_tactics and logic.zerg_moderate_anti_air(state))
-                )
-            ),
+            logic.zerg_phantoms_of_the_void_requirement,
         ),
         make_location_data(
             SC2Mission.PHANTOMS_OF_THE_VOID.mission_name,
             "Northeast Temple",
             SC2HOTS_LOC_ID_OFFSET + 1508,
             LocationType.EXTRA,
-            lambda state: (
-                logic.zerg_competent_comp(state)
-                and (
-                    logic.zerg_competent_anti_air(state)
-                    or (adv_tactics and logic.zerg_moderate_anti_air(state))
-                )
-            ),
+            logic.zerg_phantoms_of_the_void_requirement,
         ),
         make_location_data(
             SC2Mission.PHANTOMS_OF_THE_VOID.mission_name,
             "Northwest Temple",
             SC2HOTS_LOC_ID_OFFSET + 1509,
             LocationType.EXTRA,
-            lambda state: (
-                logic.zerg_competent_comp(state)
-                and (
-                    logic.zerg_competent_anti_air(state)
-                    or (adv_tactics and logic.zerg_moderate_anti_air(state))
-                )
-            ),
+            logic.zerg_phantoms_of_the_void_requirement,
         ),
         make_location_data(
             SC2Mission.WITH_FRIENDS_LIKE_THESE.mission_name,
@@ -4250,8 +4047,7 @@ def get_locations(world: Optional["SC2World"]) -> Tuple[LocationData, ...]:
             "Terran Main Base",
             SC2LOTV_LOC_ID_OFFSET + 1207,
             LocationType.MASTERY,
-            lambda state: logic.protoss_temple_of_unification_requirement(state)
-            and logic.protoss_deathball(state),
+            logic.protoss_temple_of_unification_bases,
             flags=LocationFlag.BASEBUST,
         ),
         make_location_data(
@@ -4259,8 +4055,7 @@ def get_locations(world: Optional["SC2World"]) -> Tuple[LocationData, ...]:
             "Protoss Main Base",
             SC2LOTV_LOC_ID_OFFSET + 1208,
             LocationType.MASTERY,
-            lambda state: logic.protoss_temple_of_unification_requirement(state)
-            and logic.protoss_deathball(state),
+            logic.protoss_temple_of_unification_bases,
             flags=LocationFlag.BASEBUST,
         ),
         make_location_data(
@@ -4998,9 +4793,7 @@ def get_locations(world: Optional["SC2World"]) -> Tuple[LocationData, ...]:
             "Clear Void Chasms",
             SC2LOTV_LOC_ID_OFFSET + 2507,
             LocationType.MASTERY,
-            lambda state: logic.amons_fall_requirement(state)
-            and logic.spread_creep(state, False)
-            and logic.zerg_big_monsters(state),
+            logic.zerg_amons_fall_full_clear,
         ),
         # Nova Covert Ops
         make_location_data(

--- a/worlds/sc2/locations.py
+++ b/worlds/sc2/locations.py
@@ -4849,41 +4849,42 @@ def get_locations(world: Optional["SC2World"]) -> Tuple[LocationData, ...]:
             "Victory",
             SC2NCO_LOC_ID_OFFSET + 200,
             LocationType.VICTORY,
-            logic.sudden_strike_requirement,
+            logic.terran_sudden_strike_requirement,
         ),
         make_location_data(
             SC2Mission.SUDDEN_STRIKE.mission_name,
             "Research Center",
             SC2NCO_LOC_ID_OFFSET + 201,
             LocationType.VANILLA,
-            logic.sudden_strike_requirement,
+            logic.terran_sudden_strike_requirement,
         ),
         make_location_data(
             SC2Mission.SUDDEN_STRIKE.mission_name,
             "Weaponry Labs",
             SC2NCO_LOC_ID_OFFSET + 202,
             LocationType.VANILLA,
-            logic.sudden_strike_requirement,
+            logic.terran_sudden_strike_requirement,
         ),
         make_location_data(
             SC2Mission.SUDDEN_STRIKE.mission_name,
             "Brutalisk",
             SC2NCO_LOC_ID_OFFSET + 203,
             LocationType.EXTRA,
-            logic.sudden_strike_requirement,
+            logic.terran_sudden_strike_requirement,
         ),
         make_location_data(
             SC2Mission.SUDDEN_STRIKE.mission_name,
             "Gas Pickups",
             SC2NCO_LOC_ID_OFFSET + 204,
             LocationType.EXTRA,
+            logic.terran_sudden_strike_requirement_or_advanced_tactics,
         ),
         make_location_data(
             SC2Mission.SUDDEN_STRIKE.mission_name,
             "Protect Buildings",
             SC2NCO_LOC_ID_OFFSET + 205,
             LocationType.CHALLENGE,
-            logic.sudden_strike_requirement,
+            logic.terran_sudden_strike_requirement,
             flags=LocationFlag.PREVENTATIVE,
         ),
         make_location_data(
@@ -4892,7 +4893,7 @@ def get_locations(world: Optional["SC2World"]) -> Tuple[LocationData, ...]:
             SC2NCO_LOC_ID_OFFSET + 206,
             LocationType.MASTERY,
             lambda state: (
-                logic.sudden_strike_requirement(state)
+                logic.terran_sudden_strike_requirement(state)
                 and logic.terran_competent_comp(state)
                 and logic.terran_base_trasher(state)
                 and logic.terran_power_rating(state) >= 8
@@ -13846,6 +13847,7 @@ def get_locations(world: Optional["SC2World"]) -> Tuple[LocationData, ...]:
             "Gas Pickups",
             SC2_RACESWAP_LOC_ID_OFFSET + 15104,
             LocationType.EXTRA,
+            logic.zerg_sudden_strike_requirement,
         ),
         make_location_data(
             SC2Mission.SUDDEN_STRIKE_Z.mission_name,

--- a/worlds/sc2/rules.py
+++ b/worlds/sc2/rules.py
@@ -2216,7 +2216,7 @@ class SC2Logic:
 
     def terran_great_train_robbery_kill_team(self, state: CollectionState) -> bool:
         return (
-            self.terran_great_train_robbery_kill_team(state)
+            self.terran_great_train_robbery_train_stopper(state)
             and (self.advanced_tactics or self.terran_common_unit(state))
         )
 

--- a/worlds/sc2/rules.py
+++ b/worlds/sc2/rules.py
@@ -216,6 +216,9 @@ class SC2Logic:
     def terran_common_unit_competent_aa(self, state: CollectionState) -> bool:
         return self.terran_common_unit(state) and self.terran_competent_anti_air(state)
 
+    def terran_competent_comp_or_advanced_tactics(self, state: CollectionState) -> bool:
+        return self.advanced_tactics or self.terran_competent_comp(state)
+
     def terran_early_tech(self, state: CollectionState) -> bool:
         """
         Basic combat unit that can be deployed quickly from mission start
@@ -508,6 +511,9 @@ class SC2Logic:
             if self.terran_sustainable_mech_heal(state) and (vehicle or (micro_gas_vehicle and light_frontline)):
                 return True
         return False
+
+    def terran_competent_comp_wa2(self, state: CollectionState) -> bool:
+        return self.terran_competent_comp(state, 2)
 
     def terran_mineral_dump(self, state: CollectionState) -> bool:
         """
@@ -908,9 +914,13 @@ class SC2Logic:
 
     def zerg_basic_air_to_air(self, state: CollectionState) -> bool:
         return (
-            state.has_any(
-                {item_names.MUTALISK, item_names.CORRUPTOR, item_names.BROOD_QUEEN, item_names.SCOURGE, item_names.INFESTED_LIBERATOR}, self.player
-            )
+            state.has_any((
+                item_names.MUTALISK,
+                item_names.CORRUPTOR,
+                item_names.BROOD_QUEEN,
+                item_names.SCOURGE,
+                item_names.INFESTED_LIBERATOR,
+            ), self.player)
             or self.morph_devourer(state)
             or self.morph_viper(state)
             or (self.morph_guardian(state) and state.has(item_names.GUARDIAN_PRIMAL_ADAPTATION, self.player))
@@ -981,6 +991,7 @@ class SC2Logic:
         )
 
     def zerg_competent_comp(self, state: CollectionState) -> bool:
+        """Solid zerg comp. Does not include AA"""
         if self.zerg_army_weapon_armor_upgrade_min_level(state) < 2:
             return False
         advanced = self.advanced_tactics
@@ -1023,8 +1034,14 @@ class SC2Logic:
     def zerg_common_unit_competent_aa(self, state: CollectionState) -> bool:
         return self.zerg_common_unit(state) and self.zerg_competent_anti_air(state)
 
+    def zerg_common_unit_or_advanced_tactics(self, state: CollectionState) -> bool:
+        return self.advanced_tactics or self.zerg_common_unit(state)
+
     def zerg_competent_comp_basic_aa(self, state: CollectionState) -> bool:
         return self.zerg_competent_comp(state) and self.zerg_basic_anti_air(state)
+
+    def zerg_competent_comp_moderate_aa(self, state: CollectionState) -> bool:
+        return self.zerg_competent_comp(state) and self.zerg_moderate_anti_air(state)
 
     def zerg_competent_comp_competent_aa(self, state: CollectionState) -> bool:
         return self.zerg_competent_comp(state) and self.zerg_competent_anti_air(state)
@@ -2191,6 +2208,18 @@ class SC2Logic:
             )
         )
 
+    def terran_great_train_robbery_requirement(self, state: CollectionState) -> bool:
+        return (
+            self.terran_great_train_robbery_train_stopper(state)
+            and self.terran_basic_anti_air(state)
+        )
+
+    def terran_great_train_robbery_kill_team(self, state: CollectionState) -> bool:
+        return (
+            self.terran_great_train_robbery_kill_team(state)
+            and (self.advanced_tactics or self.terran_common_unit(state))
+        )
+
     def zerg_great_train_robbery_train_stopper(self, state: CollectionState) -> bool:
         """
         Ability to deal with trains (moving target with a lot of HP)
@@ -2256,6 +2285,15 @@ class SC2Logic:
                         )
                     )
                 )
+            )
+        )
+
+    def terran_cutthroat_victory(self, state: CollectionState) -> bool:
+        return (
+            self.terran_common_unit(state)
+            and (
+                self.advanced_tactics
+                or self.terran_moderate_anti_air(state)
             )
         )
 
@@ -2632,6 +2670,12 @@ class SC2Logic:
     def protoss_in_utter_darkness_requirement(self, state: CollectionState) -> bool:
         return self.protoss_competent_comp(state) and self.protoss_defense_rating(state, True) >= 4
 
+    def terran_belly_of_the_beast_requirement(self, state: CollectionState) -> bool:
+        return (
+            self.advanced_tactics
+            or self.marine_medic_firebat_upgrade(state)
+        )
+
     def terran_all_in_requirement(self, state: CollectionState) -> bool:
         """
         All-in
@@ -2744,6 +2788,15 @@ class SC2Logic:
     # ###################################################################################################### #
     # region HotS Missions ................................................................................. #
     # ###################################################################################################### #
+
+    def zerg_lab_rat_requirement(self, state: CollectionState) -> bool:
+        return (
+            self.zerg_common_unit(state)
+            or state.has_any((item_names.ZERGLING, item_names.PYGALISK), self.player)
+        )
+
+    def zerg_lab_rat_progress(self, state: CollectionState) -> bool:
+        return self.advanced_tactics or self.zerg_lab_rat_requirement(state)
 
     def zerg_any_units_back_in_the_saddle_requirement(self, state: CollectionState) -> bool:
         return (
@@ -2946,6 +2999,13 @@ class SC2Logic:
             )
         )
 
+    def zerg_fire_in_the_sky_requirement(self, state: CollectionState) -> bool:
+        return (
+            self.zerg_competent_comp(state)
+            and self.zerg_moderate_anti_air(state)
+            and self.spread_creep(state)
+        )
+
     def terran_waking_the_ancient_requirement(self, state: CollectionState) -> bool:
         return (
             self.terran_common_unit(state)
@@ -2984,11 +3044,27 @@ class SC2Logic:
             )
         )
 
+    def zerg_waking_the_ancient_easy_pools(self, state: CollectionState) -> bool:
+        return (
+            self.zerg_common_unit(state)
+            and (
+                self.zerg_competent_anti_air(state)
+                or (self.advanced_tactics and self.zerg_basic_anti_air(state))
+            )
+        )
+
     def terran_crucible_requirement(self, state: CollectionState) -> bool:
         return (
             self.terran_common_unit(state)
             and self.terran_defense_rating(state, True, True) >= 5
             and self.terran_competent_anti_air(state)
+        )
+
+    def zerg_crucible_requirement(self, state: CollectionState) -> bool:
+        return (
+            self.zerg_common_unit(state)
+            and self.zerg_defense_rating(state, True, True) >= 7
+            and self.zerg_competent_anti_air(state)
         )
 
     def protoss_crucible_requirement(self, state: CollectionState) -> bool:
@@ -3042,6 +3118,13 @@ class SC2Logic:
             )
         )
 
+    def zerg_infested_science_facilities(self, state: CollectionState) -> bool:
+        return (
+            self.zerg_common_unit(state)
+            and self.zerg_moderate_anti_air(state)
+            and self.spread_creep(state)
+        )
+
     def protoss_infested_garrison_claimer(self, state: CollectionState) -> bool:
         return (
             state.has_any((
@@ -3080,6 +3163,15 @@ class SC2Logic:
 
     def protoss_hand_of_darkness_requirement(self, state: CollectionState) -> bool:
         return self.protoss_competent_comp(state) and self.protoss_power_rating(state) >= 6
+
+    def zerg_phantoms_of_the_void_requirement(self, state: CollectionState) -> bool:
+        return (
+            self.zerg_competent_comp(state)
+            and (
+                self.zerg_competent_anti_air(state)
+                or (self.advanced_tactics and self.zerg_moderate_anti_air(state))
+            )
+        )
 
     def terran_planetfall_requirement(self, state: CollectionState) -> bool:
         return self.terran_beats_protoss_deathball(state) and self.terran_power_rating(state) >= 8
@@ -3489,6 +3581,9 @@ class SC2Logic:
 
     def protoss_temple_of_unification_requirement(self, state: CollectionState) -> bool:
         return self.protoss_competent_comp(state) and self.protoss_power_rating(state) >= 10
+
+    def protoss_temple_of_unification_bases(self, state: CollectionState) -> bool:
+        return self.protoss_temple_of_unification_requirement(state) and self.protoss_deathball(state)
 
     def protoss_harbinger_of_oblivion_requirement(self, state: CollectionState) -> bool:
         return (
@@ -4035,6 +4130,13 @@ class SC2Logic:
                 )
                 or (self.advanced_tactics and self.spread_creep(state, False) and self.zerg_big_monsters(state))
             ) and self.zerg_competent_comp(state)
+
+    def zerg_amons_fall_full_clear(self, state: CollectionState) -> bool:
+        return (
+            self.amons_fall_requirement(state)
+            and self.spread_creep(state, False)
+            and self.zerg_big_monsters(state)
+        )
 
     def terran_amons_fall_requirement(self, state: CollectionState) -> bool:
         if not self.terran_very_hard_mission_weapon_armor_level(state):

--- a/worlds/sc2/rules.py
+++ b/worlds/sc2/rules.py
@@ -207,6 +207,15 @@ class SC2Logic:
     def terran_common_unit(self, state: CollectionState) -> bool:
         return state.has_any(self.basic_terran_units, self.player)
 
+    def terran_common_unit_or_advanced_tactics(self, state: CollectionState) -> bool:
+        return self.advanced_tactics or self.terran_common_unit(state)
+
+    def terran_common_unit_moderate_aa(self, state: CollectionState) -> bool:
+        return self.terran_common_unit(state) and self.terran_moderate_anti_air(state)
+
+    def terran_common_unit_competent_aa(self, state: CollectionState) -> bool:
+        return self.terran_common_unit(state) and self.terran_competent_anti_air(state)
+
     def terran_early_tech(self, state: CollectionState) -> bool:
         """
         Basic combat unit that can be deployed quickly from mission start
@@ -484,15 +493,18 @@ class SC2Logic:
         vehicle_weapons = self.weapon_armor_upgrade_count(item_names.PROGRESSIVE_TERRAN_VEHICLE_WEAPON, state)
         vehicle_armor = self.weapon_armor_upgrade_count(item_names.PROGRESSIVE_TERRAN_VEHICLE_ARMOR, state)
         if vehicle_weapons >= upgrade_level and vehicle_armor >= upgrade_level:
-            strong_vehicle = state.has_any({item_names.THOR, item_names.SIEGE_TANK}, self.player)
-            light_frontline = state.has_any(
-                {item_names.MARINE, item_names.DOMINION_TROOPER, item_names.HELLION, item_names.VULTURE}, self.player
-            ) or state.has_all({item_names.REAPER, item_names.REAPER_RESOURCE_EFFICIENCY}, self.player)
+            strong_vehicle = state.has_any((item_names.THOR, item_names.SIEGE_TANK), self.player)
+            light_frontline = (
+                state.has_any((
+                    item_names.MARINE, item_names.DOMINION_TROOPER, item_names.HELLION, item_names.VULTURE,
+                ), self.player)
+                or state.has_all((item_names.REAPER, item_names.REAPER_RESOURCE_EFFICIENCY), self.player)
+            )
             if strong_vehicle and light_frontline:
                 return True
             # Mech with Healing
-            vehicle = state.has_any({item_names.GOLIATH, item_names.WARHOUND}, self.player)
-            micro_gas_vehicle = self.advanced_tactics and state.has_any({item_names.DIAMONDBACK, item_names.CYCLONE}, self.player)
+            vehicle = state.has_any((item_names.GOLIATH, item_names.WARHOUND), self.player)
+            micro_gas_vehicle = self.advanced_tactics and state.has_any((item_names.DIAMONDBACK, item_names.CYCLONE), self.player)
             if self.terran_sustainable_mech_heal(state) and (vehicle or (micro_gas_vehicle and light_frontline)):
                 return True
         return False
@@ -1500,48 +1512,45 @@ class SC2Logic:
     def protoss_common_unit_competent_anti_air(self, state: CollectionState) -> bool:
         return self.protoss_common_unit(state) and self.protoss_competent_anti_air(state)
 
-    def protoss_competent_anti_air(self, state: CollectionState) -> bool:
+    def protoss_deathball_or_advanced_competent_comp(self, state: CollectionState) -> bool:
         return (
-            state.has_any(
-                {
-                    item_names.STALKER,
-                    item_names.SLAYER,
-                    item_names.INSTIGATOR,
-                    item_names.ADEPT,
-                    item_names.VOID_RAY,
-                    item_names.DESTROYER,
-                    item_names.TEMPEST,
-                    item_names.CALADRIUS,
-                },
-                self.player,
-            )
+            self.protoss_deathball(state)
+            or (self.advanced_tactics and self.protoss_competent_comp(state))
+        )
+
+    def protoss_competent_anti_air(self, state: CollectionState) -> bool:
+        aa_immortals = (
+            state.has_any((item_names.IMMORTAL, item_names.ANNIHILATOR), self.player)
+            and state.has(item_names.IMMORTAL_ANNIHILATOR_ADVANCED_TARGETING, self.player)
+        )
+        return (
+            state.has_any((
+                item_names.STALKER,
+                item_names.SLAYER,
+                item_names.INSTIGATOR,
+                item_names.ADEPT,
+                item_names.VOID_RAY,
+                item_names.DESTROYER,
+                item_names.TEMPEST,
+                item_names.CALADRIUS,
+            ), self.player)
             or (
                 (
-                    state.has_any(
-                        {
-                            item_names.PHOENIX,
-                            item_names.MIRAGE,
-                            item_names.CORSAIR,
-                            item_names.CARRIER,
-                        },
-                        self.player,
-                    )
+                    state.has_any((
+                        item_names.PHOENIX,
+                        item_names.MIRAGE,
+                        item_names.CORSAIR,
+                        item_names.CARRIER,
+                    ), self.player)
                     or state.has_all((item_names.SKIRMISHER, item_names.SKIRMISHER_PEER_CONTEMPT), self.player)
                 )
                 and (
                     state.has_any((item_names.SCOUT, item_names.MISTWING, item_names.DRAGOON), self.player)
-                    or state.has_all({item_names.WRATHWALKER, item_names.WRATHWALKER_AERIAL_TRACKING}, self.player)
-                    or (
-                        state.has_any({item_names.IMMORTAL, item_names.ANNIHILATOR}, self.player)
-                        and state.has(item_names.IMMORTAL_ANNIHILATOR_ADVANCED_TARGETING, self.player)
-                    )
+                    or state.has_all((item_names.WRATHWALKER, item_names.WRATHWALKER_AERIAL_TRACKING), self.player)
+                    or aa_immortals
                 )
             )
-            or (
-                self.advanced_tactics
-                and state.has_any({item_names.IMMORTAL, item_names.ANNIHILATOR}, self.player)
-                and state.has(item_names.IMMORTAL_ANNIHILATOR_ADVANCED_TARGETING, self.player)
-            )
+            or (self.advanced_tactics and aa_immortals)
         )
 
     def protoss_has_blink(self, state: CollectionState) -> bool:
@@ -2919,6 +2928,76 @@ class SC2Logic:
             )
         )
 
+    def terran_domination_requirement(self, state: CollectionState) -> bool:
+        return (
+            self.terran_common_unit(state)
+            and (
+                self.advanced_tactics
+                or self.terran_basic_anti_air(state)
+            )
+        )
+
+    def protoss_domination_requirement(self, state: CollectionState) -> bool:
+        return (
+            self.protoss_common_unit(state)
+            and (
+                self.advanced_tactics
+                or self.protoss_basic_anti_air(state)
+            )
+        )
+
+    def terran_waking_the_ancient_requirement(self, state: CollectionState) -> bool:
+        return (
+            self.terran_common_unit(state)
+            and (
+                self.terran_competent_anti_air(state)
+                or (self.advanced_tactics
+                    and self.terran_basic_anti_air(state)
+                )
+            )
+        )
+
+    def terran_waking_the_ancient_flawless(self, state: CollectionState) -> bool:
+        return (
+            self.terran_competent_comp(state)
+            and (
+                # Fast unit
+                state.has_any((
+                    item_names.DOMINION_TROOPER,
+                    item_names.BANSHEE,
+                    item_names.VULTURE,
+                    item_names.HELLION,
+                    item_names.DIAMONDBACK,
+                    item_names.WARHOUND,
+                    item_names.CYCLONE,
+                ), self.player)
+                or state.has_all((
+                    item_names.VALKYRIE, item_names.VALKYRIE_FLECHETTE_MISSILES,
+                ), self.player)
+                or (
+                    state.has(item_names.WRAITH, self.player)
+                    and state.has_any((
+                        item_names.WRAITH_ADVANCED_LASER_TECHNOLOGY,
+                        item_names.WRAITH_RESOURCE_EFFICIENCY,
+                    ), self.player)
+                )
+            )
+        )
+
+    def terran_crucible_requirement(self, state: CollectionState) -> bool:
+        return (
+            self.terran_common_unit(state)
+            and self.terran_defense_rating(state, True, True) >= 5
+            and self.terran_competent_anti_air(state)
+        )
+
+    def protoss_crucible_requirement(self, state: CollectionState) -> bool:
+        return (
+            self.protoss_common_unit(state)
+            and self.protoss_defense_rating(state, True) >= 5
+            and self.protoss_moderate_anti_air(state)
+        )
+
     def supreme_requirement(self, state: CollectionState) -> bool:
         return (
             self.grant_story_tech == GrantStoryTech.option_grant
@@ -2945,12 +3024,48 @@ class SC2Logic:
     def terran_infested_garrison_claimer(self, state: CollectionState) -> bool:
         return state.has_any((item_names.GHOST, item_names.SPECTRE, item_names.EMPERORS_SHADOW), self.player)
 
+    def terran_infested_requirement(self, state: CollectionState) -> bool:
+        return (
+            self.terran_common_unit_moderate_aa(state)
+            and (
+                self.advanced_tactics
+                or self.terran_infested_garrison_claimer(state)
+            )
+        )
+
+    def terran_infested_far_garrison(self, state: CollectionState) -> bool:
+        return (
+            self.terran_competent_comp(state)
+            and (
+                self.advanced_tactics
+                or self.terran_infested_garrison_claimer(state)
+            )
+        )
+
     def protoss_infested_garrison_claimer(self, state: CollectionState) -> bool:
         return (
             state.has_any((
                 item_names.HIGH_TEMPLAR, item_names.SIGNIFIER, item_names.ASCENDANT,
             ), self.player)
             or self.protoss_can_merge_dark_archon(state)
+        )
+
+    def protoss_infested_requirement(self, state: CollectionState) -> bool:
+        return (
+            self.protoss_common_unit_basic_aa(state)
+            and (
+                self.advanced_tactics
+                or self.protoss_infested_garrison_claimer(state)
+            )
+        )
+
+    def protoss_infested_far_garrison(self, state: CollectionState) -> bool:
+        return (
+            self.protoss_competent_comp(state)
+            and (
+                self.advanced_tactics
+                or self.protoss_infested_garrison_claimer(state)
+            )
         )
 
     def terran_hand_of_darkness_requirement(self, state: CollectionState) -> bool:

--- a/worlds/sc2/rules.py
+++ b/worlds/sc2/rules.py
@@ -73,12 +73,12 @@ class SC2Logic:
         self.war_council_upgrades = True if world is None else not world.options.war_council_nerfs.value
         self.base_power_rating = 2 if self.advanced_tactics else 0
         self.hero_presence_option = HeroPresence.default if world is None else world.options.hero_presence
-        
+
         # Must be set externally for accurate logic checking of upgrade level when generic_upgrade_missions is checked
         self.total_mission_count = 1
 
         # Conditionally changed by the world after finalizing missions
-        self.hero_presence = {}
+        self.hero_presence: dict[SC2Campaign, dict[SC2Race, HeroFlag]] = {}
         self.kerrigan_items_granted = False
         self.kerrigan_levels_granted = False
         self.kerrigan_build_missions = False
@@ -98,7 +98,9 @@ class SC2Logic:
         self.unit_count_functions: Dict[Tuple[SC2Race, int], Callable[[CollectionState], bool]] = {}
         """Cache of logic functions used by any_units logic level"""
 
-    # Super Globals
+    # ###################################################################################################### #
+    # region Generic ....................................................................................... #
+    # ###################################################################################################### #
 
     def is_item_placement(self, state: CollectionState) -> bool:
         """
@@ -157,7 +159,11 @@ class SC2Logic:
             power_rating += 2
         return power_rating
 
-    # Global Terran
+    # endregion Generic
+
+    # ###################################################################################################### #
+    # region Global Terran ................................................................................. #
+    # ###################################################################################################### #
 
     def terran_power_rating(self, state: CollectionState) -> int:
         power_score = self.base_power_rating
@@ -198,7 +204,6 @@ class SC2Logic:
     def terran_very_hard_mission_weapon_armor_level(self, state: CollectionState) -> bool:
         return self.terran_army_weapon_armor_upgrade_min_level(state) >= self.get_very_hard_required_upgrade_level()
 
-    # WoL
     def terran_common_unit(self, state: CollectionState) -> bool:
         return state.has_any(self.basic_terran_units, self.player)
 
@@ -578,10 +583,10 @@ class SC2Logic:
 
     def terran_mobile_detector(self, state: CollectionState) -> bool:
         return state.has_any({item_names.RAVEN, item_names.SCIENCE_VESSEL, item_names.COMMAND_CENTER_SCANNER_SWEEP}, self.player)
-    
+
     def zerg_mobile_detector(self, state: CollectionState) -> bool:
         return state.has_any({item_names.OVERSEER, item_names.BROOD_QUEEN}, self.player)
-    
+
     def protoss_mobile_detector(self, state: CollectionState) -> bool:
         return state.has_any({item_names.OBSERVER, item_names.ORACLE,}, self.player)
 
@@ -669,44 +674,13 @@ class SC2Logic:
 
     def nova_escape_assist(self, state: CollectionState) -> bool:
         return state.has_any({item_names.NOVA_BLINK, item_names.NOVA_HOLO_DECOY, item_names.NOVA_IONIC_FORCE_FIELD}, self.player)
-    
-    def nova_beat_stone(self, state: CollectionState) -> bool:
-        """
-        Used for any units logic for beating Stone. Shotgun may not be possible; may need feedback.
-        """
-        return ( 
-            self.grant_story_tech == GrantStoryTech.option_grant 
-            or self.nova_items_granted
-            or state.has_any((
-                item_names.NOVA_DOMINATION,
-                item_names.NOVA_BLAZEFIRE_GUNBLADE,
-                item_names.NOVA_C20A_CANISTER_RIFLE,
-            ), self.player)
-            or ((
-                    state.has_any((
-                        item_names.NOVA_PLASMA_RIFLE,
-                        item_names.NOVA_MONOMOLECULAR_BLADE,
-                    ), self.player)
-                    or state.has_all((
-                        item_names.NOVA_HELLFIRE_SHOTGUN,
-                        item_names.NOVA_STIM_INFUSION
-                    ), self.player)
-                )
-                and state.has_any((
-                    item_names.NOVA_JUMP_SUIT_MODULE,
-                    item_names.NOVA_ARMORED_SUIT_MODULE,
-                    item_names.NOVA_ENERGY_SUIT_MODULE,
-                ), self.player)
-                and state.has_any((
-                    item_names.NOVA_FLASHBANG_GRENADES,
-                    item_names.NOVA_STIM_INFUSION,
-                    item_names.NOVA_BLINK,
-                    item_names.NOVA_IONIC_FORCE_FIELD,
-                ), self.player)
-            )
-        )
 
-    # Global Zerg
+    # endregion Global Terran
+
+    # ###################################################################################################### #
+    # region Global Zerg ................................................................................... #
+    # ###################################################################################################### #
+
     def zerg_power_rating(self, state: CollectionState) -> int:
         power_score = self.base_power_rating
         # Passive Score (Economic upgrades and global army upgrades)
@@ -858,8 +832,11 @@ class SC2Logic:
         return state.has_any(self.basic_zerg_units, self.player)
 
     def zerg_competent_anti_air(self, state: CollectionState) -> bool:
-        return state.has_any({item_names.HYDRALISK, item_names.MUTALISK, item_names.CORRUPTOR, item_names.BROOD_QUEEN}, self.player) or (
-            self.advanced_tactics and state.has(item_names.INFESTOR, self.player)
+        return (
+            state.has_any((
+                item_names.HYDRALISK, item_names.MUTALISK, item_names.CORRUPTOR, item_names.BROOD_QUEEN
+            ), self.player)
+            or (self.advanced_tactics and state.has(item_names.INFESTOR, self.player))
         )
 
     def zerg_moderate_anti_air(self, state: CollectionState) -> bool:
@@ -1129,6 +1106,11 @@ class SC2Logic:
                 item_names.ROACH_CORPSER_STRAIN,
         ), self.player)
 
+    # endregion Global Zerg
+
+    # ###################################################################################################### #
+    # region Heroes ........................................................................................ #
+    # ###################################################################################################### #
     def kerrigan_levels(self, state: CollectionState, target: int, story_levels_available: bool = True) -> bool:
         if (story_levels_available or self.kerrigan_levels_granted):
             return True  # Levels are granted
@@ -1154,7 +1136,7 @@ class SC2Logic:
             levels = min2(levels, self.kerrigan_total_level_cap)
 
         return levels >= target
-    
+
     def get_hero_flag(self, mission: SC2Mission) -> HeroFlag:
         return self.hero_presence.get(mission.campaign, {}).get(mission.race, HeroFlag.NONE)
 
@@ -1241,7 +1223,7 @@ class SC2Logic:
                 or self.nova_dash(state)
             )
         )
-    
+
     def competent_kerrigan(self, state: CollectionState) -> bool:
         return (
             self.basic_kerrigan(state, False)
@@ -1249,13 +1231,17 @@ class SC2Logic:
             and state.count_from_list(item_groups.kerrigan_passives, self.player) >= 1
             and state.count_from_list(item_groups.kerrigan_logic_ultimates, self.player) >= 1
         )
-    
+
     def competent_artanis(self, state: CollectionState) -> bool:
         return (
             True # TODO (Snarky): Revisit once Artanis is implemented
         )
 
-    # Global Protoss
+    # endregion Heroes
+
+    # ###################################################################################################### #
+    # region Global Protoss ................................................................................ #
+    # ###################################################################################################### #
     def protoss_power_rating(self, state: CollectionState) -> int:
         power_score = self.base_power_rating
         # War Council Upgrades (all units are improved)
@@ -1325,6 +1311,9 @@ class SC2Logic:
 
     def protoss_common_unit(self, state: CollectionState) -> bool:
         return state.has_any(self.basic_protoss_units, self.player)
+
+    def protoss_common_unit_or_advanced_tactics(self, state: CollectionState) -> bool:
+        return self.advanced_tactics or self.protoss_common_unit(state)
 
     def protoss_any_gap_transport(self, state: CollectionState) -> bool:
         """Can get ground units across large gaps, larger than blink range"""
@@ -1507,6 +1496,9 @@ class SC2Logic:
 
     def protoss_common_unit_anti_armor_air(self, state: CollectionState) -> bool:
         return self.protoss_common_unit(state) and self.protoss_anti_armor_anti_air(state)
+
+    def protoss_common_unit_competent_anti_air(self, state: CollectionState) -> bool:
+        return self.protoss_common_unit(state) and self.protoss_competent_anti_air(state)
 
     def protoss_competent_anti_air(self, state: CollectionState) -> bool:
         return (
@@ -1751,7 +1743,12 @@ class SC2Logic:
                 item_names.STALKER_INSTIGATOR_SLAYER_PARTICLE_REFLECTION,
         ), self.player)
 
-    # Mission-specific rules
+    # endregion Global Protoss
+
+    # ###################################################################################################### #
+    # region WoL Missions .................................................................................. #
+    # ###################################################################################################### #
+
     def terran_outlaws_early_requirement(self, state: CollectionState) -> bool:
         return (
             self.terran_common_unit(state)
@@ -1803,7 +1800,7 @@ class SC2Logic:
             and (self.advanced_tactics or self.terran_basic_anti_air(state))
             and self.basic_or_no_hero(state, SC2Mission.ZERO_HOUR, False)
         )
-    
+
     def zerg_zero_hour_early_requirement(self, state: CollectionState) -> bool:
         return (
             self.zerg_common_unit(state)
@@ -1816,13 +1813,13 @@ class SC2Logic:
             and self.zerg_basic_kerriganless_anti_air(state)
             and self.basic_or_no_hero(state, SC2Mission.ZERO_HOUR_Z, False)
         )
-    
+
     def protoss_zero_hour_early_requirement(self, state: CollectionState) -> bool:
         return (
             self.protoss_common_unit(state)
             or self.basic_hero(state, SC2Mission.ZERO_HOUR_P, False)
         )
-        
+
     def protoss_zero_hour_requirement(self, state: CollectionState) -> bool:
         return (
             self.protoss_common_unit(state)
@@ -1834,16 +1831,15 @@ class SC2Logic:
             )
         )
 
-
-
-
     def terran_evacuation_start_requirement(self, state: CollectionState) -> bool:
         return self.basic_or_no_nova(state, SC2Mission.EVACUATION, False)
+
     def terran_evacuation_early_requirement(self, state: CollectionState) -> bool:
         return (
-            self.terran_early_tech
+            self.terran_early_tech(state)
             or self.basic_hero(state, SC2Mission.EVACUATION, False)
         )
+
     def terran_evacuation_requirement(self, state: CollectionState) -> bool:
         return (
             self.terran_early_tech(state)
@@ -1853,6 +1849,7 @@ class SC2Logic:
             )
             and self.basic_or_no_hero(state, SC2Mission.EVACUATION, False)
         )
+
     def terran_evacuation_flawless_requirement(self, state: CollectionState) -> bool:
         return (
             self.terran_early_tech(state)
@@ -1866,11 +1863,13 @@ class SC2Logic:
 
     def zerg_evacuation_start_requirement(self, state: CollectionState) -> bool:
         return self.basic_or_no_nova(state, SC2Mission.EVACUATION_Z, False)
+
     def zerg_evacuation_early_requirement(self, state: CollectionState) -> bool:
         return (
             self.zerg_common_unit(state)
             or self.basic_hero(state, SC2Mission.EVACUATION_Z, False)
         )
+
     def zerg_evacuation_requirement(self, state: CollectionState) -> bool:
         return (
             self.zerg_common_unit(state)
@@ -1880,6 +1879,7 @@ class SC2Logic:
             )
             and self.basic_or_no_hero(state, SC2Mission.EVACUATION_Z, False)
         )
+
     def zerg_evacuation_flawless_requirement(self, state: CollectionState) -> bool:
         return (
             self.zerg_common_unit(state)
@@ -1889,16 +1889,18 @@ class SC2Logic:
             )
             and self.basic_or_no_hero(state, SC2Mission.EVACUATION_Z, False)
         )
-    
+
     def protoss_evacuation_start_requirement(self, state: CollectionState) -> bool:
         return (
             self.basic_or_no_nova(state, SC2Mission.EVACUATION_P, False)
         )
+
     def protoss_evacuation_early_requirement(self, state: CollectionState) -> bool:
         return (
             self.protoss_common_unit(state)
             or self.basic_hero(state, SC2Mission.EVACUATION_P, False)
         )
+
     def protoss_evacuation_requirement(self, state: CollectionState) -> bool:
         return (
             self.protoss_common_unit(state)
@@ -1908,6 +1910,7 @@ class SC2Logic:
             )
             and self.basic_or_no_hero(state, SC2Mission.EVACUATION_P, False)
         )
+
     def protoss_evacuation_flawless_requirement(self, state: CollectionState) -> bool:
         return (
             self.protoss_common_unit(state)
@@ -1918,7 +1921,7 @@ class SC2Logic:
             )
             and self.basic_or_no_hero(state, SC2Mission.EVACUATION_P, False)
         )
-    
+
     def ghost_of_a_chance_requirement(self, state: CollectionState) -> bool:
         return (
             True
@@ -1935,10 +1938,10 @@ class SC2Logic:
     def terran_outbreak_requirement(self, state: CollectionState) -> bool:
         """Outbreak mission requirement"""
         return (
-            self.terran_defense_rating(state, True, False) >= 4 
+            self.terran_defense_rating(state, True, False) >= 4
             and self.basic_or_no_hero(state, SC2Mission.OUTBREAK)
-            and 
-                (self.terran_common_unit(state) 
+            and
+                (self.terran_common_unit(state)
                  or state.has(item_names.REAPER, self.player)
             )
         )
@@ -1987,23 +1990,20 @@ class SC2Logic:
             and self.protoss_basic_splash(state)
             and self.basic_or_no_hero(state, SC2Mission.OUTBREAK_P)
             and (
-                state.has_any(
-                    (
-                        item_names.STALKER,
-                        item_names.SLAYER,
-                        item_names.INSTIGATOR,
-                        item_names.ADEPT,
-                        item_names.COLOSSUS,
-                        item_names.VANGUARD,
-                        item_names.SKIRMISHER,
-                        item_names.OPPRESSOR,
-                        item_names.CARRIER,
-                        item_names.SKYLORD,
-                        item_names.TRIREME,
-                        item_names.DAWNBRINGER,
-                    ),
-                    self.player,
-                )
+                state.has_any((
+                    item_names.STALKER,
+                    item_names.SLAYER,
+                    item_names.INSTIGATOR,
+                    item_names.ADEPT,
+                    item_names.COLOSSUS,
+                    item_names.VANGUARD,
+                    item_names.SKIRMISHER,
+                    item_names.OPPRESSOR,
+                    item_names.CARRIER,
+                    item_names.SKYLORD,
+                    item_names.TRIREME,
+                    item_names.DAWNBRINGER,
+                ), self.player)
                 or (self.advanced_tactics and (state.has_any((item_names.VOID_RAY, item_names.DESTROYER), self.player)))
             )
         )
@@ -2026,7 +2026,7 @@ class SC2Logic:
             )
         )
 
-    def terran_respond_to_colony_infestations(self, state: CollectionState) -> bool:
+    def terran_havens_fall_respond_to_colony_infestations(self, state: CollectionState) -> bool:
         """
         Can deal quickly with Brood Lords and Mutas in Haven's Fall and being able to progress the mission
         """
@@ -2077,7 +2077,7 @@ class SC2Logic:
             )
         )
 
-    def protoss_respond_to_colony_infestations(self, state: CollectionState) -> bool:
+    def protoss_havens_fall_respond_to_colony_infestations(self, state: CollectionState) -> bool:
         """
         Can deal quickly with Brood Lords and Mutas in Haven's Fall and being able to progress the mission
         """
@@ -2160,48 +2160,6 @@ class SC2Logic:
             return False
         return self.protoss_common_unit(state) and self.protoss_anti_armor_anti_air(state)
 
-    def terran_can_grab_ghosts_in_the_fog_east_rock_formation(self, state: CollectionState) -> bool:
-        """
-        Able to shoot by a long range or from air to claim the rock formation separated by a chasm
-        """
-        return (
-            state.has_any((
-                item_names.MEDIVAC,
-                item_names.HERCULES,
-                item_names.VIKING,
-                item_names.BANSHEE,
-                item_names.WRAITH,
-                item_names.SIEGE_TANK,
-                item_names.BATTLECRUISER,
-                item_names.NIGHT_HAWK,
-                item_names.NIGHT_WOLF,
-                item_names.SHOCK_DIVISION,
-                item_names.SKY_FURY,
-            ), self.player)
-            or state.has_all({item_names.VALKYRIE, item_names.VALKYRIE_FLECHETTE_MISSILES}, self.player)
-            or state.has_all({item_names.RAVEN, item_names.RAVEN_HUNTER_SEEKER_WEAPON}, self.player)
-            or (
-                state.has_any({item_names.LIBERATOR, item_names.EMPERORS_GUARDIAN}, self.player)
-                and state.has(item_names.LIBERATOR_RAID_ARTILLERY, self.player)
-            )
-            or (
-                self.advanced_tactics
-                and (
-                    state.has_any((
-                        item_names.HELS_ANGELS,
-                        item_names.DUSK_WINGS,
-                        item_names.WINGED_NIGHTMARES,
-                        item_names.SIEGE_BREAKERS,
-                        item_names.BRYNHILDS,
-                        item_names.JACKSONS_REVENGE,
-                    ), self.player)
-                    or state.has_all((
-                        item_names.MIDNIGHT_RIDERS, item_names.LIBERATOR_RAID_ARTILLERY,
-                    ), self.player)
-                )
-            )
-        )
-
     def terran_great_train_robbery_train_stopper(self, state: CollectionState) -> bool:
         """
         Ability to deal with trains (moving target with a lot of HP)
@@ -2226,15 +2184,12 @@ class SC2Logic:
         if not self.basic_or_no_hero(state, SC2Mission.THE_GREAT_TRAIN_ROBBERY_Z):
             return False
         return (
-            state.has_any(
-                (
-                    item_names.ABERRATION,
-                    item_names.INFESTED_DIAMONDBACK,
-                    item_names.INFESTED_BANSHEE,
-                ),
-                self.player,
-            )
-            or state.has_all({item_names.MUTALISK, item_names.MUTALISK_SUNDERING_GLAIVE}, self.player)
+            state.has_any((
+                item_names.ABERRATION,
+                item_names.INFESTED_DIAMONDBACK,
+                item_names.INFESTED_BANSHEE,
+            ), self.player)
+            or state.has_all((item_names.MUTALISK, item_names.MUTALISK_SUNDERING_GLAIVE), self.player)
             or state.has_all((item_names.HYDRALISK, item_names.HYDRALISK_MUSCULAR_AUGMENTS), self.player)
             # Note: Zerglings were tested by Snarky, and it was found they'd need >= 3 upgrades to be viable,
             # so they are not included in this logic.
@@ -2296,17 +2251,19 @@ class SC2Logic:
             or (
                 not self.active_hero(state, SC2Mission.THE_DIG)
                 and (
-                    self.marine_medic_upgrade(state) 
+                    self.marine_medic_upgrade(state)
                     or self.advanced_tactics
                 )
             )
         )
+
     def terran_the_dig_early_requirement(self, state: CollectionState) -> bool:
         return(
             self.terran_the_dig_start_requirement(state)
             and self.terran_defense_rating(state, False, False) >= 6
             and self.terran_common_unit(state)
         )
+
     def terran_the_dig_requirement(self, state: CollectionState) -> bool:
         return (
             self.terran_the_dig_start_requirement(state)
@@ -2315,21 +2272,22 @@ class SC2Logic:
             and (
                 self.terran_competent_anti_air(state)
                 or (
-                    self.advanced_tactics 
+                    self.advanced_tactics
                     and self.terran_moderate_anti_air(state)
                 )
             )
         )
+
     def terran_the_dig_bases_requirement(self, state: CollectionState) -> bool:
         return (
             self.terran_the_dig_requirement(state)
             and self.terran_beats_protoss_deathball(state)
             and self.terran_base_trasher(state)
         )
-    
+
     def zerg_the_dig_start_requirement(self, state: CollectionState) -> bool:
         return self.basic_or_no_hero(state, SC2Mission.THE_DIG_Z)
-    
+
     def zerg_the_dig_early_requirement(self, state: CollectionState) -> bool:
         return (
             self.basic_or_no_hero(state, SC2Mission.THE_DIG_Z)
@@ -2355,17 +2313,17 @@ class SC2Logic:
             and self.zerg_competent_anti_air(state)
             and self.zerg_base_buster(state)
         )
-    
+
     def protoss_the_dig_start_requirement(self, state: CollectionState) -> bool:
         return self.basic_or_no_hero(state, SC2Mission.THE_DIG_P)
-    
+
     def protoss_the_dig_early_requirement(self, state: CollectionState) -> bool:
         return (
             self.basic_or_no_hero(state, SC2Mission.THE_DIG_P)
             and self.protoss_defense_rating(state, False) >= 6
             and self.protoss_common_unit(state)
         )
-    
+
     def protoss_the_dig_requirement(self, state: CollectionState) -> bool:
         return (
             self.basic_or_no_hero(state, SC2Mission.THE_DIG_P)
@@ -2376,7 +2334,7 @@ class SC2Logic:
                 or (self.advanced_tactics and self.protoss_moderate_anti_air(state))
             )
         )
-    
+
     def protoss_the_dig_bases_requirement(self, state: CollectionState) -> bool:
         return (
             self.basic_or_no_hero(state, SC2Mission.THE_DIG_P)
@@ -2386,7 +2344,7 @@ class SC2Logic:
             and self.protoss_deathball(state)
         )
 
-    def terran_can_rescue(self, state) -> bool:
+    def terran_moebius_factor_can_rescue(self, state: CollectionState) -> bool:
         """
         Rescuing in The Moebius Factor
         """
@@ -2397,10 +2355,21 @@ class SC2Logic:
             or self.advanced_tactics
         )
 
-    def terran_supernova_requirement(self, state) -> bool:
+    def zerg_moebius_factor_can_rescue(self, state: CollectionState) -> bool:
+        return state.has_any((
+            item_names.YGGDRASIL,
+            item_names.OVERLORD_VENTRAL_SACS,
+            item_names.NYDUS_WORM,
+            item_names.BULLFROG,
+        ), self.player)
+
+    def protoss_moebius_factor_can_rescue(self, state: CollectionState) -> bool:
+        return self.advanced_tactics or state.has(item_names.WARP_PRISM, self.player)
+
+    def terran_supernova_requirement(self, state: CollectionState) -> bool:
         return self.terran_beats_protoss_deathball(state) and self.terran_power_rating(state) >= 6
 
-    def zerg_supernova_requirement(self, state) -> bool:
+    def zerg_supernova_requirement(self, state: CollectionState) -> bool:
         return (
             self.zerg_common_unit(state)
             and self.zerg_power_rating(state) >= 6
@@ -2537,7 +2506,10 @@ class SC2Logic:
             and self.protoss_common_unit_anti_armor_air(state)
             and self.protoss_fleet(state)
         )
-    
+
+    def protoss_maw_snipeable_locations(self, state: CollectionState) -> bool:
+        return self.advanced_tactics or self.protoss_maw_requirement(state)
+
     def terran_engine_of_destruction_start_requirement(self, state: CollectionState) -> bool:
         return (
             self.basic_or_no_hero(state, SC2Mission.ENGINE_OF_DESTRUCTION, False)
@@ -2546,6 +2518,7 @@ class SC2Logic:
                 or self.marine_medic_upgrade(state)
             )
         )
+
     def terran_engine_of_destruction_requirement(self, state: CollectionState) -> bool:
         power_rating = self.terran_power_rating(state)
         if not self.basic_or_no_hero(state, SC2Mission.ENGINE_OF_DESTRUCTION):
@@ -2561,6 +2534,7 @@ class SC2Logic:
                     and state.has_any((item_names.BANSHEE, item_names.LIBERATOR), self.player)
                 )
             )
+
     def zerg_engine_of_destruction_start_requirement(self, state: CollectionState) -> bool:
         return (
             self.basic_or_no_hero(state, SC2Mission.ENGINE_OF_DESTRUCTION_Z, False)
@@ -2569,6 +2543,7 @@ class SC2Logic:
                 or self.zergling_hydra_roach_start(state)
             )
         )
+
     def zerg_engine_of_destruction_requirement(self, state: CollectionState) -> bool:
         power_rating = self.zerg_power_rating(state)
         if not self.basic_or_no_hero(state, SC2Mission.ENGINE_OF_DESTRUCTION_Z, False):
@@ -2594,6 +2569,7 @@ class SC2Logic:
                 or self.zealot_sentry_slayer_start(state)
             )
         )
+
     def protoss_engine_of_destruction_requirement(self, state: CollectionState) -> bool:
         if not self.basic_or_no_hero(state, SC2Mission.ENGINE_OF_DESTRUCTION_P, False):
             return False
@@ -2615,18 +2591,26 @@ class SC2Logic:
             state.has(item_names.SENTRY, self.player)
             or state.has_all((item_names.CARRIER, item_names.CARRIER_REPAIR_DRONES), self.player)
             or (
-                self.spear_of_adun_passive_presence
-                in [SpearOfAdunPassiveAbilityPresence.option_protoss, SpearOfAdunPassiveAbilityPresence.option_everywhere]
+                self.spear_of_adun_passive_presence in (
+                    SpearOfAdunPassiveAbilityPresence.option_protoss,
+                    SpearOfAdunPassiveAbilityPresence.option_everywhere,
+                )
                 and state.has(item_names.RECONSTRUCTION_BEAM, self.player)
             )
-            or (self.advanced_tactics and state.has_all({item_names.SHIELD_BATTERY, item_names.KHALAI_INGENUITY}, self.player))
+            or (self.advanced_tactics
+                and state.has_all((item_names.SHIELD_BATTERY, item_names.KHALAI_INGENUITY), self.player)
+            )
         )
 
     def terran_in_utter_darkness_requirement(self, state: CollectionState) -> bool:
         return self.terran_competent_comp(state) and self.terran_defense_rating(state, True, True) >= 8
 
     def zerg_in_utter_darkness_requirement(self, state: CollectionState) -> bool:
-        return self.zerg_competent_comp(state) and self.zerg_competent_anti_air(state) and self.zerg_defense_rating(state, True, True) >= 8
+        return (
+            self.zerg_competent_comp(state)
+            and self.zerg_competent_anti_air(state)
+            and self.zerg_defense_rating(state, True, True) >= 8
+        )
 
     def protoss_in_utter_darkness_requirement(self, state: CollectionState) -> bool:
         return self.protoss_competent_comp(state) and self.protoss_defense_rating(state, True) >= 4
@@ -2738,20 +2722,12 @@ class SC2Logic:
                 defense_rating += 2
             return defense_rating >= 9 and (state.has_any({item_names.TEMPEST, item_names.SKYLORD, item_names.VOID_RAY}, self.player))
 
-    def zerg_can_grab_ghosts_in_the_fog_east_rock_formation(self, state: CollectionState) -> bool:
-        return (
-            state.has_any({item_names.MUTALISK, item_names.INFESTED_BANSHEE, item_names.OVERLORD_VENTRAL_SACS, item_names.INFESTOR}, self.player)
-            or (self.morph_devourer(state) and state.has(item_names.DEVOURER_PRESCIENT_SPORES, self.player))
-            or (self.morph_guardian(state) and state.has(item_names.GUARDIAN_PRIMAL_ADAPTATION, self.player))
-            or ((self.morph_guardian(state) or self.morph_brood_lord(state)) and self.zerg_basic_air_to_air(state))
-            or (
-                self.advanced_tactics
-                and (
-                    state.has_any({item_names.INFESTED_SIEGE_BREAKERS, item_names.INFESTED_DUSK_WINGS}, self.player)
-                    or (state.has(item_names.HUNTERLING, self.player) and self.zerg_basic_air_to_air(state))
-                )
-            )
-        )
+    # endregion WoL Missions
+
+    # ###################################################################################################### #
+    # region HotS Missions ................................................................................. #
+    # ###################################################################################################### #
+
     def zerg_any_units_back_in_the_saddle_requirement(self, state: CollectionState) -> bool:
         return (
             # Note(mm): This check isn't necessary as self.kerrigan_levels cover it,
@@ -2792,7 +2768,7 @@ class SC2Logic:
             and self.basic_or_no_nova(state, SC2Mission.RENDEZVOUS, False)
             and self.zerg_defense_rating(state, False, False) >= 3
         )
-    
+
     def zerg_rendezvous_speedrun_requirement(self, state: CollectionState) -> bool:
         return (
             self.zerg_competent_comp(state)
@@ -2801,7 +2777,7 @@ class SC2Logic:
             and self.zerg_defense_rating(state, False, False) >= 3
             and self.zerg_power_rating(state) >= 5
         )
-    
+
     def terran_rendezvous_requirement(self, state: CollectionState) -> bool:
         return (
             self.terran_common_unit(state)
@@ -2809,7 +2785,7 @@ class SC2Logic:
             and self.basic_or_no_nova(state, SC2Mission.RENDEZVOUS_T, False)
             and self.terran_defense_rating(state, False) >= 3
         )
-    
+
     def terran_rendezvous_speedrun_requirement(self, state: CollectionState) -> bool:
         return (
             self.terran_common_unit(state)
@@ -2827,8 +2803,8 @@ class SC2Logic:
             and self.basic_or_no_nova(state, SC2Mission.RENDEZVOUS_P, False)
             and self.protoss_defense_rating(state, False) >= 3
         )
-    
-    def protoss_rendezvous_requirement(self, state: CollectionState) -> bool:
+
+    def protoss_rendezvous_speedrun_requirement(self, state: CollectionState) -> bool:
         return (
             self.protoss_competent_comp(state)
             and self.basic_or_no_hero(state, SC2Mission.RENDEZVOUS_P, False)
@@ -2840,13 +2816,13 @@ class SC2Logic:
         return (
             self.basic_or_no_nova(state, SC2Mission.HARVEST_OF_SCREAMS, False)
         )
-    
+
     def zerg_harvest_early_requirement(self, state: CollectionState) -> bool:
         return (
             self.zerg_common_unit(state)
             and self.basic_or_no_nova(state, SC2Mission.HARVEST_OF_SCREAMS, False)
         )
-    
+
     def zerg_harvest_requirement(self, state: CollectionState) -> bool:
         return (
             self.zerg_common_unit(state)
@@ -2858,13 +2834,13 @@ class SC2Logic:
         return (
             self.basic_or_no_nova(state, SC2Mission.HARVEST_OF_SCREAMS_T, False)
         )
-    
+
     def terran_harvest_early_requirement(self, state: CollectionState) -> bool:
         return (
             self.terran_common_unit(state)
             and self.basic_or_no_nova(state, SC2Mission.HARVEST_OF_SCREAMS_T, False)
         )
-    
+
     def terran_harvest_requirement(self, state: CollectionState) -> bool:
         return (
             self.terran_common_unit(state)
@@ -2876,13 +2852,13 @@ class SC2Logic:
         return (
             self.basic_or_no_nova(state, SC2Mission.HARVEST_OF_SCREAMS_P, False)
         )
-    
+
     def protoss_harvest_early_requirement(self, state: CollectionState) -> bool:
         return (
             self.protoss_common_unit(state)
             and self.basic_or_no_nova(state, SC2Mission.HARVEST_OF_SCREAMS_P, False)
         )
-    
+
     def protoss_harvest_requirement(self, state: CollectionState) -> bool:
         return (
             self.protoss_common_unit(state)
@@ -2898,7 +2874,7 @@ class SC2Logic:
             )
         )
 
-    def zerg_pass_vents(self, state: CollectionState) -> bool:
+    def zerg_enemy_within_pass_vents(self, state: CollectionState) -> bool:
         return (
             self.grant_story_tech == GrantStoryTech.option_grant
             or state.has_any(item_groups.ENEMY_WITHIN_ZERG_STANDARD_UNITS, self.player)
@@ -2906,7 +2882,7 @@ class SC2Logic:
                 and self.zerg_enemy_within_advanced_tactics_requirement(state)
             )
         )
-    
+
     def zerg_enemy_within_victory_requirement(self, state: CollectionState) -> bool:
         return (
             self.grant_story_tech == GrantStoryTech.option_grant
@@ -2925,7 +2901,7 @@ class SC2Logic:
                 and state.has_any(item_groups.ENEMY_WITHIN_TERRAN_ADVANCED_UNITS, self.player)
             )
         )
-    
+
     def protoss_enemy_within_requirement(self, state: CollectionState) -> bool:
         return (
             self.grant_story_tech == GrantStoryTech.option_grant
@@ -2934,7 +2910,7 @@ class SC2Logic:
                 and state.has_any(item_groups.ENEMY_WITHIN_PROTOSS_ADVANCED_UNITS, self.player)
             )
         )
-     
+
     def supreme_requirement(self, state: CollectionState) -> bool:
         return (
             self.grant_story_tech == GrantStoryTech.option_grant
@@ -2962,9 +2938,12 @@ class SC2Logic:
         return state.has_any((item_names.GHOST, item_names.SPECTRE, item_names.EMPERORS_SHADOW), self.player)
 
     def protoss_infested_garrison_claimer(self, state: CollectionState) -> bool:
-        return state.has_any(
-            (item_names.HIGH_TEMPLAR, item_names.SIGNIFIER, item_names.ASCENDANT), self.player
-        ) or self.protoss_can_merge_dark_archon(state)
+        return (
+            state.has_any((
+                item_names.HIGH_TEMPLAR, item_names.SIGNIFIER, item_names.ASCENDANT,
+            ), self.player)
+            or self.protoss_can_merge_dark_archon(state)
+        )
 
     def terran_hand_of_darkness_requirement(self, state: CollectionState) -> bool:
         return self.terran_competent_comp(state) and self.terran_power_rating(state) >= 6
@@ -3012,30 +2991,11 @@ class SC2Logic:
             and (not self.take_over_ai_allies or (self.terran_competent_comp(state) and self.terran_very_hard_mission_weapon_armor_level(state)))
         )
 
-    def protoss_can_attack_behind_chasm(self, state: CollectionState) -> bool:
-        return (
-            state.has_any((
-                item_names.SCOUT,
-                item_names.SKIRMISHER,
-                item_names.TEMPEST,
-                item_names.CARRIER,
-                item_names.SKYLORD,
-                item_names.TRIREME,
-                item_names.VOID_RAY,
-                item_names.DESTROYER,
-                item_names.PULSAR,
-                item_names.DAWNBRINGER,
-                item_names.MOTHERSHIP_TALDARIM,
-                item_names.MOTHERSHIP_PURIFIER,
-                item_names.MOTHERSHIP_AIUR,
-            ), self.player)
-            or self.protoss_has_blink(state)
-            or (
-                state.has(item_names.WARP_PRISM, self.player)
-                and (self.protoss_common_unit(state) or state.has(item_names.WARP_PRISM_PHASE_BLASTER, self.player))
-            )
-            or (self.advanced_tactics and state.has_any({item_names.ORACLE, item_names.ARBITER}, self.player))
-        )
+    # endregion HotS Missions
+
+    # ###################################################################################################### #
+    # region LotV Missions ................................................................................. #
+    # ###################################################################################################### #
 
     def the_infinite_cycle_requirement(self, state: CollectionState) -> bool:
         return (
@@ -3096,6 +3056,120 @@ class SC2Logic:
             and self.basic_or_no_hero(state, SC2Mission.DARK_WHISPERS)
         )
 
+    def protoss_dark_whispers_zerg_base(self, state: CollectionState) -> bool:
+        return self.protoss_deathball(state) and (self.protoss_power_rating(state) >= 6)
+
+    def protoss_can_attack_behind_chasm(self, state: CollectionState) -> bool:
+        return (
+            state.has_any((
+                item_names.SCOUT,
+                item_names.SKIRMISHER,
+                item_names.TEMPEST,
+                item_names.CARRIER,
+                item_names.SKYLORD,
+                item_names.TRIREME,
+                item_names.VOID_RAY,
+                item_names.DESTROYER,
+                item_names.PULSAR,
+                item_names.DAWNBRINGER,
+                item_names.MOTHERSHIP_TALDARIM,
+                item_names.MOTHERSHIP_PURIFIER,
+                item_names.MOTHERSHIP_AIUR,
+            ), self.player)
+            or self.protoss_has_blink(state)
+            or (
+                state.has(item_names.WARP_PRISM, self.player)
+                and (self.protoss_common_unit(state) or state.has(item_names.WARP_PRISM_PHASE_BLASTER, self.player))
+            )
+            or (self.advanced_tactics and state.has_any({item_names.ORACLE, item_names.ARBITER}, self.player))
+        )
+
+    def protoss_ghosts_in_the_fog_requirement(self, state: CollectionState) -> bool:
+        return self.protoss_competent_comp(state) and self.protoss_mineral_dump(state)
+    
+    def protoss_ghosts_in_the_fog_east_rock_formation(self, state: CollectionState) -> bool:
+        return self.protoss_mineral_dump(state) and self.protoss_can_attack_behind_chasm(state)
+
+    def terran_can_grab_ghosts_in_the_fog_east_rock_formation(self, state: CollectionState) -> bool:
+        """
+        Able to shoot by a long range or from air to claim the rock formation separated by a chasm
+        """
+        return (
+            state.has_any((
+                item_names.MEDIVAC,
+                item_names.HERCULES,
+                item_names.VIKING,
+                item_names.BANSHEE,
+                item_names.WRAITH,
+                item_names.SIEGE_TANK,
+                item_names.BATTLECRUISER,
+                item_names.NIGHT_HAWK,
+                item_names.NIGHT_WOLF,
+                item_names.SHOCK_DIVISION,
+                item_names.SKY_FURY,
+            ), self.player)
+            or state.has_all({item_names.VALKYRIE, item_names.VALKYRIE_FLECHETTE_MISSILES}, self.player)
+            or state.has_all({item_names.RAVEN, item_names.RAVEN_HUNTER_SEEKER_WEAPON}, self.player)
+            or (
+                state.has_any({item_names.LIBERATOR, item_names.EMPERORS_GUARDIAN}, self.player)
+                and state.has(item_names.LIBERATOR_RAID_ARTILLERY, self.player)
+            )
+            or (
+                self.advanced_tactics
+                and (
+                    state.has_any((
+                        item_names.HELS_ANGELS,
+                        item_names.DUSK_WINGS,
+                        item_names.WINGED_NIGHTMARES,
+                        item_names.SIEGE_BREAKERS,
+                        item_names.BRYNHILDS,
+                        item_names.JACKSONS_REVENGE,
+                    ), self.player)
+                    or state.has_all((
+                        item_names.MIDNIGHT_RIDERS, item_names.LIBERATOR_RAID_ARTILLERY,
+                    ), self.player)
+                )
+            )
+        )
+
+    def terran_ghosts_in_the_fog_east_rock_formation_requirement(self, state: CollectionState) -> bool:
+        return (
+            self.terran_mineral_dump(state)
+            and self.terran_can_grab_ghosts_in_the_fog_east_rock_formation(state)
+        )
+
+    def zerg_can_grab_ghosts_in_the_fog_east_rock_formation(self, state: CollectionState) -> bool:
+        return (
+            state.has_any({item_names.MUTALISK, item_names.INFESTED_BANSHEE, item_names.OVERLORD_VENTRAL_SACS, item_names.INFESTOR}, self.player)
+            or (self.morph_devourer(state) and state.has(item_names.DEVOURER_PRESCIENT_SPORES, self.player))
+            or (self.morph_guardian(state) and state.has(item_names.GUARDIAN_PRIMAL_ADAPTATION, self.player))
+            or ((self.morph_guardian(state) or self.morph_brood_lord(state)) and self.zerg_basic_air_to_air(state))
+            or (
+                self.advanced_tactics
+                and (
+                    state.has_any({item_names.INFESTED_SIEGE_BREAKERS, item_names.INFESTED_DUSK_WINGS}, self.player)
+                    or (state.has(item_names.HUNTERLING, self.player) and self.zerg_basic_air_to_air(state))
+                )
+            )
+        )
+
+    def zerg_ghosts_in_the_fog_east_rock_formation_requirement(self, state: CollectionState) -> bool:
+        return (
+            self.zerg_competent_anti_air(state)
+            and self.zerg_mineral_dump(state)
+            and self.zerg_can_grab_ghosts_in_the_fog_east_rock_formation(state)
+        )
+
+    def protoss_evil_awoken_requirement(self, state: CollectionState) -> bool:
+        return (
+            self.advanced_tactics
+            or state.has_any((
+                item_names.STALKER_PHASE_REACTOR,
+                item_names.STALKER_INSTIGATOR_SLAYER_DISINTEGRATING_PARTICLES,
+                item_names.STALKER_INSTIGATOR_SLAYER_PARTICLE_REFLECTION,
+            ), self.player)
+        )
+
     def protoss_growing_shadow_requirement(self, state: CollectionState) -> bool:
         return (
             self.protoss_common_unit(state)
@@ -3109,26 +3183,26 @@ class SC2Logic:
             and self.terran_moderate_anti_air(state)
             and self.basic_or_no_hero(state, SC2Mission.THE_GROWING_SHADOW_T)
         )
-    
+
     def zerg_growing_shadow_requirement(self, state: CollectionState) -> bool:
         return (
             self.zerg_common_unit(state)
             and self.zerg_moderate_anti_air(state)
             and self.basic_or_no_hero(state, SC2Mission.THE_GROWING_SHADOW_Z)
         )
-    
+
     def terran_spear_of_adun_requirement(self, state: CollectionState) -> bool:
         return (
-            self.terran_common_unit(state) 
-            and self.terran_competent_anti_air(state) 
+            self.terran_common_unit(state)
+            and self.terran_competent_anti_air(state)
             and self.terran_defense_rating(state, False, False) >= 5
             and self.basic_or_no_hero(state, SC2Mission.THE_SPEAR_OF_ADUN_T)
         )
 
     def zerg_spear_of_adun_requirement(self, state: CollectionState) -> bool:
         return (
-            self.zerg_common_unit(state) 
-            and self.zerg_competent_anti_air(state) 
+            self.zerg_common_unit(state)
+            and self.zerg_competent_anti_air(state)
             and self.zerg_defense_rating(state, False, False) >= 5
             and self.basic_or_no_hero(state, SC2Mission.THE_SPEAR_OF_ADUN_Z)
         )
@@ -3147,24 +3221,24 @@ class SC2Logic:
 
     def terran_sky_shield_requirement(self, state: CollectionState) -> bool:
         return (
-            self.terran_common_unit(state) 
-            and self.terran_competent_anti_air(state) 
+            self.terran_common_unit(state)
+            and self.terran_competent_anti_air(state)
             and self.terran_power_rating(state) >= 7
             and self.basic_or_no_hero(state, SC2Mission.SKY_SHIELD_T)
         )
-    
+
     def zerg_sky_shield_requirement(self, state: CollectionState) -> bool:
-        return ( 
-            self.zerg_common_unit(state) 
-            and self.zerg_competent_anti_air(state) 
+        return (
+            self.zerg_common_unit(state)
+            and self.zerg_competent_anti_air(state)
             and self.zerg_power_rating(state) >= 7
             and self.basic_or_no_hero(state, SC2Mission.SKY_SHIELD_Z)
         )
 
     def protoss_sky_shield_requirement(self, state: CollectionState) -> bool:
         return (
-            self.protoss_common_unit(state) 
-            and self.protoss_competent_anti_air(state) 
+            self.protoss_common_unit(state)
+            and self.protoss_competent_anti_air(state)
             and self.protoss_power_rating(state) >= 7
             and self.basic_or_no_hero(state, SC2Mission.SKY_SHIELD)
         )
@@ -3322,7 +3396,7 @@ class SC2Logic:
             and (self.take_over_ai_allies or (self.zerg_competent_comp(state) and self.zerg_big_monsters(state)))
             and self.zerg_power_rating(state) >= 6
         )
-    
+
     def protoss_unsealing_the_past_ledge_requirement(self, state: CollectionState) -> bool:
         return (
             state.has_any((item_names.COLOSSUS, item_names.WRATHWALKER), self.player)
@@ -3709,8 +3783,8 @@ class SC2Logic:
             self.zerg_very_hard_mission_weapon_armor_level(state) and self.protoss_very_hard_mission_weapon_armor_level(state)
         ):
             return False
-        return self.terran_competent_comp(state) and self.terran_competent_anti_air(state) and self.terran_power_rating(state) >= 6 
-    
+        return self.terran_competent_comp(state) and self.terran_competent_anti_air(state) and self.terran_power_rating(state) >= 6
+
     def zerg_into_the_void_requirement(self, state: CollectionState) -> bool:
         if not self.zerg_very_hard_mission_weapon_armor_level(state):
             return False
@@ -3718,7 +3792,7 @@ class SC2Logic:
             self.terran_very_hard_mission_weapon_armor_level(state) and self.protoss_very_hard_mission_weapon_armor_level(state)
         ):
             return False
-        return self.zerg_competent_comp(state) and self.zerg_competent_anti_air(state) and self.zerg_power_rating(state) >= 6 
+        return self.zerg_competent_comp(state) and self.zerg_competent_anti_air(state) and self.zerg_power_rating(state) >= 6
 
     def essence_of_eternity_requirement(self, state: CollectionState) -> bool:
         if not self.terran_very_hard_mission_weapon_armor_level(state):
@@ -3744,7 +3818,7 @@ class SC2Logic:
             )
             and self.terran_power_rating(state) >= 6
         )
-    
+
     def zerg_essence_of_eternity_requirement(self, state: CollectionState) -> bool:
         if not self.zerg_very_hard_mission_weapon_armor_level(state):
             return False
@@ -3759,10 +3833,10 @@ class SC2Logic:
                 defense_score += 2
         return (
             defense_score >= 12
-            and self.zerg_competent_anti_air(state) 
+            and self.zerg_competent_anti_air(state)
             and self.zerg_power_rating(state) >= 6
         )
-    
+
     def protoss_essence_of_eternity_requirement(self, state: CollectionState) -> bool:
         if not self.protoss_very_hard_mission_weapon_armor_level(state):
             return False
@@ -3775,10 +3849,10 @@ class SC2Logic:
             defense_score = max(defense_score, self.terran_defense_rating(state, False, True))
         return (
             defense_score >= 12
-            and self.protoss_competent_anti_air(state) 
+            and self.protoss_competent_anti_air(state)
             and self.protoss_power_rating(state) >= 6
         )
-    
+
     def amons_fall_requirement(self, state: CollectionState) -> bool:
         if not self.zerg_very_hard_mission_weapon_armor_level(state):
             return False
@@ -3827,7 +3901,7 @@ class SC2Logic:
                 )
                 or (self.advanced_tactics and self.spread_creep(state, False) and self.zerg_big_monsters(state))
             ) and self.zerg_competent_comp(state)
-        
+
     def terran_amons_fall_requirement(self, state: CollectionState) -> bool:
         if not self.terran_very_hard_mission_weapon_armor_level(state):
             return False
@@ -3841,7 +3915,7 @@ class SC2Logic:
             return False
         if self.take_over_ai_allies:
             return (
-                self.terran_beats_protoss_deathball(state) and self.zerg_competent_comp(state) 
+                self.terran_beats_protoss_deathball(state) and self.zerg_competent_comp(state)
                 and (self.protoss_deathball(state) or self.protoss_fleet(state))
             )
         else:
@@ -3860,19 +3934,25 @@ class SC2Logic:
             return False
         if self.take_over_ai_allies:
             return (
-                self.terran_beats_protoss_deathball(state) and self.zerg_competent_comp(state) 
+                self.terran_beats_protoss_deathball(state) and self.zerg_competent_comp(state)
                 and (self.protoss_deathball(state) or self.protoss_fleet(state))
             )
         else:
             return self.protoss_deathball(state) or self.protoss_fleet(state)
-        
+
+    # endregion LotV Missions
+
+    # ###################################################################################################### #
+    # region NCO Missions .................................................................................. #
+    # ###################################################################################################### #
+
     def the_escape_stuff_granted(self) -> bool:
         """
         The NCO first mission requires having too much stuff first before actually able to do anything
         :return:
         """
-        return ( 
-            self.grant_story_tech == GrantStoryTech.option_grant 
+        return (
+            self.grant_story_tech == GrantStoryTech.option_grant
             or self.mission_order == MissionOrder.option_vanilla and self.enabled_campaigns == {SC2Campaign.NCO}
             or self.nova_items_granted
         )
@@ -3885,13 +3965,13 @@ class SC2Logic:
 
     def the_escape_hard_rule(self, state: CollectionState) -> bool:
         return (
-            self.grant_story_tech == GrantStoryTech.option_grant 
+            self.grant_story_tech == GrantStoryTech.option_grant
             or self.nova_items_granted
             or self.nova_any_nobuild_damage(state)
         )
-    
+
     def hero_handle_defiler(self, state: CollectionState, presence: HeroFlag) -> bool:
-        if presence == HeroFlag.NONE: 
+        if presence == HeroFlag.NONE:
             return False
         return (
             (
@@ -3919,12 +3999,11 @@ class SC2Logic:
             )
         )
 
-
     def terran_able_to_snipe_defiler(self, state: CollectionState, presence: HeroFlag = HeroFlag.NONE) -> bool:
         return (
             state.has(item_names.BANSHEE, self.player)
             or (state.has_all({item_names.SIEGE_TANK, item_names.SIEGE_TANK_MAELSTROM_ROUNDS, item_names.SIEGE_TANK_JUMP_JETS}, self.player))
-            or (self.hero_handle_defiler, presence)
+            or self.hero_handle_defiler(state, presence)
         )
 
     def zerg_handle_defiler(self, state: CollectionState, presence: HeroFlag = HeroFlag.NONE) -> bool:
@@ -3932,22 +4011,22 @@ class SC2Logic:
             state.has(item_names.ABERRATION,self.player)
             or state.has(item_names.ULTRALISK,self.player)
             or self.morph_tyrannozor(state)
-            or (self.advanced_tactics 
+            or (self.advanced_tactics
                 and (
                     state.has_any({item_names.INFESTOR, item_names.BROOD_QUEEN},self.player)
                     or self.morph_viper(state)
                 )
             )
-            or (self.hero_handle_defiler, presence)
+            or self.hero_handle_defiler(state, presence)
         )
-    
+
     def protoss_handle_defiler(self, state: CollectionState, presence: HeroFlag = HeroFlag.NONE) -> bool:
         return (
             state.has_all({item_names.COLOSSUS,item_names.COLOSSUS_FIRE_LANCE},self.player)
             or (self.advanced_tactics and state.has_any({item_names.HIGH_TEMPLAR, item_names.ASCENDANT, item_names.DISRUPTOR},self.player))
-            or (self.hero_handle_defiler, presence)
+            or self.hero_handle_defiler(state, presence)
         )
-    
+
     def sudden_strike_nova(self, state: CollectionState) -> bool:
         return (
             self.nova_splash(state)
@@ -3955,7 +4034,7 @@ class SC2Logic:
                 or state.has(item_names.NOVA_JUMP_SUIT_MODULE, self.player)
             )
         )
-    
+
     def sudden_strike_kerrigan(self, state: CollectionState) -> bool:
         return (
             self.two_kerrigan_actives(state, False)
@@ -3988,7 +4067,6 @@ class SC2Logic:
                 and self.terran_able_to_snipe_defiler(state, presence)
                 and (self.terran_cliffjumper(state) or state.has(item_names.BANSHEE, self.player))
                 and self.terran_defense_rating(state, True, False) >= 3
-
             )
         else:
             # no hero
@@ -3999,7 +4077,6 @@ class SC2Logic:
                 and self.terran_defense_rating(state, True, False) >= 5
             )
 
-    
     def zerg_sudden_strike_requirement(self, state: CollectionState) -> bool:
         presence = self.get_hero_flag(SC2Mission.SUDDEN_STRIKE_Z)
         if presence != HeroFlag.NONE:
@@ -4032,7 +4109,7 @@ class SC2Logic:
                 and self.protoss_defense_rating(state,True) >= 5
             )
 
-    def enemy_intelligence_garrisonable_unit(self, state: CollectionState) -> bool:
+    def terran_enemy_intelligence_garrisonable_unit(self, state: CollectionState) -> bool:
         """
         Has unit usable as a Garrison in Enemy Intelligence
         """
@@ -4070,7 +4147,7 @@ class SC2Logic:
                 ), self.player) >= 3
             )
         )
-    
+
     def zerg_enemy_intelligence_garrisonable_unit(self, state: CollectionState) -> bool:
         """
         Has zerg unit usable as a Garrison in Enemy Intelligence
@@ -4095,7 +4172,7 @@ class SC2Logic:
                 ), self.player) >= 3
             )
         )
-    
+
     def protoss_enemy_intelligence_garrisonable_unit(self, state: CollectionState) -> bool:
         """
         Has a garrisonable protoss unit in Enemy Intelligence
@@ -4120,35 +4197,35 @@ class SC2Logic:
                 item_names.REAVER,
             ), self.player)
         )
-    
+
     def enemy_intelligence_cliff_garrison(self, state: CollectionState) -> bool:
         return (
             state.has_any({item_names.REAPER, item_names.VIKING}, self.player)
             or (state.has_any({item_names.MEDIVAC, item_names.HERCULES}, self.player)
-                and self.enemy_intelligence_garrisonable_unit(state)
+                and self.terran_enemy_intelligence_garrisonable_unit(state)
             )
             or state.has_all({item_names.GOLIATH, item_names.GOLIATH_JUMP_JETS}, self.player)
             or (self.advanced_tactics and state.has_any({item_names.HELS_ANGELS, item_names.BRYNHILDS}, self.player))
         )
-    
+
     def zerg_enemy_intelligence_cliff_garrison(self, state: CollectionState) -> bool:
         return (
             (
                 state.has_any((
-                    item_names.YGGDRASIL, 
-                    item_names.OVERLORD_VENTRAL_SACS, 
+                    item_names.YGGDRASIL,
+                    item_names.OVERLORD_VENTRAL_SACS,
                     item_names.BULLFROG,
                 ), self.player)
                 or self.morph_viper(state)
             )
             # consider Creep Teleport + Overlord creep?
             and self.zerg_enemy_intelligence_garrisonable_unit(state)
-        ) 
-    
+        )
+
     def protoss_enemy_intelligence_cliff_garrison(self, state: CollectionState) -> bool:
         return (
             state.has_any((
-                item_names.STALKER, 
+                item_names.STALKER,
                 item_names.INSTIGATOR,
                 item_names.COLOSSUS,
                 item_names.WRATHWALKER,
@@ -4161,34 +4238,33 @@ class SC2Logic:
             )
         )
 
-
     def enemy_intelligence_first_stage_requirement(self, state: CollectionState) -> bool:
         return (
-            self.enemy_intelligence_garrisonable_unit(state)
+            self.terran_enemy_intelligence_garrisonable_unit(state)
             and (
                 self.terran_competent_comp(state)
                 or (
                     self.basic_nova(state, SC2Mission.ENEMY_INTELLIGENCE, False)
-                    and self.terran_common_unit(state) 
-                    and self.terran_competent_anti_air(state) 
+                    and self.terran_common_unit(state)
+                    and self.terran_competent_anti_air(state)
                     and state.has(item_names.NOVA_NUKE, self.player)
                 )
             )
             and self.terran_defense_rating(state, True, True) >= 5
         )
-    
+
     def zerg_enemy_intelligence_first_stage_requirement(self, state: CollectionState) -> bool:
         return (
-            self.zerg_enemy_intelligence_garrisonable_unit(state) 
+            self.zerg_enemy_intelligence_garrisonable_unit(state)
             # TODO: revisit defense ratings
-            and self.zerg_competent_comp(state) 
+            and self.zerg_competent_comp(state)
             and self.zerg_defense_rating(state, True, True) >= 5
         )
-    
+
     def protoss_enemy_intelligence_first_stage_requirement(self, state: CollectionState) -> bool:
         return (
-            self.protoss_enemy_intelligence_garrisonable_unit(state) 
-            and self.protoss_competent_comp(state) 
+            self.protoss_enemy_intelligence_garrisonable_unit(state)
+            and self.protoss_competent_comp(state)
             and self.protoss_defense_rating(state, True) >= 5
         )
 
@@ -4196,21 +4272,21 @@ class SC2Logic:
         return (
             self.nova_any_weapon(state)
             and (
-                self.nova_full_stealth(state) 
+                self.nova_full_stealth(state)
                 or (
-                    self.nova_heal(state) 
-                    and self.nova_splash(state) 
+                    self.nova_heal(state)
+                    and self.nova_splash(state)
                     and self.nova_ranged_weapon(state)
                     and self.nova_dash(state)
                 )
             )
         )
-    
+
     def enemy_intelligence_kerrigan(self, state: CollectionState) -> bool:
         return (
             self.two_kerrigan_solo_actives(state)
         )
-    
+
     def enemy_intelligence_artanis(self, state: CollectionState) -> bool:
         return True # TODO (Snarky): Revisit once Artanis is implemented
 
@@ -4233,7 +4309,7 @@ class SC2Logic:
             and self.enemy_intelligence_cliff_garrison(state)
             and self.enemy_intelligence_hero(state, presence)
         )
-    
+
     def zerg_enemy_intelligence_second_stage_requirement(self, state: CollectionState) -> bool:
         presence = self.get_hero_flag(SC2Mission.ENEMY_INTELLIGENCE_Z)
         return (
@@ -4241,7 +4317,7 @@ class SC2Logic:
             and self.zerg_enemy_intelligence_cliff_garrison(state)
             and self.enemy_intelligence_hero(state, presence)
         )
-    
+
     def protoss_enemy_intelligence_second_stage_requirement(self, state: CollectionState) -> bool:
         presence = self.get_hero_flag(SC2Mission.ENEMY_INTELLIGENCE_P)
         return (
@@ -4252,31 +4328,31 @@ class SC2Logic:
 
     def enemy_intelligence_third_stage_requirement(self, state: CollectionState) -> bool:
         # same logic for stage 2 and 3 for now. Might be changed later.
-        return self.enemy_intelligence_second_stage_requirement(state) 
-    
+        return self.enemy_intelligence_second_stage_requirement(state)
+
     def zerg_enemy_intelligence_third_stage_requirement(self, state: CollectionState) -> bool:
         return self.zerg_enemy_intelligence_second_stage_requirement(state)
-    
+
     def protoss_enemy_intelligence_third_stage_requirement(self, state: CollectionState) -> bool:
-        return self.protoss_enemy_intelligence_second_stage_requirement(state) 
-    
+        return self.protoss_enemy_intelligence_second_stage_requirement(state)
+
     def enemy_intelligence_hard_rule(self, state: CollectionState) -> bool:
         return (
             self.enemy_intelligence_cliff_garrison(state)
             and self.enemy_intelligence_hero(state, self.get_hero_flag(SC2Mission.ENEMY_INTELLIGENCE))
-        )    
-    
+        )
+
     def zerg_enemy_intelligence_hard_rule(self, state: CollectionState) -> bool:
         return (
             self.zerg_enemy_intelligence_cliff_garrison(state)
             and self.enemy_intelligence_hero(state, self.get_hero_flag(SC2Mission.ENEMY_INTELLIGENCE_Z))
-        )    
-    
+        )
+
     def protoss_enemy_intelligence_hard_rule(self, state: CollectionState) -> bool:
         return (
             self.protoss_enemy_intelligence_cliff_garrison(state)
             and self.enemy_intelligence_hero(state, self.get_hero_flag(SC2Mission.ENEMY_INTELLIGENCE_P))
-        )    
+        )
 
     def trouble_in_paradise_requirement(self, state: CollectionState) -> bool:
         presence = self.get_hero_flag(SC2Mission.TROUBLE_IN_PARADISE)
@@ -4294,7 +4370,7 @@ class SC2Logic:
                 and self.terran_defense_rating(state, True, True) >= 5
                 and self.terran_power_rating(state) >= 5
             )
-    
+
     def zerg_trouble_in_paradise_requirement(self, state: CollectionState) -> bool:
         presence = self.get_hero_flag(SC2Mission.TROUBLE_IN_PARADISE_Z)
         if presence != HeroFlag.NONE:
@@ -4304,13 +4380,13 @@ class SC2Logic:
                 and self.zerg_defense_rating(state, True, True) >= 5
                 and self.zerg_power_rating(state) >= 3
             )
-        else: 
+        else:
             return (
                 self.zerg_base_buster(state)
                 and self.zerg_defense_rating(state, True, True) >= 5
                 and self.zerg_power_rating(state) >= 5
             )
-    
+
     def protoss_trouble_in_paradise_requirement(self, state: CollectionState) -> bool:
         presence = self.get_hero_flag(SC2Mission.TROUBLE_IN_PARADISE_P)
         if presence != HeroFlag.NONE:
@@ -4320,7 +4396,7 @@ class SC2Logic:
                 and self.protoss_defense_rating(state, True) >= 5
                 and self.protoss_power_rating(state) >= 3
             )
-        else: 
+        else:
             return (
                 self.protoss_deathball(state)
                 and self.protoss_defense_rating(state, True) >= 5
@@ -4362,13 +4438,13 @@ class SC2Logic:
             )
             and self.terran_army_weapon_armor_upgrade_min_level(state) >= 2
         )
-    
+
     def zerg_night_terrors_requirement(self, state: CollectionState) -> bool:
         return (
             self.zerg_competent_comp(state)
             and self.zerg_power_rating(state) >= 3
         )
-    
+
     def protoss_night_terrors_requirement(self, state: CollectionState) -> bool:
         return (
             self.protoss_competent_comp(state)
@@ -4380,19 +4456,19 @@ class SC2Logic:
             self.night_terrors_requirement(state)
             and self.competent_or_no_hero(state, SC2Mission.NIGHT_TERRORS)
         )
-    
+
     def zerg_night_terrors_side_area_requirement(self, state: CollectionState) -> bool:
         return (
             self.zerg_night_terrors_requirement(state)
             and self.competent_or_no_hero(state, SC2Mission.NIGHT_TERRORS_Z)
         )
-    
+
     def protoss_night_terrors_side_area_requirement(self, state: CollectionState) -> bool:
         return (
             self.protoss_night_terrors_requirement(state)
             and self.competent_or_no_hero(state, SC2Mission.NIGHT_TERRORS_P)
         )
-    
+
     def flashpoint_far_requirement(self, state: CollectionState) -> bool:
         return (
             self.terran_competent_comp(state)
@@ -4403,7 +4479,7 @@ class SC2Logic:
             and (self.advanced_tactics or self.terran_competent_ground_to_air(state))
             and self.competent_or_no_hero(state, SC2Mission.FLASHPOINT)
         )
-    
+
     def zerg_flashpoint_far_requirement(self, state: CollectionState) -> bool:
         return (
             self.zerg_competent_comp(state)
@@ -4412,7 +4488,7 @@ class SC2Logic:
             and self.zerg_army_weapon_armor_upgrade_min_level(state) >= 2
             and self.competent_or_no_hero(state, SC2Mission.FLASHPOINT_Z)
         )
-    
+
     def protoss_flashpoint_far_requirement(self, state: CollectionState) -> bool:
         return (
             self.protoss_competent_comp(state)
@@ -4424,47 +4500,44 @@ class SC2Logic:
 
     def enemy_shadow_tripwires_tool(self, state: CollectionState) -> bool:
         return (
-            self.grant_story_tech == GrantStoryTech.option_grant 
+            self.grant_story_tech == GrantStoryTech.option_grant
             or self.nova_items_granted
             or state.has_any({item_names.NOVA_FLASHBANG_GRENADES, item_names.NOVA_BLINK, item_names.NOVA_DOMINATION}, self.player)
         )
 
     def enemy_shadow_door_unlocks_tool(self, state: CollectionState) -> bool:
         return (
-            self.grant_story_tech == GrantStoryTech.option_grant 
+            self.grant_story_tech == GrantStoryTech.option_grant
             or self.nova_items_granted
-            or state.has_any({item_names.NOVA_DOMINATION, item_names.NOVA_BLINK, item_names.NOVA_JUMP_SUIT_MODULE}, self.player)
+            or state.has_any((item_names.NOVA_DOMINATION, item_names.NOVA_BLINK, item_names.NOVA_JUMP_SUIT_MODULE), self.player)
         )
-    
+
     def enemy_shadow_blazefire_unlock(self, state: CollectionState) -> bool:
         return (
             self.enemy_shadow_second_stage(state)
             and (
-                self.grant_story_tech == GrantStoryTech.option_grant 
+                self.grant_story_tech == GrantStoryTech.option_grant
                 or self.nova_items_granted
                 or state.has(item_names.NOVA_BLINK, self.player)
                 or (
                     self.advanced_tactics
-                    and state.has_all(
-                        {
-                            item_names.NOVA_DOMINATION,
-                            item_names.NOVA_HOLO_DECOY,
-                            item_names.NOVA_JUMP_SUIT_MODULE,
-                        },
-                        self.player,
-                    )
+                    and state.has_all((
+                        item_names.NOVA_DOMINATION,
+                        item_names.NOVA_HOLO_DECOY,
+                        item_names.NOVA_JUMP_SUIT_MODULE,
+                    ), self.player)
                 )
             )
         )
 
     def enemy_shadow_nova_damage_and_blazefire_unlock(self, state: CollectionState) -> bool:
         return (
-            self.grant_story_tech == GrantStoryTech.option_grant 
+            self.grant_story_tech == GrantStoryTech.option_grant
             or self.nova_items_granted
             or (
-                self.nova_any_nobuild_damage(state) 
+                self.nova_any_nobuild_damage(state)
                 and (
-                    state.has(item_names.NOVA_BLINK, self.player) 
+                    state.has(item_names.NOVA_BLINK, self.player)
                     or state.has_all((item_names.NOVA_HOLO_DECOY, item_names.NOVA_DOMINATION), self.player)
                 )
             )
@@ -4472,7 +4545,7 @@ class SC2Logic:
 
     def enemy_shadow_domination(self, state: CollectionState) -> bool:
         return (
-            self.grant_story_tech == GrantStoryTech.option_grant 
+            self.grant_story_tech == GrantStoryTech.option_grant
             or self.nova_items_granted
             or (
                 self.nova_ranged_weapon(state)
@@ -4486,7 +4559,7 @@ class SC2Logic:
 
     def enemy_shadow_first_stage(self, state: CollectionState) -> bool:
         return (
-            self.enemy_shadow_domination(state) 
+            self.enemy_shadow_domination(state)
             and (
                 self.grant_story_tech == GrantStoryTech.option_grant
                 or self.nova_items_granted
@@ -4499,7 +4572,7 @@ class SC2Logic:
 
     def enemy_shadow_second_stage(self, state: CollectionState) -> bool:
         return (
-            self.enemy_shadow_first_stage(state) 
+            self.enemy_shadow_first_stage(state)
             and (
                 self.grant_story_tech == GrantStoryTech.option_grant
                 or self.nova_items_granted
@@ -4508,54 +4581,102 @@ class SC2Logic:
             )
         )
 
-    def enemy_shadow_door_controls(self, state: CollectionState) -> bool:
+    def enemy_shadow_can_reach_stone(self, state: CollectionState) -> bool:
         return (
-            self.enemy_shadow_second_stage(state) 
+            self.enemy_shadow_second_stage(state)
             and (
-                self.grant_story_tech == GrantStoryTech.option_grant 
+                self.grant_story_tech == GrantStoryTech.option_grant
                 or self.nova_items_granted
                 or self.enemy_shadow_door_unlocks_tool(state)
             )
         )
 
+    def nova_beat_stone(self, state: CollectionState) -> bool:
+        """
+        Used for any units logic for beating Stone. Shotgun may not be possible; may need feedback.
+        """
+        return (
+            self.grant_story_tech == GrantStoryTech.option_grant
+            or self.nova_items_granted
+            or state.has_any((
+                item_names.NOVA_DOMINATION,
+                item_names.NOVA_BLAZEFIRE_GUNBLADE,
+                item_names.NOVA_C20A_CANISTER_RIFLE,
+            ), self.player)
+            or ((
+                    state.has_any((
+                        item_names.NOVA_PLASMA_RIFLE,
+                        item_names.NOVA_MONOMOLECULAR_BLADE,
+                    ), self.player)
+                    or state.has_all((
+                        item_names.NOVA_HELLFIRE_SHOTGUN,
+                        item_names.NOVA_STIM_INFUSION
+                    ), self.player)
+                )
+                and state.has_any((
+                    item_names.NOVA_JUMP_SUIT_MODULE,
+                    item_names.NOVA_ARMORED_SUIT_MODULE,
+                    item_names.NOVA_ENERGY_SUIT_MODULE,
+                ), self.player)
+                and state.has_any((
+                    item_names.NOVA_FLASHBANG_GRENADES,
+                    item_names.NOVA_STIM_INFUSION,
+                    item_names.NOVA_BLINK,
+                    item_names.NOVA_IONIC_FORCE_FIELD,
+                ), self.player)
+            )
+        )
+
     def enemy_shadow_victory(self, state: CollectionState) -> bool:
         return (
-            self.enemy_shadow_door_controls(state) 
+            self.enemy_shadow_can_reach_stone(state)
             and (
-                self.grant_story_tech == GrantStoryTech.option_grant 
+                self.grant_story_tech == GrantStoryTech.option_grant
                 or self.nova_items_granted
                 or (self.nova_heal(state) and self.nova_beat_stone(state))
             )
         )
-    
+
     def enemy_shadow_hard_rule(self, state: CollectionState) -> bool:
         return (
-            self.grant_story_tech == GrantStoryTech.option_grant 
+            self.grant_story_tech == GrantStoryTech.option_grant
             or self.nova_items_granted
             or self.nova_any_nobuild_damage(state)
+        )
+
+    def enemy_shadow_can_reach_stone_hard_rule(self, state: CollectionState) -> bool:
+        return self.enemy_shadow_hard_rule(state) and self.enemy_shadow_door_unlocks_tool(state)
+
+    def enemy_shadow_victory_hard_rule(self, state: CollectionState) -> bool:
+        return (
+            self.nova_items_granted
+            or (
+                self.nova_beat_stone(state)
+                and self.enemy_shadow_door_unlocks_tool(state)
+            )
         )
 
     def dark_skies_requirement(self, state: CollectionState) -> bool:
         # TODO: revisit defense ratings
         return (
-            self.terran_common_unit(state) 
-            and self.terran_beats_protoss_deathball(state) 
+            self.terran_common_unit(state)
+            and self.terran_beats_protoss_deathball(state)
             and self.terran_defense_rating(state, False, True) >= 8
             and self.competent_or_no_hero(state, SC2Mission.DARK_SKIES)
         )
-    
+
     def zerg_dark_skies_requirement(self, state: CollectionState) -> bool:
         return (
-            self.zerg_competent_comp(state) 
-            and self.zerg_defense_rating(state, False, True) >= 8 
+            self.zerg_competent_comp(state)
+            and self.zerg_defense_rating(state, False, True) >= 8
             and self.zerg_power_rating(state) >= 5
             and self.competent_or_no_hero(state, SC2Mission.DARK_SKIES_Z)
         )
-    
+
     def protoss_dark_skies_requirement(self, state: CollectionState) -> bool:
         return (
-            self.protoss_competent_comp(state) 
-            and self.protoss_defense_rating(state, False) >= 8 
+            self.protoss_competent_comp(state)
+            and self.protoss_defense_rating(state, False) >= 8
             and self.protoss_power_rating(state) >= 5
             and self.competent_or_no_hero(state, SC2Mission.DARK_SKIES_P)
         )
@@ -4599,7 +4720,7 @@ class SC2Logic:
             )
             and self.terran_army_weapon_armor_upgrade_min_level(state) >= 3
         )
-    
+
     def zerg_end_game_requirement(self, state: CollectionState) -> bool:
         return (
             self.zerg_base_buster(state)
@@ -4619,8 +4740,13 @@ class SC2Logic:
             and self.protoss_power_rating(state) >= 5
             and self.competent_or_no_hero(state, SC2Mission.END_GAME_P)
         )
-    
-    
+
+    # endregion NCO Missions
+
+    # ###################################################################################################### #
+    # region Any Units ..................................................................................... #
+    # ###################################################################################################### #
+
     def has_terran_units(self, target: int) -> Callable[["CollectionState"], bool]:
         def _has_terran_units(state: CollectionState) -> bool:
             return (
@@ -4725,6 +4851,7 @@ class SC2Logic:
                     state.has_any((
                         item_names.ZERGLING,
                         item_names.SWARM_QUEEN,
+                        item_names.HIVE_QUEEN,
                         item_names.ROACH,
                         item_names.HYDRALISK,
                         item_names.ABERRATION,
@@ -4853,6 +4980,8 @@ class SC2Logic:
         assert result
         self.unit_count_functions[(race, target)] = result
         return result
+
+    # endregion Any Units
 
 
 def get_basic_units(logic_level: int, race: SC2Race) -> Set[str]:

--- a/worlds/sc2/rules.py
+++ b/worlds/sc2/rules.py
@@ -1754,39 +1754,43 @@ class SC2Logic:
             self.terran_common_unit(state)
             or self.basic_hero(state, SC2Mission.THE_OUTLAWS, False)
         )
+
     def terran_outlaws_requirement(self, state: CollectionState) -> bool:
         return (
             self.terran_common_unit(state)
             and self.basic_or_no_hero(state, SC2Mission.THE_OUTLAWS, False)
         )
+
     def zerg_outlaws_early_requirement(self, state: CollectionState) -> bool:
         return (
             self.zerg_common_unit(state)
             or self.basic_hero(state, SC2Mission.THE_OUTLAWS_Z, False)
         )
+
     def zerg_outlaws_requirement(self, state: CollectionState) -> bool:
         return (
             self.zerg_common_unit(state)
             and self.basic_or_no_hero(state, SC2Mission.THE_OUTLAWS_Z, False)
         )
+
     def protoss_outlaws_early_requirement(self, state: CollectionState) -> bool:
         return (
             self.protoss_common_unit(state)
             or self.basic_hero(state, SC2Mission.THE_OUTLAWS_P, False)
         )
+
     def protoss_outlaws_requirement(self, state: CollectionState) -> bool:
         return (
             self.protoss_common_unit(state)
             and self.basic_or_no_hero(state, SC2Mission.THE_OUTLAWS_P, False)
         )
-    
-
 
     def terran_zero_hour_early_requirement(self, state: CollectionState) -> bool:
         return (
             self.terran_common_unit(state)
             or self.basic_hero(state, SC2Mission.ZERO_HOUR, False)
         )
+
     def terran_zero_hour_stage_2_requirement(self, state: CollectionState) -> bool:
         return (
             self.terran_common_unit(state)
@@ -1806,6 +1810,7 @@ class SC2Logic:
             self.zerg_common_unit(state)
             or self.basic_hero(state, SC2Mission.ZERO_HOUR_Z, False)
         )
+
     def zerg_zero_hour_requirement(self, state: CollectionState) -> bool:
         return (
             self.zerg_common_unit(state)
@@ -2349,19 +2354,22 @@ class SC2Logic:
         Rescuing in The Moebius Factor
         """
         return (
-            state.has_any((
+            self.advanced_tactics
+            or state.has_any((
                 item_names.MEDIVAC, item_names.HERCULES, item_names.RAVEN, item_names.VIKING
             ), self.player)
-            or self.advanced_tactics
         )
 
     def zerg_moebius_factor_can_rescue(self, state: CollectionState) -> bool:
-        return state.has_any((
-            item_names.YGGDRASIL,
-            item_names.OVERLORD_VENTRAL_SACS,
-            item_names.NYDUS_WORM,
-            item_names.BULLFROG,
-        ), self.player)
+        return (
+            self.advanced_tactics
+            or state.has_any((
+                item_names.YGGDRASIL,
+                item_names.OVERLORD_VENTRAL_SACS,
+                item_names.NYDUS_WORM,
+                item_names.BULLFROG,
+            ), self.player)
+        )
 
     def protoss_moebius_factor_can_rescue(self, state: CollectionState) -> bool:
         return self.advanced_tactics or state.has(item_names.WARP_PRISM, self.player)
@@ -2752,7 +2760,7 @@ class SC2Logic:
             # Tested by THE EV, "facetank with Kerrigan and stutter step to the end with >10s left"
             # > have to lure the first group of Zerg in the 2nd timed section into the first room of the second area
             # > (with the heal box) so you can kill them before the timer starts.
-            # 
+            #
             # phaneros: Technically possible without the levels, but adding them in for safety margin and to hopefully
             # make generation force this branch less often
             or (state.has_any((item_names.KERRIGAN_HEROIC_FORTITUDE, item_names.KERRIGAN_INFEST_BROODLINGS), self.player)
@@ -3086,7 +3094,7 @@ class SC2Logic:
 
     def protoss_ghosts_in_the_fog_requirement(self, state: CollectionState) -> bool:
         return self.protoss_competent_comp(state) and self.protoss_mineral_dump(state)
-    
+
     def protoss_ghosts_in_the_fog_east_rock_formation(self, state: CollectionState) -> bool:
         return self.protoss_mineral_dump(state) and self.protoss_can_attack_behind_chasm(state)
 
@@ -3094,6 +3102,8 @@ class SC2Logic:
         """
         Able to shoot by a long range or from air to claim the rock formation separated by a chasm
         """
+        # Note(mm): It's possible to just float a building over and produce on the other side, or SCV drop.
+        # Leaving this rule in place for now in case a potential future speedrun location gets implemented.
         return (
             state.has_any((
                 item_names.MEDIVAC,
@@ -3108,12 +3118,14 @@ class SC2Logic:
                 item_names.SHOCK_DIVISION,
                 item_names.SKY_FURY,
             ), self.player)
-            or state.has_all({item_names.VALKYRIE, item_names.VALKYRIE_FLECHETTE_MISSILES}, self.player)
-            or state.has_all({item_names.RAVEN, item_names.RAVEN_HUNTER_SEEKER_WEAPON}, self.player)
+            or state.has_all((item_names.VALKYRIE, item_names.VALKYRIE_FLECHETTE_MISSILES), self.player)
+            or state.has_all((item_names.RAVEN, item_names.RAVEN_HUNTER_SEEKER_WEAPON), self.player)
             or (
-                state.has_any({item_names.LIBERATOR, item_names.EMPERORS_GUARDIAN}, self.player)
+                state.has_any((item_names.LIBERATOR, item_names.EMPERORS_GUARDIAN), self.player)
                 and state.has(item_names.LIBERATOR_RAID_ARTILLERY, self.player)
             )
+            or state.has_all((item_names.REAPER, item_names.REAPER_JET_PACK_OVERDRIVE), self.player)
+            or state.has_all((item_names.WARHOUND, item_names.WARHOUND_JUMP_JETS), self.player)
             or (
                 self.advanced_tactics
                 and (
@@ -3140,15 +3152,22 @@ class SC2Logic:
 
     def zerg_can_grab_ghosts_in_the_fog_east_rock_formation(self, state: CollectionState) -> bool:
         return (
-            state.has_any({item_names.MUTALISK, item_names.INFESTED_BANSHEE, item_names.OVERLORD_VENTRAL_SACS, item_names.INFESTOR}, self.player)
+            state.has_any((
+                item_names.MUTALISK,
+                item_names.INFESTED_BANSHEE,
+                item_names.OVERLORD_VENTRAL_SACS,
+                item_names.YGGDRASIL,
+                item_names.BULLFROG,
+            ), self.player)
             or (self.morph_devourer(state) and state.has(item_names.DEVOURER_PRESCIENT_SPORES, self.player))
             or (self.morph_guardian(state) and state.has(item_names.GUARDIAN_PRIMAL_ADAPTATION, self.player))
             or ((self.morph_guardian(state) or self.morph_brood_lord(state)) and self.zerg_basic_air_to_air(state))
             or (
                 self.advanced_tactics
                 and (
-                    state.has_any({item_names.INFESTED_SIEGE_BREAKERS, item_names.INFESTED_DUSK_WINGS}, self.player)
+                    state.has_any((item_names.INFESTED_SIEGE_BREAKERS, item_names.INFESTED_DUSK_WINGS), self.player)
                     or (state.has(item_names.HUNTERLING, self.player) and self.zerg_basic_air_to_air(state))
+                    or state.has_all((item_names.INFESTOR, item_names.INFESTOR_INFESTED_TERRAN), self.player)
                 )
             )
         )

--- a/worlds/sc2/rules.py
+++ b/worlds/sc2/rules.py
@@ -1734,6 +1734,13 @@ class SC2Logic:
             return True
         return False
 
+    def protoss_competent_comp_wa2(self, state: CollectionState) -> bool:
+        return (
+            self.protoss_competent_comp(state)
+            # todo(mm): Make this unit-specific within the competent comp function tree
+            and self.protoss_army_weapon_armor_upgrade_min_level(state) >= 2
+        )
+
     def protoss_deathball(self, state: CollectionState) -> bool:
         return (
             self.protoss_common_unit(state)
@@ -3196,14 +3203,39 @@ class SC2Logic:
         else:
             return self.zerg_competent_comp(state) and self.zerg_competent_anti_air(state) and self.zerg_very_hard_mission_weapon_armor_level(state)
 
+    def zerg_the_reckoning_odin_speedrun(self, state: CollectionState) -> bool:
+        return (
+            self.zerg_the_reckoning_requirement(state)
+            and (
+                self.kerrigan_items_granted
+                or (
+                    self.kerrigan_levels(state, 50, False)
+                    and state.has_any(item_groups.kerrigan_logic_ultimates, self.player)
+                )
+            )
+            and self.zerg_power_rating(state) >= 10
+        )
+
     def terran_the_reckoning_requirement(self, state: CollectionState) -> bool:
         return self.terran_very_hard_mission_weapon_armor_level(state) and self.terran_base_trasher(state)
+
+    def terran_the_reckoning_odin_speedrun(self, state: CollectionState) -> bool:
+        return self.terran_the_reckoning_requirement(state) and self.terran_power_rating(state) >= 10
 
     def protoss_the_reckoning_requirement(self, state: CollectionState) -> bool:
         return (
             self.protoss_very_hard_mission_weapon_armor_level(state)
             and self.protoss_deathball(state)
             and (not self.take_over_ai_allies or (self.terran_competent_comp(state) and self.terran_very_hard_mission_weapon_armor_level(state)))
+        )
+
+    def protoss_the_reckoning_odin_speedrun(self, state: CollectionState) -> bool:
+        return (
+            self.protoss_the_reckoning_requirement(state)
+            and (
+                self.protoss_fleet(state)
+                or self.protoss_power_rating(state) >= 10
+            )
         )
 
     # endregion HotS Missions
@@ -3273,6 +3305,21 @@ class SC2Logic:
 
     def protoss_dark_whispers_zerg_base(self, state: CollectionState) -> bool:
         return self.protoss_deathball(state) and (self.protoss_power_rating(state) >= 6)
+
+    def terran_dark_whispers_zerg_base(self, state: CollectionState) -> bool:
+        return (
+            self.terran_competent_comp(state)
+            and self.terran_base_trasher(state)
+            and self.terran_power_rating(state) >= 6
+        )
+
+    def zerg_dark_whispers_zerg_base(self, state: CollectionState) -> bool:
+        return (
+            self.zerg_competent_comp(state)
+            and self.zerg_moderate_anti_air(state)
+            and self.zerg_base_buster(state)
+            and self.zerg_power_rating(state) >= 6
+        )
 
     def protoss_can_attack_behind_chasm(self, state: CollectionState) -> bool:
         return (
@@ -3469,7 +3516,6 @@ class SC2Logic:
             and self.basic_or_no_hero(state, SC2Mission.SKY_SHIELD)
         )
 
-
     def protoss_brothers_in_arms_requirement(self, state: CollectionState) -> bool:
         return (self.protoss_common_unit(state) and self.protoss_anti_armor_anti_air(state) and self.protoss_hybrid_counter(state)) or (
             self.take_over_ai_allies
@@ -3485,6 +3531,19 @@ class SC2Logic:
                     and self.terran_bio_heal(state)
                 )
             )
+        )
+
+    def protoss_brothers_in_arms_speedrun(self, state: CollectionState) -> bool:
+        return (
+            self.protoss_brothers_in_arms_requirement(state)
+            and self.protoss_deathball(state)
+            and self.protoss_power_rating(state) >= 8
+        )
+
+    def terran_brothers_in_arms_speedrun(self, state: CollectionState) -> bool:
+        return (
+            self.terran_base_trasher(state)
+            and self.terran_power_rating(state) >= 8
         )
 
     def zerg_brothers_in_arms_requirement(self, state: CollectionState) -> bool:
@@ -3506,6 +3565,13 @@ class SC2Logic:
             )
         )
 
+    def zerg_brothers_in_arms_speedrun(self, state: CollectionState) -> bool:
+        return (
+            self.zerg_brothers_in_arms_requirement(state)
+            and self.zerg_base_buster(state)
+            and self.zerg_power_rating(state) >= 8
+        )
+
     def protoss_amons_reach_requirement(self, state: CollectionState) -> bool:
         return self.protoss_common_unit_anti_light_air(state) and self.protoss_basic_splash(state) and self.protoss_power_rating(state) >= 7
 
@@ -3517,6 +3583,23 @@ class SC2Logic:
             and self.protoss_defense_rating(state, False) >= 8
         )
 
+    def protoss_last_stand_1p5_billion(self, state: CollectionState) -> bool:
+        return (
+            self.protoss_last_stand_requirement(state)
+            and (
+                state.has_all((
+                    item_names.KHAYDARIN_MONOLITH,
+                    item_names.PHOTON_CANNON,
+                    item_names.SHIELD_BATTERY,
+                ), self.player)
+                or state.has_any((
+                    item_names.SOA_SOLAR_LANCE,
+                    item_names.SOA_DEPLOY_FENIX,
+                ), self.player)
+            )
+            and self.protoss_defense_rating(state, False) >= 13
+        )
+
     def terran_last_stand_requirement(self, state: CollectionState) -> bool:
         return (
             self.terran_common_unit(state)
@@ -3526,6 +3609,12 @@ class SC2Logic:
             and state.has_any({item_names.VIKING, item_names.BATTLECRUISER}, self.player)
             and self.terran_defense_rating(state, True, False) >= 10
             and self.terran_army_weapon_armor_upgrade_min_level(state) >= 2
+        )
+
+    def terran_last_stand_1p5_billion(self, state: CollectionState) -> bool:
+        return (
+            self.terran_last_stand_requirement(state)
+            and self.terran_defense_rating(state, True, True) >= 13
         )
 
     def zerg_last_stand_requirement(self, state: CollectionState) -> bool:
@@ -3626,10 +3715,20 @@ class SC2Logic:
             and self.zerg_power_rating(state) >= 6
         )
 
+    def protoss_unsealing_the_past_requirement(self, state: CollectionState) -> bool:
+        return (
+            self.protoss_deathball(state)
+            and self.protoss_power_rating(state) >= 6
+        )
+
     def protoss_unsealing_the_past_ledge_requirement(self, state: CollectionState) -> bool:
         return (
-            state.has_any((item_names.COLOSSUS, item_names.WRATHWALKER), self.player)
-            or self.protoss_can_attack_behind_chasm(state)
+            self.protoss_unsealing_the_past_requirement(state)
+            and (
+                self.advanced_tactics
+                or state.has_any((item_names.COLOSSUS, item_names.WRATHWALKER), self.player)
+                or self.protoss_can_attack_behind_chasm(state)
+            )
         )
 
     def terran_unsealing_the_past_requirement(self, state: CollectionState) -> bool:
@@ -4316,6 +4415,14 @@ class SC2Logic:
     def terran_sudden_strike_requirement_or_advanced_tactics(self, state: CollectionState) -> bool:
         return self.terran_sudden_strike_requirement(state) or self.advanced_tactics
 
+    def terran_sudden_strike_zerg_base(self, state: CollectionState) -> bool:
+        return (
+            self.terran_sudden_strike_requirement(state)
+            and self.terran_competent_comp(state)
+            and self.terran_base_trasher(state)
+            and self.terran_power_rating(state) >= 8
+        )
+
     def zerg_sudden_strike_requirement(self, state: CollectionState) -> bool:
         presence = self.get_hero_flag(SC2Mission.SUDDEN_STRIKE_Z)
         if presence != HeroFlag.NONE:
@@ -4332,6 +4439,13 @@ class SC2Logic:
                 and self.zerg_defense_rating(state, True, False) >= 5
             )
 
+    def zerg_sudden_strike_zerg_base(self, state: CollectionState) -> bool:
+        return (
+            self.zerg_sudden_strike_requirement(state)
+            and self.zerg_base_buster(state)
+            and self.zerg_power_rating(state) >= 8
+        )
+
     def protoss_sudden_strike_requirement(self, state: CollectionState) -> bool:
         presence = self.get_hero_flag(SC2Mission.SUDDEN_STRIKE_P)
         if presence != HeroFlag.NONE:
@@ -4347,6 +4461,13 @@ class SC2Logic:
                 and self.protoss_competent_comp(state)
                 and self.protoss_defense_rating(state,True) >= 5
             )
+
+    def protoss_sudden_strike_zerg_base(self, state: CollectionState) -> bool:
+        return (
+            self.protoss_sudden_strike_requirement(state)
+            and self.protoss_deathball(state)
+            and self.protoss_power_rating(state) >= 6
+        )
 
     def terran_enemy_intelligence_garrisonable_unit(self, state: CollectionState) -> bool:
         """

--- a/worlds/sc2/rules.py
+++ b/worlds/sc2/rules.py
@@ -4294,7 +4294,7 @@ class SC2Logic:
             or (HeroFlag.ARTANIS in presence and self.sudden_strike_artanis(state))
         )
 
-    def sudden_strike_requirement(self, state: CollectionState) -> bool:
+    def terran_sudden_strike_requirement(self, state: CollectionState) -> bool:
         presence = self.get_hero_flag(SC2Mission.SUDDEN_STRIKE)
         if presence != HeroFlag.NONE:
             # one of the heroes is active
@@ -4312,6 +4312,9 @@ class SC2Logic:
                 and (self.terran_cliffjumper(state) or state.has(item_names.BANSHEE, self.player))
                 and self.terran_defense_rating(state, True, False) >= 5
             )
+
+    def terran_sudden_strike_requirement_or_advanced_tactics(self, state: CollectionState) -> bool:
+        return self.terran_sudden_strike_requirement(state) or self.advanced_tactics
 
     def zerg_sudden_strike_requirement(self, state: CollectionState) -> bool:
         presence = self.get_hero_flag(SC2Mission.SUDDEN_STRIKE_Z)


### PR DESCRIPTION
## What is this fixing or adding?
* moving many lambdas to rules.py
* fixing mypy issues
* adding collapsible editor regions to rules.py

This is part 1 of fixing the issues I was bumping into trying to corral rules in locations.py a little bit for the rules/locations/MO refactor. There should be very few functional changes here, aside from:
* Fixed a few bugged rules that were returning always true
* Ghosts in the Fog east rock formation no longer requires competent comp (for all races)
* Hive Queen added to the list of starter zerg units for any_units

The rest should all be formatting / organizational fixes

## How was this tested?
Ran unit tests and mypy

## If this makes graphical changes, please attach screenshots.
None