### PR TITLE
sc2: Add special-case code for handling backup/ folder of wrong capitalization

### DIFF
--- a/worlds/sc2/apclient/banks.py
+++ b/worlds/sc2/apclient/banks.py
@@ -155,7 +155,7 @@ class SC2Bank:
         bank_folder = user_paths.get_bank_folder()
         if isinstance(bank_folder, Error):
             return bank_folder
-        dir = f"{bank_folder}/Backup"
+        dir = f"{bank_folder}/{user_paths.BACKUP_DIRNAME}"
         lines: list[str] = []
         lines.append(         f'<?xml version="1.0" encoding="utf-8"?>')
         lines.append(         f'<Bank version="1">')

--- a/worlds/sc2/apclient/user_paths.py
+++ b/worlds/sc2/apclient/user_paths.py
@@ -16,7 +16,6 @@ WINE_PREFIX_TO_SC2_INSTALL = "drive_c/Program Files (x86)/StarCraft II"
 DOCUMENTS_SC2_DIRNAME = f"Documents/{SC2_DIRNAME}"
 BANKS_DIRNAME = "Banks"
 BACKUP_DIRNAME = "backup"
-INVALID_BACKUP_DIRNAME = "Backup"
 
 WINE_ENV_VAR = "WINE"
 WINE_PREFIX_ENV_VAR = "WINEPREFIX"
@@ -203,31 +202,6 @@ def _get_bank_folder() -> str | Error[str]:
         return Error(f"Encountered a file instead of a folder at Banks folder location: {result}")
     if not os.path.isdir(result):
         os.makedirs(result)
-    if not Utils.is_windows:
-        # On linux, a pre-existing lowercase-b backup folder can mess with the communication,
-        # as the game will try to communicate from that folder while the client uses the capitalized one.
-        # Check if the lowercase folder exists, and if it does, move the contents to the capitalized folder
-        # and delete it.
-        backup_folder = os.path.join(result, BACKUP_DIRNAME)
-        invalid_backup_folder = os.path.join(result, INVALID_BACKUP_DIRNAME)
-        if os.path.isfile(backup_folder):
-            os.remove(backup_folder)
-        if os.path.isfile(invalid_backup_folder):
-            os.remove(invalid_backup_folder)
-        elif os.path.isdir(invalid_backup_folder):
-            if not os.path.isdir(backup_folder):
-                os.mkdir(backup_folder)
-            contents = glob.glob(os.path.join(invalid_backup_folder, '*'))
-            for source in contents:
-                target = os.path.join(backup_folder, os.path.basename(source))
-                if os.path.exists(target):
-                    # The user has done something truly cursed, with the same-name backup file in multiple
-                    # different backup folders of different capitalizations. Just give up and pick our target
-                    # file as the winner, deleting the other one. I have no regrets.
-                    os.remove(source)
-                else:
-                    os.rename(source, target)
-            os.rmdir(invalid_backup_folder)
     return result
 
 

--- a/worlds/sc2/apclient/user_paths.py
+++ b/worlds/sc2/apclient/user_paths.py
@@ -15,6 +15,9 @@ SC2_DIRNAME = "StarCraft II"
 WINE_PREFIX_TO_SC2_INSTALL = "drive_c/Program Files (x86)/StarCraft II"
 DOCUMENTS_SC2_DIRNAME = f"Documents/{SC2_DIRNAME}"
 BANKS_DIRNAME = "Banks"
+# Note(mm): The case here is important; filepaths are case-sensitive on Linux, but the game searches for a
+# path case-insensitively, preferring "backup". So setting "Backup" here when "backup" already exists leads
+# to communication failures.
 BACKUP_DIRNAME = "backup"
 
 WINE_ENV_VAR = "WINE"

--- a/worlds/sc2/apclient/user_paths.py
+++ b/worlds/sc2/apclient/user_paths.py
@@ -15,6 +15,8 @@ SC2_DIRNAME = "StarCraft II"
 WINE_PREFIX_TO_SC2_INSTALL = "drive_c/Program Files (x86)/StarCraft II"
 DOCUMENTS_SC2_DIRNAME = f"Documents/{SC2_DIRNAME}"
 BANKS_DIRNAME = "Banks"
+BACKUP_DIRNAME = "backup"
+INVALID_BACKUP_DIRNAME = "Backup"
 
 WINE_ENV_VAR = "WINE"
 WINE_PREFIX_ENV_VAR = "WINEPREFIX"
@@ -162,7 +164,7 @@ def _get_sc2_docs_folder() -> str:
             logger.warning("StarCraft II documents folder not found")
             return ""
         return result
-    
+
     # Linux handling
     wine_prefix = get_wine_prefix()
     if not isinstance(wine_prefix, Error):
@@ -201,6 +203,31 @@ def _get_bank_folder() -> str | Error[str]:
         return Error(f"Encountered a file instead of a folder at Banks folder location: {result}")
     if not os.path.isdir(result):
         os.makedirs(result)
+    if not Utils.is_windows:
+        # On linux, a pre-existing lowercase-b backup folder can mess with the communication,
+        # as the game will try to communicate from that folder while the client uses the capitalized one.
+        # Check if the lowercase folder exists, and if it does, move the contents to the capitalized folder
+        # and delete it.
+        backup_folder = os.path.join(result, BACKUP_DIRNAME)
+        invalid_backup_folder = os.path.join(result, INVALID_BACKUP_DIRNAME)
+        if os.path.isfile(backup_folder):
+            os.remove(backup_folder)
+        if os.path.isfile(invalid_backup_folder):
+            os.remove(invalid_backup_folder)
+        elif os.path.isdir(invalid_backup_folder):
+            if not os.path.isdir(backup_folder):
+                os.mkdir(backup_folder)
+            contents = glob.glob(os.path.join(invalid_backup_folder, '*'))
+            for source in contents:
+                target = os.path.join(backup_folder, os.path.basename(source))
+                if os.path.exists(target):
+                    # The user has done something truly cursed, with the same-name backup file in multiple
+                    # different backup folders of different capitalizations. Just give up and pick our target
+                    # file as the winner, deleting the other one. I have no regrets.
+                    os.remove(source)
+                else:
+                    os.rename(source, target)
+            os.rmdir(invalid_backup_folder)
     return result
 
 
@@ -284,7 +311,7 @@ def _get_sc2_install_dir() -> str:
             return result
         logger.warning(f"Could not find sc2 install path at {result}")
         return ""
-    
+
     # Linux handling
     wine_prefix = get_wine_prefix()
     if not isinstance(wine_prefix, Error):


### PR DESCRIPTION
## What is this fixing or adding?
Fixed the issue where Banks/backup/ folders of the wrong capitalization could cause connection issues on Linux.

I originally set this up to move from backup -> Backup, but then flipped the order around, then realized that if the game consistently prefers the lowercase folder then we probably don't need all this special-handling code. I'll just leave this here so we can judge how bad the edge cases are before we decide to rip it out and just use the lowercase folder.

## How was this tested?
Added an incorrectly-capitalized backup folder to the Banks/ folder and started a mission. It connected successfully.

## If this makes graphical changes, please attach screenshots.
None.