### PR TITLE
Basebust Location Fix

### DIFF
--- a/worlds/sc2/client.py
+++ b/worlds/sc2/client.py
@@ -33,7 +33,7 @@ from .options import (
     MissionOrder, KerriganPrimalStatus, EnableMorphling, GameDifficulty,
     GameSpeed, GenericUpgradeItems, GenericUpgradeResearch, ColorChoice, GenericUpgradeMissions, MaxUpgradeLevel,
     LocationInclusion, ExtraLocations, MasteryLocations, SpeedrunLocations, PreventativeLocations, ChallengeLocations,
-    VanillaLocations, EnabledHeroes, HeroPresence,
+    VanillaLocations, BasebustLocations, EnabledHeroes, HeroPresence,
     GrantStoryTech, GrantStoryLevels, TakeOverAIAllies, RequiredTactics,
     SpearOfAdunPresence, SpearOfAdunPresentInNoBuild, SpearOfAdunPassiveAbilityPresence,
     SpearOfAdunPassivesPresentInNoBuild, EnableVoidTrade, VoidTradeAgeLimit, void_trade_age_limits_ms, VoidTradeWorkers,

--- a/worlds/sc2/client.py
+++ b/worlds/sc2/client.py
@@ -1138,6 +1138,7 @@ class SC2Context(CommonContext):
                 LocationType.MASTERY: args["slot_data"].get("mastery_locations", MasteryLocations.default),
             }
             self.location_inclusions_by_flag = {
+                LocationFlag.BASEBUST: args["slot_data"].get("basebust_locations", BasebustLocations.default),
                 LocationFlag.SPEEDRUN: args["slot_data"].get("speedrun_locations", SpeedrunLocations.default),
                 LocationFlag.PREVENTATIVE: args["slot_data"].get("preventative_locations", PreventativeLocations.default),
             }


### PR DESCRIPTION
## What is this fixing or adding?
Fixes an SC2 client GUI crash when connecting to worlds with Basebust locations.

A recent bugfix PR changed the mission table GUI to correctly iterate `LocationFlag` values from `lookup_location_id_to_flags`. That exposed that the client was initializing inclusion settings for `SPEEDRUN` and `PREVENTATIVE`, but not `BASEBUST`. So when a remaining mission location had 'BASEBUST' it would crash the GUI

## How was this tested?

~~Not tested yet. Verifying fix w/ user before updating~~
UPDATE: verified with tommygun03 on discord, confirmed it fixed his game

## If this makes graphical changes, please attach screenshots.
