### PR TITLE
sc2: Fixing incorrect location name for evac p bases

### DIFF
--- a/worlds/sc2/locations.py
+++ b/worlds/sc2/locations.py
@@ -5955,7 +5955,7 @@ def get_locations(world: Optional["SC2World"]) -> Tuple[LocationData, ...]:
         ),
         make_location_data(
             SC2Mission.EVACUATION_P.mission_name,
-            "Western protoss Base",
+            "Western Zerg Base",
             SC2_RACESWAP_LOC_ID_OFFSET + 807,
             LocationType.MASTERY,
             logic.protoss_competent_comp,
@@ -5963,7 +5963,7 @@ def get_locations(world: Optional["SC2World"]) -> Tuple[LocationData, ...]:
         ),
         make_location_data(
             SC2Mission.EVACUATION_P.mission_name,
-            "Eastern protoss Base",
+            "Eastern Zerg Base",
             SC2_RACESWAP_LOC_ID_OFFSET + 808,
             LocationType.MASTERY,
             logic.protoss_competent_comp,


### PR DESCRIPTION
## What is this fixing or adding?
Spotted by piscythe a few minutes ago, the names of these locations were wrong. Looks like an erroneous change in the hero items logic PR #36.

## How was this tested?
Wasn't; string change only

## If this makes graphical changes, please attach screenshots.
none