### PR TITLE
Hero Client Option Fix

### DIFF
--- a/worlds/sc2/client.py
+++ b/worlds/sc2/client.py
@@ -415,6 +415,7 @@ class StarcraftClientProcessor(ClientCommandProcessor):
             self.output(f"Unknown {hero_name} presence target '{target}'. Use /{command_name} help to see examples.")
             return
 
+        affected_count = self.ctx.set_runtime_hero_presence(hero, target_key, enabled)
         state = "enabled" if enabled else "disabled"
         self.output(f"{hero_name} presence {state} for {target_key}.")
 

--- a/worlds/sc2/client.py
+++ b/worlds/sc2/client.py
@@ -415,7 +415,7 @@ class StarcraftClientProcessor(ClientCommandProcessor):
             self.output(f"Unknown {hero_name} presence target '{target}'. Use /{command_name} help to see examples.")
             return
 
-        affected_count = self.ctx.set_runtime_hero_presence(hero, target_key, enabled)
+        self.ctx.set_runtime_hero_presence(hero, target_key, enabled)
         state = "enabled" if enabled else "disabled"
         self.output(f"{hero_name} presence {state} for {target_key}.")
 


### PR DESCRIPTION
https://github.com/archipelago-sc2/Archipelago/pull/61

When trying to fix issues for the Hero Option Set PR, I accidentally deleted a variable assignment that is used to change the hero presence for affected missions when using the option in the client. This PR just re-adds that line back to make it so hero swapping in the client is possible.

Nothing is broken for current beta games, the option will just not work if they have an updated client