### PR TITLE
[SC2] Add Ghost Spawn item

### DIFF
--- a/worlds/sc2/__init__.py
+++ b/worlds/sc2/__init__.py
@@ -8,7 +8,7 @@ from BaseClasses import Item, MultiWorld, Location, Tutorial, ItemClassification
 from Options import Accessibility, OptionError
 from worlds.AutoWorld import WebWorld, World
 from . import location_groups
-from .item.item_groups import unreleased_items, war_council_upgrades
+from .item.item_groups import unreleased_items, war_council_upgrades, disabled_items
 from .item import (
     item_groups, item_names, item_tables, item_parents,
     FilterItem, ItemFilterFlags, StarcraftItem,
@@ -189,6 +189,7 @@ class SC2World(World):
         flag_start_inventory(self, item_list)
         flag_unused_upgrade_types(self, item_list)
         flag_unreleased_items(item_list)
+        flag_disabled_items(item_list)
         flag_war_council_items(self, item_list)
         flag_and_add_resource_locations(self, item_list)
         flag_mission_order_required_items(self, item_list)
@@ -1026,10 +1027,23 @@ def flag_unused_upgrade_types(world: SC2World, item_list: list[FilterItem]) -> N
                 elif ItemFilterFlags.UserExcluded not in item.flags:
                     upgrade_included_counts[item.name] = included + 1
 
+
 def flag_unreleased_items(item_list: list[FilterItem]) -> None:
     """Remove all unreleased items unless they're explicitly locked"""
     for item in item_list:
         if (item.name in unreleased_items
+            and not (ItemFilterFlags.Locked|ItemFilterFlags.StartInventory) & item.flags
+        ):
+            item.flags |= ItemFilterFlags.Removed
+
+
+def flag_disabled_items(item_list: list[FilterItem]) -> None:
+    """
+    Remove all disabled items unless they're explicitly locked.
+    Will be affected by options in the future.
+    """
+    for item in item_list:
+        if (item.name in disabled_items
             and not (ItemFilterFlags.Locked|ItemFilterFlags.StartInventory) & item.flags
         ):
             item.flags |= ItemFilterFlags.Removed

--- a/worlds/sc2/apclient/banks.py
+++ b/worlds/sc2/apclient/banks.py
@@ -32,6 +32,7 @@ BANK_ITEMS_KEY_TERRAN_ITEMS = "TerranItems"
 BANK_ITEMS_KEY_ZERG_ITEMS = "ZergItems"
 BANK_ITEMS_KEY_PROTOSS_ITEMS = "ProtossItems"
 BANK_ITEMS_KEY_MISC_ITEMS = "MiscItems"
+BANK_ITEMS_KEY_TRAP_ITEMS = "TrapItems"
 
 # Messages
 BANK_MESSAGES_FILE_NAME = "ArchipelagoMessages" # .SC2Bank
@@ -265,7 +266,8 @@ def send_items(
     zerg_items: str,
     protoss_items: str,
     misc_items: str,
-) -> None | Error[str]:
+    trap_items: str,
+    ) -> None | Error[str]:
     bank = SC2Bank(BANK_ITEMS_FILE_NAME)
     bank.add_entry(
         BANK_ITEMS_SECTION_ITEMS,
@@ -286,6 +288,11 @@ def send_items(
         BANK_ITEMS_SECTION_ITEMS,
         BANK_ITEMS_KEY_MISC_ITEMS,
         misc_items
+    )
+    bank.add_entry(
+        BANK_ITEMS_SECTION_ITEMS,
+        BANK_ITEMS_KEY_TRAP_ITEMS,
+        trap_items
     )
     return bank.write_file()
 

--- a/worlds/sc2/apclient/game_client.py
+++ b/worlds/sc2/apclient/game_client.py
@@ -390,12 +390,18 @@ class MissionClient:
             current_items[SC2Race.ANY][get_item_flag_word(item_names.UPGRADE_RESEARCH_COST)],
         ))
 
+    def get_trap_items(self, current_items: dict[SC2Race, list[int]]) -> str:
+        return ("{}".format(
+            current_items[SC2Race.ANY][get_item_flag_word(item_names.TRAP_GHOST_SPAWN)],
+        ))
+
     def update_tech(self, current_items: dict[SC2Race, list[int]], kerrigan_level: int) -> None | Error[str]:
         return banks.send_items(
             self.get_terran_tech(current_items),
             self.get_zerg_tech(current_items, kerrigan_level),
             self.get_protoss_tech(current_items),
-            self.get_misc_tech(current_items)
+            self.get_misc_tech(current_items),
+            self.get_trap_items(current_items),
         )
 
     def update_core_options(self, current_items: dict[SC2Race, list[int]]) -> None | Error[str]:

--- a/worlds/sc2/client.py
+++ b/worlds/sc2/client.py
@@ -1740,8 +1740,8 @@ def is_mod_update_available(owner: str, repo: str, api_version: str, metadata: s
 
         else:
             sc2_logger.warning("Failed to reach GitHub while checking for updates.")
-            sc2_logger.warning(f"Status code: {r1.status_code}")
-            sc2_logger.warning(f"text: {r1.text}")
+            # sc2_logger.warning(f"Status code: {r1.status_code}")
+            # sc2_logger.warning(f"text: {r1.text}")
             return False
     except Exception as ex:
         sc2_logger.warning(f"Failed to reach GitHub while checking for updates.")

--- a/worlds/sc2/item/__init__.py
+++ b/worlds/sc2/item/__init__.py
@@ -136,6 +136,7 @@ class FactionlessItemType(ItemTypeEnum):
     MaxSupplyTrap = "Max Supply Trap", 7
     ResearchSpeed = "Research Speed", 8
     ResearchCost = "Research Cost", 9
+    GhostSpawnTrap = "Ghost Spawn Trap", 10
     Keys = "Keys", -1
 
 

--- a/worlds/sc2/item/item_descriptions.py
+++ b/worlds/sc2/item/item_descriptions.py
@@ -604,10 +604,10 @@ item_descriptions = {
     item_names.TRAP_GHOST_SPAWN: inspect.cleandoc("""
         Trap Item.
 
-        Creates a Ghost Academy building for an enemy player.
-        The Ghost Academy periodically spawns Ghost attack waves,
+        Creates a Nuclear Silo building for an enemy player.
+        The Nuclear Silo periodically spawns Ghost attack waves,
         which will be able to use Nuclear Strikes.
-        May use additional abilities, based on difficulty level.
+        Ghosts may use additional abilities, based on difficulty level.
 
         Only works in build missions.
     """),

--- a/worlds/sc2/item/item_descriptions.py
+++ b/worlds/sc2/item/item_descriptions.py
@@ -601,6 +601,16 @@ item_descriptions = {
     item_names.STARTING_SUPPLY: "Increases the starting supply for all missions.",
     item_names.NOTHING: "Does nothing. Used to remove a location from the game.",
     item_names.MAX_SUPPLY: "Increases the maximum supply cap for all missions.",
+    item_names.TRAP_GHOST_SPAWN: inspect.cleandoc("""
+        Trap Item.
+
+        Creates a Ghost Academy building for an enemy player.
+        The Ghost Academy periodically spawns Ghost attack waves,
+        which will be able to use Nuclear Strikes.
+        May use additional abilities, based on difficulty level.
+
+        Only works in build missions.
+    """),
     item_names.REDUCED_MAX_SUPPLY: "Trap Item. Decreases the maximum supply cap for all missions.",
     item_names.SHIELD_REGENERATION: "Increases shield regeneration of all own units.",
     item_names.BUILDING_CONSTRUCTION_SPEED: "Increases building construction speed.",

--- a/worlds/sc2/item/item_groups.py
+++ b/worlds/sc2/item/item_groups.py
@@ -211,6 +211,7 @@ class ItemGroupNames:
 
     VANILLA_ITEMS = "Vanilla Items"
     OVERPOWERED_ITEMS = "Overpowered Items"
+    DISABLED_ITEMS = "Disabled Items"
     UNRELEASED_ITEMS = "Unreleased Items"
     LEGACY_ITEMS = "Legacy Items"
 
@@ -1263,6 +1264,14 @@ item_name_groups[ItemGroupNames.OVERPOWERED_ITEMS] = overpowered_items = [
     item_names.SPECTRE_BARGAIN_BIN_PRICES,
     item_names.REAVER_BARGAIN_BIN_PRICES,
     item_names.SCOUT_SUPPLY_EFFICIENCY,
+]
+
+# Opt-In items that do not show up by default.
+# These items need to be explicitly added, either by certain options
+# or by putting them into locked items or start inventory
+item_name_groups[ItemGroupNames.DISABLED_ITEMS] = disabled_items = [
+    # Trap items
+    item_names.TRAP_GHOST_SPAWN,
 ]
 
 # Items not aimed to be officially released

--- a/worlds/sc2/item/item_names.py
+++ b/worlds/sc2/item/item_names.py
@@ -1050,6 +1050,7 @@ UPGRADE_RESEARCH_SPEED      = "Increased Upgrade Research Speed"
 UPGRADE_RESEARCH_COST       = "Reduced Upgrade Research Cost"
 
 # Trap
+TRAP_GHOST_SPAWN            = "Ghost Spawn Trap"
 REDUCED_MAX_SUPPLY          = "Decreased Maximum Supply"
 NOTHING                     = "Nothing"
 

--- a/worlds/sc2/item/item_tables.py
+++ b/worlds/sc2/item/item_tables.py
@@ -1024,11 +1024,14 @@ item_table = {
         ItemData(808 + SC2WOL_ITEM_ID_OFFSET, FactionlessItemType.ResearchCost, 1, SC2Race.ANY, quantity=0,
                  classification=ItemClassification.filler),
 
-    # Trap Filler
+    # Traps
     item_names.REDUCED_MAX_SUPPLY:
         ItemData(850 + SC2WOL_ITEM_ID_OFFSET, FactionlessItemType.MaxSupplyTrap, -1, SC2Race.ANY, quantity=0,
                  classification=ItemClassification.trap),
 
+    item_names.TRAP_GHOST_SPAWN:
+        ItemData(851 + SC2WOL_ITEM_ID_OFFSET, FactionlessItemType.GhostSpawnTrap, 0, SC2Race.ANY, quantity=5,
+                 classification=ItemClassification.trap),
 
     # Nova gear
     item_names.NOVA_GHOST_VISOR:


### PR DESCRIPTION
## What is this adding

Adds a new item:
### Ghost Spawn Trap
- At the start of build missions, a Ghost Academy building is spawned in an enemy base
- This building periodically spawns Ghosts, which will attack your base in small groups
- Ghosts can use Nuclear Strikes periodically
- The item is progressive with 5 levels. Finding additional copies increases the difficulty level of the trap
- this unlocks additional abilities for the ghost, including Cloak, EMP, Lockdown, Permanent Cloak
- Difficulty of the trap also affects other variables like initial delay, spawn interval and size of Ghost groups attacking you

## Usage

The trap item will not be shuffled into the item pool by default. It must be added to your start inventory and/or locked items list. It is planned to add aditional options in the future regarding trap items/mutators. 

## How was this tested

Generated local campaigns

[SC2Data PR](https://github.com/archipelago-sc2/Archipelago-SC2-data/pull/59)