### PR TITLE
[SC2] Add Epilogue hero support

### DIFF
--- a/worlds/sc2/mission_tables.py
+++ b/worlds/sc2/mission_tables.py
@@ -214,7 +214,7 @@ class SC2Mission(Enum):
     # Epilogue
     INTO_THE_VOID = 72, "Into the Void (Protoss)", SC2Campaign.EPILOGUE, "_1", SC2Race.PROTOSS, MissionPools.VERY_HARD, "ap_into_the_void", MissionFlag.Protoss|MissionFlag.VanillaSoa|MissionFlag.VsAll|MissionFlag.AiTerranAlly|MissionFlag.AiZergAlly|MissionFlag.HasRaceSwap
     THE_ESSENCE_OF_ETERNITY = 73, "The Essence of Eternity (Terran)", SC2Campaign.EPILOGUE, "_2", SC2Race.TERRAN, MissionPools.VERY_HARD, "ap_the_essence_of_eternity", MissionFlag.Terran|MissionFlag.TimedDefense|MissionFlag.VsAll|MissionFlag.AiZergAlly|MissionFlag.AiProtossAlly|MissionFlag.HasRaceSwap
-    AMON_S_FALL = 74, "Amon's Fall (Zerg)", SC2Campaign.EPILOGUE, "_3", SC2Race.ZERG, MissionPools.VERY_HARD, "ap_amon_s_fall", MissionFlag.Zerg|MissionFlag.AutoScroller|MissionFlag.VsAll|MissionFlag.AiTerranAlly|MissionFlag.AiProtossAlly|MissionFlag.HasRaceSwap|MissionFlag.HeroSystemUnsupported
+    AMON_S_FALL = 74, "Amon's Fall (Zerg)", SC2Campaign.EPILOGUE, "_3", SC2Race.ZERG, MissionPools.VERY_HARD, "ap_amon_s_fall", MissionFlag.Zerg|MissionFlag.AutoScroller|MissionFlag.VsAll|MissionFlag.AiTerranAlly|MissionFlag.AiProtossAlly|MissionFlag.HasRaceSwap
 
     # Nova Covert Ops
     THE_ESCAPE = 75, "The Escape", SC2Campaign.NCO, "_1", SC2Race.ANY, MissionPools.MEDIUM, "ap_the_escape", MissionFlag.Terran|MissionFlag.Nova|MissionFlag.NoBuild|MissionFlag.VsTerran|MissionFlag.HeroSystemUnsupported
@@ -375,8 +375,8 @@ class SC2Mission(Enum):
     INTO_THE_VOID_Z = 227, "Into the Void (Zerg)", SC2Campaign.EPILOGUE, "_1", SC2Race.ZERG, MissionPools.VERY_HARD, "ap_into_the_void", MissionFlag.Zerg|MissionFlag.Kerrigan|MissionFlag.VsAll|MissionFlag.AiTerranAlly|MissionFlag.AiProtossAlly|MissionFlag.RaceSwap
     THE_ESSENCE_OF_ETERNITY_Z = 228, "The Essence of Eternity (Zerg)", SC2Campaign.EPILOGUE, "_2", SC2Race.ZERG, MissionPools.VERY_HARD, "ap_the_essence_of_eternity", MissionFlag.Zerg|MissionFlag.TimedDefense|MissionFlag.VsAll|MissionFlag.AiTerranAlly|MissionFlag.AiProtossAlly|MissionFlag.RaceSwap
     THE_ESSENCE_OF_ETERNITY_P = 229, "The Essence of Eternity (Protoss)", SC2Campaign.EPILOGUE, "_2", SC2Race.PROTOSS, MissionPools.VERY_HARD, "ap_the_essence_of_eternity", MissionFlag.Protoss|MissionFlag.TimedDefense|MissionFlag.VsAll|MissionFlag.AiTerranAlly|MissionFlag.AiZergAlly|MissionFlag.RaceSwap
-    AMON_S_FALL_T = 230, "Amon's Fall (Terran)", SC2Campaign.EPILOGUE, "_3", SC2Race.TERRAN, MissionPools.VERY_HARD, "ap_amon_s_fall", MissionFlag.Terran|MissionFlag.AutoScroller|MissionFlag.VsAll|MissionFlag.AiZergAlly|MissionFlag.AiProtossAlly|MissionFlag.RaceSwap|MissionFlag.HeroSystemUnsupported
-    AMON_S_FALL_P = 231, "Amon's Fall (Protoss)", SC2Campaign.EPILOGUE, "_3", SC2Race.PROTOSS, MissionPools.VERY_HARD, "ap_amon_s_fall", MissionFlag.Protoss|MissionFlag.AutoScroller|MissionFlag.VsAll|MissionFlag.AiTerranAlly|MissionFlag.AiZergAlly|MissionFlag.RaceSwap|MissionFlag.HeroSystemUnsupported
+    AMON_S_FALL_T = 230, "Amon's Fall (Terran)", SC2Campaign.EPILOGUE, "_3", SC2Race.TERRAN, MissionPools.VERY_HARD, "ap_amon_s_fall", MissionFlag.Terran|MissionFlag.AutoScroller|MissionFlag.VsAll|MissionFlag.AiZergAlly|MissionFlag.AiProtossAlly|MissionFlag.RaceSwap
+    AMON_S_FALL_P = 231, "Amon's Fall (Protoss)", SC2Campaign.EPILOGUE, "_3", SC2Race.PROTOSS, MissionPools.VERY_HARD, "ap_amon_s_fall", MissionFlag.Protoss|MissionFlag.AutoScroller|MissionFlag.VsAll|MissionFlag.AiTerranAlly|MissionFlag.AiZergAlly|MissionFlag.RaceSwap
 
     # Nova Covert Ops (Race-Swapped)
     # 232/233 - The Escape

--- a/worlds/sc2/mission_tables.py
+++ b/worlds/sc2/mission_tables.py
@@ -213,7 +213,7 @@ class SC2Mission(Enum):
 
     # Epilogue
     INTO_THE_VOID = 72, "Into the Void (Protoss)", SC2Campaign.EPILOGUE, "_1", SC2Race.PROTOSS, MissionPools.VERY_HARD, "ap_into_the_void", MissionFlag.Protoss|MissionFlag.VanillaSoa|MissionFlag.VsAll|MissionFlag.AiTerranAlly|MissionFlag.AiZergAlly|MissionFlag.HasRaceSwap
-    THE_ESSENCE_OF_ETERNITY = 73, "The Essence of Eternity (Terran)", SC2Campaign.EPILOGUE, "_2", SC2Race.TERRAN, MissionPools.VERY_HARD, "ap_the_essence_of_eternity", MissionFlag.Terran|MissionFlag.TimedDefense|MissionFlag.VsAll|MissionFlag.AiZergAlly|MissionFlag.AiProtossAlly|MissionFlag.HasRaceSwap|MissionFlag.HeroSystemUnsupported
+    THE_ESSENCE_OF_ETERNITY = 73, "The Essence of Eternity (Terran)", SC2Campaign.EPILOGUE, "_2", SC2Race.TERRAN, MissionPools.VERY_HARD, "ap_the_essence_of_eternity", MissionFlag.Terran|MissionFlag.TimedDefense|MissionFlag.VsAll|MissionFlag.AiZergAlly|MissionFlag.AiProtossAlly|MissionFlag.HasRaceSwap
     AMON_S_FALL = 74, "Amon's Fall (Zerg)", SC2Campaign.EPILOGUE, "_3", SC2Race.ZERG, MissionPools.VERY_HARD, "ap_amon_s_fall", MissionFlag.Zerg|MissionFlag.AutoScroller|MissionFlag.VsAll|MissionFlag.AiTerranAlly|MissionFlag.AiProtossAlly|MissionFlag.HasRaceSwap|MissionFlag.HeroSystemUnsupported
 
     # Nova Covert Ops
@@ -373,8 +373,8 @@ class SC2Mission(Enum):
     # Epilogue (Race-Swapped)
     INTO_THE_VOID_T = 226, "Into the Void (Terran)", SC2Campaign.EPILOGUE, "_1", SC2Race.TERRAN, MissionPools.VERY_HARD, "ap_into_the_void", MissionFlag.Terran|MissionFlag.VsAll|MissionFlag.AiZergAlly|MissionFlag.AiProtossAlly|MissionFlag.RaceSwap
     INTO_THE_VOID_Z = 227, "Into the Void (Zerg)", SC2Campaign.EPILOGUE, "_1", SC2Race.ZERG, MissionPools.VERY_HARD, "ap_into_the_void", MissionFlag.Zerg|MissionFlag.Kerrigan|MissionFlag.VsAll|MissionFlag.AiTerranAlly|MissionFlag.AiProtossAlly|MissionFlag.RaceSwap
-    THE_ESSENCE_OF_ETERNITY_Z = 228, "The Essence of Eternity (Zerg)", SC2Campaign.EPILOGUE, "_2", SC2Race.ZERG, MissionPools.VERY_HARD, "ap_the_essence_of_eternity", MissionFlag.Zerg|MissionFlag.TimedDefense|MissionFlag.VsAll|MissionFlag.AiTerranAlly|MissionFlag.AiProtossAlly|MissionFlag.RaceSwap|MissionFlag.HeroSystemUnsupported
-    THE_ESSENCE_OF_ETERNITY_P = 229, "The Essence of Eternity (Protoss)", SC2Campaign.EPILOGUE, "_2", SC2Race.PROTOSS, MissionPools.VERY_HARD, "ap_the_essence_of_eternity", MissionFlag.Protoss|MissionFlag.TimedDefense|MissionFlag.VsAll|MissionFlag.AiTerranAlly|MissionFlag.AiZergAlly|MissionFlag.RaceSwap|MissionFlag.HeroSystemUnsupported
+    THE_ESSENCE_OF_ETERNITY_Z = 228, "The Essence of Eternity (Zerg)", SC2Campaign.EPILOGUE, "_2", SC2Race.ZERG, MissionPools.VERY_HARD, "ap_the_essence_of_eternity", MissionFlag.Zerg|MissionFlag.TimedDefense|MissionFlag.VsAll|MissionFlag.AiTerranAlly|MissionFlag.AiProtossAlly|MissionFlag.RaceSwap
+    THE_ESSENCE_OF_ETERNITY_P = 229, "The Essence of Eternity (Protoss)", SC2Campaign.EPILOGUE, "_2", SC2Race.PROTOSS, MissionPools.VERY_HARD, "ap_the_essence_of_eternity", MissionFlag.Protoss|MissionFlag.TimedDefense|MissionFlag.VsAll|MissionFlag.AiTerranAlly|MissionFlag.AiZergAlly|MissionFlag.RaceSwap
     AMON_S_FALL_T = 230, "Amon's Fall (Terran)", SC2Campaign.EPILOGUE, "_3", SC2Race.TERRAN, MissionPools.VERY_HARD, "ap_amon_s_fall", MissionFlag.Terran|MissionFlag.AutoScroller|MissionFlag.VsAll|MissionFlag.AiZergAlly|MissionFlag.AiProtossAlly|MissionFlag.RaceSwap|MissionFlag.HeroSystemUnsupported
     AMON_S_FALL_P = 231, "Amon's Fall (Protoss)", SC2Campaign.EPILOGUE, "_3", SC2Race.PROTOSS, MissionPools.VERY_HARD, "ap_amon_s_fall", MissionFlag.Protoss|MissionFlag.AutoScroller|MissionFlag.VsAll|MissionFlag.AiTerranAlly|MissionFlag.AiZergAlly|MissionFlag.RaceSwap|MissionFlag.HeroSystemUnsupported
 

--- a/worlds/sc2/mission_tables.py
+++ b/worlds/sc2/mission_tables.py
@@ -212,7 +212,7 @@ class SC2Mission(Enum):
     SALVATION = 71, "Salvation (Protoss)", SC2Campaign.LOTV, "Return to Aiur", SC2Race.PROTOSS, MissionPools.VERY_HARD, "ap_salvation", MissionFlag.Protoss|MissionFlag.VanillaSoa|MissionFlag.TimedDefense|MissionFlag.VsPZ|MissionFlag.AiProtossAlly|MissionFlag.HasRaceSwap
 
     # Epilogue
-    INTO_THE_VOID = 72, "Into the Void (Protoss)", SC2Campaign.EPILOGUE, "_1", SC2Race.PROTOSS, MissionPools.VERY_HARD, "ap_into_the_void", MissionFlag.Protoss|MissionFlag.VanillaSoa|MissionFlag.VsAll|MissionFlag.AiTerranAlly|MissionFlag.AiZergAlly|MissionFlag.HasRaceSwap|MissionFlag.HeroSystemUnsupported
+    INTO_THE_VOID = 72, "Into the Void (Protoss)", SC2Campaign.EPILOGUE, "_1", SC2Race.PROTOSS, MissionPools.VERY_HARD, "ap_into_the_void", MissionFlag.Protoss|MissionFlag.VanillaSoa|MissionFlag.VsAll|MissionFlag.AiTerranAlly|MissionFlag.AiZergAlly|MissionFlag.HasRaceSwap
     THE_ESSENCE_OF_ETERNITY = 73, "The Essence of Eternity (Terran)", SC2Campaign.EPILOGUE, "_2", SC2Race.TERRAN, MissionPools.VERY_HARD, "ap_the_essence_of_eternity", MissionFlag.Terran|MissionFlag.TimedDefense|MissionFlag.VsAll|MissionFlag.AiZergAlly|MissionFlag.AiProtossAlly|MissionFlag.HasRaceSwap|MissionFlag.HeroSystemUnsupported
     AMON_S_FALL = 74, "Amon's Fall (Zerg)", SC2Campaign.EPILOGUE, "_3", SC2Race.ZERG, MissionPools.VERY_HARD, "ap_amon_s_fall", MissionFlag.Zerg|MissionFlag.AutoScroller|MissionFlag.VsAll|MissionFlag.AiTerranAlly|MissionFlag.AiProtossAlly|MissionFlag.HasRaceSwap|MissionFlag.HeroSystemUnsupported
 
@@ -371,8 +371,8 @@ class SC2Mission(Enum):
     SALVATION_Z = 225, "Salvation (Zerg)", SC2Campaign.LOTV, "Return to Aiur", SC2Race.ZERG, MissionPools.VERY_HARD, "ap_salvation", MissionFlag.Zerg|MissionFlag.TimedDefense|MissionFlag.VsPZ|MissionFlag.AiProtossAlly|MissionFlag.RaceSwap
 
     # Epilogue (Race-Swapped)
-    INTO_THE_VOID_T = 226, "Into the Void (Terran)", SC2Campaign.EPILOGUE, "_1", SC2Race.TERRAN, MissionPools.VERY_HARD, "ap_into_the_void", MissionFlag.Terran|MissionFlag.VsAll|MissionFlag.AiZergAlly|MissionFlag.AiProtossAlly|MissionFlag.RaceSwap|MissionFlag.HeroSystemUnsupported
-    INTO_THE_VOID_Z = 227, "Into the Void (Zerg)", SC2Campaign.EPILOGUE, "_1", SC2Race.ZERG, MissionPools.VERY_HARD, "ap_into_the_void", MissionFlag.Zerg|MissionFlag.Kerrigan|MissionFlag.VsAll|MissionFlag.AiTerranAlly|MissionFlag.AiProtossAlly|MissionFlag.RaceSwap|MissionFlag.HeroSystemUnsupported
+    INTO_THE_VOID_T = 226, "Into the Void (Terran)", SC2Campaign.EPILOGUE, "_1", SC2Race.TERRAN, MissionPools.VERY_HARD, "ap_into_the_void", MissionFlag.Terran|MissionFlag.VsAll|MissionFlag.AiZergAlly|MissionFlag.AiProtossAlly|MissionFlag.RaceSwap
+    INTO_THE_VOID_Z = 227, "Into the Void (Zerg)", SC2Campaign.EPILOGUE, "_1", SC2Race.ZERG, MissionPools.VERY_HARD, "ap_into_the_void", MissionFlag.Zerg|MissionFlag.Kerrigan|MissionFlag.VsAll|MissionFlag.AiTerranAlly|MissionFlag.AiProtossAlly|MissionFlag.RaceSwap
     THE_ESSENCE_OF_ETERNITY_Z = 228, "The Essence of Eternity (Zerg)", SC2Campaign.EPILOGUE, "_2", SC2Race.ZERG, MissionPools.VERY_HARD, "ap_the_essence_of_eternity", MissionFlag.Zerg|MissionFlag.TimedDefense|MissionFlag.VsAll|MissionFlag.AiTerranAlly|MissionFlag.AiProtossAlly|MissionFlag.RaceSwap|MissionFlag.HeroSystemUnsupported
     THE_ESSENCE_OF_ETERNITY_P = 229, "The Essence of Eternity (Protoss)", SC2Campaign.EPILOGUE, "_2", SC2Race.PROTOSS, MissionPools.VERY_HARD, "ap_the_essence_of_eternity", MissionFlag.Protoss|MissionFlag.TimedDefense|MissionFlag.VsAll|MissionFlag.AiTerranAlly|MissionFlag.AiZergAlly|MissionFlag.RaceSwap|MissionFlag.HeroSystemUnsupported
     AMON_S_FALL_T = 230, "Amon's Fall (Terran)", SC2Campaign.EPILOGUE, "_3", SC2Race.TERRAN, MissionPools.VERY_HARD, "ap_amon_s_fall", MissionFlag.Terran|MissionFlag.AutoScroller|MissionFlag.VsAll|MissionFlag.AiZergAlly|MissionFlag.AiProtossAlly|MissionFlag.RaceSwap|MissionFlag.HeroSystemUnsupported

--- a/worlds/sc2/rules.py
+++ b/worlds/sc2/rules.py
@@ -4206,6 +4206,8 @@ class SC2Logic:
     def essence_of_eternity_requirement(self, state: CollectionState) -> bool:
         if not self.terran_very_hard_mission_weapon_armor_level(state):
             return False
+        if not self.competent_or_no_hero(state,SC2Mission.THE_ESSENCE_OF_ETERNITY):
+            return False
         if self.take_over_ai_allies and not (
             self.protoss_very_hard_mission_weapon_armor_level(state) and self.zerg_very_hard_mission_weapon_armor_level(state)
         ):
@@ -4231,6 +4233,8 @@ class SC2Logic:
     def zerg_essence_of_eternity_requirement(self, state: CollectionState) -> bool:
         if not self.zerg_very_hard_mission_weapon_armor_level(state):
             return False
+        if not self.competent_or_no_hero(state,SC2Mission.THE_ESSENCE_OF_ETERNITY_Z):
+            return False
         if self.take_over_ai_allies and not (
             self.terran_very_hard_mission_weapon_armor_level(state) and self.protoss_very_hard_mission_weapon_armor_level(state)
         ):
@@ -4248,6 +4252,8 @@ class SC2Logic:
 
     def protoss_essence_of_eternity_requirement(self, state: CollectionState) -> bool:
         if not self.protoss_very_hard_mission_weapon_armor_level(state):
+            return False
+        if not self.competent_or_no_hero(state,SC2Mission.THE_ESSENCE_OF_ETERNITY_P):
             return False
         if self.take_over_ai_allies and not (
             self.terran_very_hard_mission_weapon_armor_level(state) and self.zerg_very_hard_mission_weapon_armor_level(state)

--- a/worlds/sc2/rules.py
+++ b/worlds/sc2/rules.py
@@ -4167,6 +4167,8 @@ class SC2Logic:
             self.terran_very_hard_mission_weapon_armor_level(state) and self.zerg_very_hard_mission_weapon_armor_level(state)
         ):
             return False
+        if not self.competent_or_no_hero(state,SC2Mission.INTO_THE_VOID):
+            return False
         return self.protoss_competent_comp(state) or (
             self.take_over_ai_allies
             and (
@@ -4182,7 +4184,11 @@ class SC2Logic:
             self.zerg_very_hard_mission_weapon_armor_level(state) and self.protoss_very_hard_mission_weapon_armor_level(state)
         ):
             return False
-        return self.terran_competent_comp(state) and self.terran_competent_anti_air(state) and self.terran_power_rating(state) >= 6
+        return (self.terran_competent_comp(state)
+            and self.terran_competent_anti_air(state)
+            and self.terran_power_rating(state) >= 6
+            and self.competent_or_no_hero(state,SC2Mission.INTO_THE_VOID_T)
+        )
 
     def zerg_into_the_void_requirement(self, state: CollectionState) -> bool:
         if not self.zerg_very_hard_mission_weapon_armor_level(state):
@@ -4191,7 +4197,11 @@ class SC2Logic:
             self.terran_very_hard_mission_weapon_armor_level(state) and self.protoss_very_hard_mission_weapon_armor_level(state)
         ):
             return False
-        return self.zerg_competent_comp(state) and self.zerg_competent_anti_air(state) and self.zerg_power_rating(state) >= 6
+        return (self.zerg_competent_comp(state)
+            and self.zerg_competent_anti_air(state)
+            and self.zerg_power_rating(state) >= 6
+            and self.competent_or_no_hero(state,SC2Mission.INTO_THE_VOID_Z)
+        )
 
     def essence_of_eternity_requirement(self, state: CollectionState) -> bool:
         if not self.terran_very_hard_mission_weapon_armor_level(state):

--- a/worlds/sc2/rules.py
+++ b/worlds/sc2/rules.py
@@ -4275,6 +4275,8 @@ class SC2Logic:
             return False
         if self.zerg_power_rating(state) < 6:
             return False
+        if not self.competent_or_no_hero(state,SC2Mission.AMON_S_FALL):
+            return False
         if self.take_over_ai_allies and not (
             self.terran_very_hard_mission_weapon_armor_level(state) and self.protoss_very_hard_mission_weapon_armor_level(state)
         ):
@@ -4331,6 +4333,8 @@ class SC2Logic:
             return False
         if self.terran_power_rating(state) < 6:
             return False
+        if not self.competent_or_no_hero(state,SC2Mission.AMON_S_FALL_T):
+            return False
         if self.take_over_ai_allies and not (
             self.zerg_very_hard_mission_weapon_armor_level(state) and self.protoss_very_hard_mission_weapon_armor_level(state)
         ):
@@ -4349,6 +4353,8 @@ class SC2Logic:
         if not self.protoss_competent_anti_air(state):
             return False
         if self.protoss_power_rating(state) < 6:
+            return False
+        if not self.competent_or_no_hero(state,SC2Mission.AMON_S_FALL_P):
             return False
         if self.take_over_ai_allies and not (
             self.terran_very_hard_mission_weapon_armor_level(state) and self.zerg_very_hard_mission_weapon_armor_level(state)


### PR DESCRIPTION
## What is this fixing or adding?

Allows proper hero support Epilogue missions.

### Into the Void
* Hero is added to the starting no-build section
* Removed Stukov for the Zerg race-swap, you only get your regular major heroes
  * if you play other race swaps, Stukov will be present still, controlled by the zerg AI
  * if you play ally control, Stukov will be present under your control
* If you play ally control, the heroes are distributed across the 3 bases according to their race

----

* made starting units assume formation after reaching the base, as opposed to spawn in a blob
* fixed starting units trying to move back to the starting area

### Essence of Eternity
* For ally control, major heroes replace respective minor hero and get placed in the respective bases
* For now, the hero UI will only support 2 heroes (+ Kerridrill), if you play with 3 heroes, the 3rd won't be added to the hero UI.

### Amon's Fall
* Heroes are added in addition to Kerrigod
* for ally control, heroes get placed in their respective bases
* added preparations for an option to fully replace Kerrigod
* also added a debug command to remove Kerrigod mid-mission

## How was this tested?

Functionality tested in local testmap. Logic/presence changes tested in local campaign.
Specifically tested generating a campaign with Kerrigan disabled and Into the Void (Zerg) in the mission pool, to make sure Kerrigan items get culled correctly.

----

[SC2Data PR](https://github.com/archipelago-sc2/Archipelago-SC2-data/pull/89)
