### PR TITLE
sc2: Adding an inspirations doc for tracking sources of where items came from

### DIFF
--- a/worlds/sc2/docs/inspirations.md
+++ b/worlds/sc2/docs/inspirations.md
@@ -20,9 +20,9 @@ This doc is not expected to be complete.
 
 #### Marine
 * Combat Shield -- vanilla WoL and melee upgrade
-* Mag-rail Munition -- vanilla NCO technology
+* Laser Targeting System -- vanilla NCO technology
+* Magrail Munition -- vanilla NCO technology
 * Medpack -- see @medpack
-* Optimized Logistics -- vanilla NCO technology
 * Optimized Logistics -- vanilla NCO technology
 * Stimpack -- vanilla WoL and melee upgrade
 
@@ -69,6 +69,7 @@ This doc is not expected to be complete.
 * Resource Efficiency / Bargain Bin Prices -- copied from Ghost RE
 
 #### HERC
+Based off the melee LotV beta unit; also appears in NCO 6 Flashpoint
 * Juggernaut Plating -- inspired by Firebat Juggernaut Plating
 * Kinetic Foam -- inspired by Marauder Kinetic Foam
 
@@ -118,9 +119,11 @@ This doc is not expected to be complete.
 * Large Scale Field Construction -- inspired by WoL alpha footage
 
 #### Warhound
+Based off the melee HotS beta unit
 * Deploy Turret -- loosely inspired by co-op Tychus's Sirius ability
 
 #### Cyclone
+Based off the melee LotV unit
 * Internal Tech Module -- melee 5.0.12 removed the tech lab requirement for Cyclones
 * Mag-Field Aceelerator -- melee upgrade added in 4.7.1
 * Mag-Field Launcher -- melee 3.8.0 briefly had a +2 range upgrade with 4 base range, before just making it baseline
@@ -129,6 +132,7 @@ This doc is not expected to be complete.
 * Targeting Optics -- co-op Swann upgrade
 
 #### Widow Mine
+Based off the melee HotS unit
 * Black Market Launchers -- inspired by co-op Han & Horner upgrade
 * Executioner Missiles -- inspired by co-op Han & Horner upgrade
 * Demolition Payload -- AP original
@@ -158,12 +162,13 @@ This doc is not expected to be complete.
 * Shockwave Missile Battery -- vanilla WoL upgrade; vanilla NCO technology (Special Ordnance)
 
 #### Liberator
+Based off the melee LotV unit; also from NCO
 * Cloak -- vanilla NCO technology
 * Optimized Logistics -- vanilla NCO technology
 * Smart Servos -- vanilla NCO technology
 
 #### Valkyrie
-Brood war unit
+Based off the brood war unit
 
 #### Science Vessel
 * Defensive Matrix -- co-op Swann upgrade; brood war ability
@@ -209,7 +214,88 @@ Brood war unit
 #### Perdition Turret
 
 #### Devastator Turret
-Brought in from co-op Swann Devastator Turrets / Blaster Billy
+Based off the co-op Swann building: Devastator Turret / Blaster Billy
 
-### Zerg
-### Protoss
+## Zerg
+### General
+
+### Hatchery Units
+#### Zergling
+#### Swarm Queen
+#### Hive Queen
+Based off the melee Queen
+
+#### Roach
+#### Hydralisk
+#### Aberration
+#### Mutalisk
+#### Swarm Host
+#### Infestor
+#### Ultralisk
+#### Pygalisk
+Based off the enemy unit in Piercing the Shroud; largely original
+
+#### Corruptor
+Based off the melee unit
+
+#### Scourge
+Based off the brood war unit and co-op Zagara unit; also appears for the enemy in WoL
+
+#### Brood Queen
+Based off the co-op Stukov unit; also from brood war
+
+#### Defiler
+Based off the brood war; also appears for the enemy in NCO 2
+
+### Morphs
+#### Baneling
+#### Impaler
+#### Lurker
+#### Brood Lord
+#### Viper
+#### Guardian
+#### Devourer
+#### Ravager
+Based off the melee LotV unit
+
+#### Overseer
+Based off the melee unit
+
+#### Primal Igniter
+Based off the co-op Dehaka unit
+
+#### Tyrannozor
+Based off the co-op Dehaka unit
+
+### Infested Terran
+#### Infested Marine
+Based off the co-op Stukov unit
+
+#### Infested Diamondback
+Based off the co-op Stukov unit
+
+#### Infested Siege Tank
+Based off the co-op Stukov unit
+
+#### Bullfrog
+AP original unit
+
+#### Infested Banshee
+Based off the co-op Stukov unit
+
+#### Infested Liberator
+Based off the co-op Stukov unit
+
+### Buildings
+#### Spine Crawler
+#### Spore Crawler
+#### Bile Launcher
+Based off the co-op Zagara building
+
+#### Infested Missile Turret
+Based off the co-op Stukov building
+
+#### Infested Bunker
+Based off the co-op Stukov building
+
+## Protoss

--- a/worlds/sc2/docs/inspirations.md
+++ b/worlds/sc2/docs/inspirations.md
@@ -1,0 +1,215 @@
+# Inspirations
+This document is for tracking the history and inspiration behind various item ideas, to:
+* Give some credit to other mods where we took inspiration
+* Track what vanilla game content ideas came from (campaign, co-op, melee, brood war, etc)
+* Potentially track tweaks or paths not taken
+
+This doc is not expected to be complete.
+
+## Terran
+### General
+* Rogue Forces -- inspired by RaegLordDz's WoL 3p co-op mod
+
+@medpack -- originally tier 2 stimpack to recreate vanilla NCO technology; split into non-progressive
+
+### Barracks
+#### SCV
+* Advanced Construction -- vanilla WoL upgrade
+* Construction Jump Jets -- inspired by Covert Ops Redux by OrcaWarrior
+* Dual Fusion Welders -- vanilla WoL upgrade
+
+#### Marine
+* Combat Shield -- vanilla WoL and melee upgrade
+* Mag-rail Munition -- vanilla NCO technology
+* Medpack -- see @medpack
+* Optimized Logistics -- vanilla NCO technology
+* Optimized Logistics -- vanilla NCO technology
+* Stimpack -- vanilla WoL and melee upgrade
+
+#### Marauder
+* Concussive Shells -- vanilla WoL upgrade
+* Kinetic Foam -- vanilla WoL upgrade
+* Medpack -- see @Medpack
+* Stimpack -- melee upgrade; enables vanilla NCO advanced stimpack technology
+
+#### Firebat
+* Incinerator Gauntlets -- vanilla WoL upgrade
+* Infernal Pre-Igniter -- inspired by melee Hellion upgrade
+* Juggernaut Plating -- vanilla WoL upgrade
+* Kinetic Foam -- inspired by Marauder Kinetic Foam
+* Resource Efficiency -- brood war baseline cost is 50/25/1
+
+#### Medic
+* Advanced Medic Facilities -- vanilla WoL upgrade
+* Stabilizer Medpacks -- vanilla WoL upgrade
+* Restoration -- brood war ability
+* Optical Flare -- brood war ability
+* Resource Efficiency -- brood war baseline cost is 50/25/1
+
+#### Reaper
+* Advanced Cloaking Field -- vanilla NCO technology
+* Combat Drugs -- melee baseline passive in Legacy of the Void
+* G-4 Clusterbomb -- vanilla WoL upgrade
+* Jet Pack Overdrive -- co-op Han & Horner upgrade
+* Medpack -- see @medpack
+* Spider Mines -- vanilla NCO technology
+* Stimpack -- lifted from vanilla Marine; enables vanilla NCO advanced stimpack technology
+* U-238 Rounds -- vanilla WoL upgrade
+
+#### Ghost
+* Crius Suit -- vanilla WoL upgrade
+* EMP Rounds -- gives their melee ability
+* Lockdown -- brood war ability
+* Ocular Implants -- vanilla WoL upgrade
+* Resource Efficiency / Bargain Bin Prices -- brood war baseline cost is 75/25/1, these are tuned to reach that together. They were incredibly overpowered, so the upgrade was split and BBP made OP
+
+#### Spectre
+* Nyx-Class Cloaking Module -- vanilla WoL upgrade
+* Psionic Lash -- vanilla WoL upgrade
+* Resource Efficiency / Bargain Bin Prices -- copied from Ghost RE
+
+#### HERC
+* Juggernaut Plating -- inspired by Firebat Juggernaut Plating
+* Kinetic Foam -- inspired by Marauder Kinetic Foam
+
+### Factory
+#### Hellion
+* Infernal Plating -- co-op Swann upgrade
+* Jump Jets -- vanilla NCO technology
+* Twin-Linked Flamethrower -- vanilla WoL upgrade
+* Thermite Filaments -- vanilla WoL upgrade
+
+#### Vulture
+* Ion Thrusters -- brood war upgrade
+* Replenishable magazine -- level 1: vanilla WoL upgrade
+
+#### Spider Mine
+* Cerberus Mine -- vanilla WoL upgrade (on the vulture)
+* High Explosive Munition -- co-op Raynor and Nova mines do 125 damage (WoL does 70)
+
+#### Goliath
+* Ares-Class Targeting System -- vanilla WoL upgrade
+* Jump Jets -- vanilla NCO technology
+* Laser Targeting System -- vanilla NCO technology
+* Optimized Logistics -- vanilla NCO technology
+* Multi-Lock Weapons System -- vanilla WoL upgrade
+* Resource Efficiency -- brood war baseline cost is 100/50/2
+* Shaped Hull -- post-WoL goliaths have 150 health (seen in NCO)
+
+#### Diamondback
+* Shaped Hull -- vanilla WoL upgrade
+* Tri-Lithium Power Cell -- level 1: vanilla WoL upgrade
+
+#### Siege Tank
+* Advanced Siege Tech -- inspired by co-op Raynor upgrade
+* Graduating Range -- inspired by co-op Nova upgrade
+* Internal Tech Module -- vanilla NCO technology
+* Jump Jets -- vanilla NCO technology
+* Maelstrom Rounds -- vanilla WoL upgrade; co-op Swann upgrade
+* Resource Efficiency -- brood war baseline cost is 150/100/2
+* Shaped Blast -- vanilla WoL upgrade
+* Smart Servos -- vanilla NCO technology
+* Spider Mine -- vanilla NCO technology
+
+#### Thor
+* 330mm Barrage Cannon -- vanilla WoL upgrade
+* Button With a Skull on it -- inspired by the vanilla setpiece with the Odin on Engine of Destruction
+* Immortality Protocol -- level 1: vanilla WoL upgrade
+* Large Scale Field Construction -- inspired by WoL alpha footage
+
+#### Warhound
+* Deploy Turret -- loosely inspired by co-op Tychus's Sirius ability
+
+#### Cyclone
+* Internal Tech Module -- melee 5.0.12 removed the tech lab requirement for Cyclones
+* Mag-Field Aceelerator -- melee upgrade added in 4.7.1
+* Mag-Field Launcher -- melee 3.8.0 briefly had a +2 range upgrade with 4 base range, before just making it baseline
+* Rapid Fire Launchers -- melee upgrade added in 4.0.0, removed in 4.7.1
+* Resource Efficiency -- melee 5.0.12 reduced Cyclone cost 150/100/3 -> 125/50/3 alongside a general power level overhaul
+* Targeting Optics -- co-op Swann upgrade
+
+#### Widow Mine
+* Black Market Launchers -- inspired by co-op Han & Horner upgrade
+* Executioner Missiles -- inspired by co-op Han & Horner upgrade
+* Demolition Payload -- AP original
+* Drilling Claws -- melee HotS and LotV upgrade at various times
+
+### Starport
+#### Medivac
+* Afterburners -- melee LotV ability
+* Rapid Deployment Tube -- vanilla WoL upgrade
+* Advanced Healing AI -- vanilla WoL upgrade
+
+#### Viking
+* Anti-Mechanical Munition -- melee LotV adds bonus vs mechanical (patch 3.8.0)
+* Phobos-Class Weapons System -- vanilla WoL upgrade
+* Ripwave Missiles -- vanilla WoL upgrade
+
+#### Wraith
+* Displacement Field -- vanilla WoL upgrade
+* Tomahawk Power Cells -- level 1 is a vanilla WoL upgrade; level 2 extends general NCO-level permacloak
+
+#### Banshee
+* Cross-Spectrium Dampeners -- level 1: vanilla WoL upgrade; level 2: vanilla NCO technology
+* Hyperflight Rotors -- melee LotV upgrade
+* Internal Tech Module -- vanilla NCO technology
+* Laser Targeting System -- vanilla NCO technology
+* Rocket Barrage -- inspired by co-op Nova ability on Covert Banshees
+* Shockwave Missile Battery -- vanilla WoL upgrade; vanilla NCO technology (Special Ordnance)
+
+#### Liberator
+* Cloak -- vanilla NCO technology
+* Optimized Logistics -- vanilla NCO technology
+* Smart Servos -- vanilla NCO technology
+
+#### Valkyrie
+Brood war unit
+
+#### Science Vessel
+* Defensive Matrix -- co-op Swann upgrade; brood war ability
+* EMP Shockwave -- brood war ability
+* Improved Nano-Repair -- inspired by co-op Swann upgrade
+* Magellan Computation Systems -- inspired by Medivac Advanced Healing AI
+* Tactical Jump -- inspired by co-op Swann prestige 3 Payload Director
+
+#### Raven
+* Anti-Armor Missile -- melee LotV ability
+* Bio-Mechanical Repair Drone -- vanilla NCO technology; related to co-op Nova ability
+* Hunter-Seeker Weapon -- vanilla NCO technology (special ordnance)
+* Interference Matrix -- melee LotV ability
+* Internal Tech Module -- vanilla NCO technology
+* Railgun Turret -- co-op Nova ability; vanilla NCO technology (Magrail Munitions)
+* Resource Efficiency -- melee LotV patch change in 5.0.11
+* Spider Mines -- vanilla NCO technology
+
+#### Battlecruiser
+* Defensive Matrix -- level 1 is a vanilla WoL upgrade; level 2 is original, an attempt to make it useable
+* Missile Pods -- level 1 is a vanilla WoL upgrade; level 2 is original, an attempt to make it useable
+
+### Royal Guard
+
+### Buildings
+#### Bunker
+* Emergency Rations -- AP original, intended to let bunkers provide supply-free defense
+* Fortified Bunker -- vanilla WoL lab upgrade
+* Neosteel Bunker -- vanilla WoL upgrade
+* Projectile Accelerator -- vanilla WoL upgrade
+* Shrike Turret -- vanilla WoL lab upgrade
+
+#### Missile Turret
+* Titanium Housing -- vanilla WoL upgrade
+* Hellstorm Batteries -- vanilla WoL upgrade
+* Resource Efficiency -- brood war baseline cost is 75 minerals
+
+#### Planetary Fortress
+* Augmented Thrusters -- AP original
+* Ibiks Tracking Scanners -- AP original
+* Orbital Module -- AP original
+
+#### Perdition Turret
+
+#### Devastator Turret
+Brought in from co-op Swann Devastator Turrets / Blaster Billy
+
+### Zerg
+### Protoss


### PR DESCRIPTION
## What is this fixing or adding?
Adding an inspirations doc to have a place to track sources / inspirations in future. Filled out a bunch of the terran upgrade information.

## How was this tested?
No code change. NCO/co-op/melee/bw information was checked against Liquipedia, sc2coop.com, and the fandom wiki

## If this makes graphical changes, please attach screenshots.
None