### PR TITLE
sc2: misc mission order type fixes

### DIFF
--- a/worlds/sc2/mission_order/layout_types.py
+++ b/worlds/sc2/mission_order/layout_types.py
@@ -24,7 +24,7 @@ class LayoutType(ABC):
 
         This should include at least one entrance and exit."""
         return []
-    
+
     def final_setup(self, missions: List[SC2MOGenMission]):
         """Called after user changes to the layout are applied to make any final checks and changes.
 
@@ -36,10 +36,10 @@ class LayoutType(ABC):
 
         If the term cannot be parsed, either raise an exception or return `None`."""
         return self.parse_index_as_function(term)
-    
+
     def parse_index_as_function(self, term: str) -> Union[Set[int], None]:
         """Helper function to interpret the term as a function call on the layout type, if it is declared in `self.index_functions`.
-        
+
         Returns the function's return value if `term` is a valid function call, `None` otherwise."""
         left = term.find('(')
         right = term.find(')')
@@ -66,7 +66,7 @@ class LayoutType(ABC):
     def get_visual_layout(self) -> List[List[int]]:
         """Organize the mission slots into a list of columns from left to right and top to bottom.
         The list should contain indices into the list created by `make_slots`. Intentionally empty spots should contain -1.
-        
+
         The resulting 2D list should be rectangular."""
         pass
 
@@ -84,7 +84,7 @@ class Column(LayoutType):
         for i in range(self.size - 1):
             missions[i].next.append(missions[i + 1])
         return missions
-    
+
     def get_visual_layout(self) -> List[List[int]]:
         return [list(range(self.size))]
 
@@ -147,27 +147,27 @@ class Grid(LayoutType):
     @staticmethod
     def manhattan_distance(point1: Tuple[int, int], point2: Tuple[int, int]) -> int:
         return abs(point1[0] - point2[0]) + abs(point1[1] - point2[1])
-    
+
     @staticmethod
     def euclidean_distance_squared(point1: Tuple[int, int], point2: Tuple[int, int]) -> int:
         return (point1[0] - point2[0]) ** 2 + (point1[1] - point2[1]) ** 2
-    
+
     @staticmethod
     def euclidean_distance(point1: Tuple[int, int], point2: Tuple[int, int]) -> float:
         return math.sqrt(Grid.euclidean_distance_squared(point1, point2))
 
     def get_grid_coordinates(self, idx: int) -> Tuple[int, int]:
         return (idx % self.width), (idx // self.width)
-    
+
     def get_grid_index(self, x: int, y: int) -> int:
         return y * self.width + x
-    
+
     def is_valid_coordinates(self, x: int, y: int) -> bool:
         return (
             0 <= x < self.width and
             0 <= y < self.height
         )
-    
+
     def make_slots(self, mission_factory: Callable[[], SC2MOGenMission]) -> List[SC2MOGenMission]:
         missions = [mission_factory() for _ in range(self.width * self.height)]
         if self.two_start_positions:
@@ -191,7 +191,7 @@ class Grid(LayoutType):
                     if self.is_valid_coordinates(nb_x, nb_y)
                 ]
                 missions[idx].next = [missions[nb] for nb in neighbours]
-        
+
         # Empty corners
         top_corners = math.floor(self.num_corners_to_remove / 2)
         bottom_corners = math.ceil(self.num_corners_to_remove / 2)
@@ -227,14 +227,14 @@ class Grid(LayoutType):
             y += 1
 
         return missions
-    
+
     def get_visual_layout(self) -> List[List[int]]:
         columns = [
             [self.get_grid_index(x, y) for y in range(self.height)]
             for x in range(self.width)
         ]
         return columns
-    
+
     def idx_point(self, x: str, y: str) -> Union[Set[int], None]:
         try:
             x = int(x)
@@ -244,7 +244,7 @@ class Grid(LayoutType):
         if self.is_valid_coordinates(x, y):
             return {self.get_grid_index(x, y)}
         return None
-    
+
     def idx_rect(self, x: str, y: str, width: str, height: str) -> Union[Set[int], None]:
         try:
             x = int(x)
@@ -260,7 +260,7 @@ class Grid(LayoutType):
             if self.is_valid_coordinates(pt_x, pt_y)
         }
         return indices
-    
+
 
 class Canvas(Grid):
     """Rectangular grid that determines size and filled slots based on special canvas option."""
@@ -295,7 +295,7 @@ class Canvas(Grid):
         for (line_idx, line) in enumerate(self.canvas):
             for (char_idx, char) in enumerate(line):
                 self.groups.setdefault(char, []).append(self.get_grid_index(char_idx, line_idx))
-        
+
         return options
 
     def make_slots(self, mission_factory: Callable[[], SC2MOGenMission]) -> List[SC2MOGenMission]:
@@ -313,7 +313,7 @@ class Canvas(Grid):
                 point[0] + direction[0] * distance,
                 point[1] + direction[1] * distance
             )
-        
+
         def raycast(point: Tuple[int, int], direction: Tuple[int, int], max_distance: int) -> Union[Tuple[int, SC2MOGenMission], None]:
             for distance in range(1, max_distance + 1):
                 target = jump(point, direction, distance)
@@ -362,7 +362,7 @@ class Canvas(Grid):
         # if the user didn't set one themselves
         def distance_lambda(point: Tuple[int, int]) -> Callable[[Tuple[int, SC2MOGenMission]], int]:
             return lambda idx_mission: Grid.euclidean_distance_squared(self.get_grid_coordinates(idx_mission[0]), point)
-        
+
         if not any(mission.option_entrance for mission in missions):
             top_left = self.get_grid_coordinates(0)
             closest_to_top_left = sorted(
@@ -435,9 +435,9 @@ class Hopscotch(LayoutType):
             for next_idx in indices:
                 if next_idx < self.size:
                     slots[idx].next.append(slots[next_idx])
-        
+
         return slots
-    
+
     @staticmethod
     def space_at_column(idx: int) -> List[int]:
         # -1 0 1 2 3 4 5
@@ -468,7 +468,7 @@ class Hopscotch(LayoutType):
             if col_idx >= self.width:
                 final_cols[col_idx % self.width].extend([-1 for _ in range(self.spacer)])
             final_cols[col_idx % self.width].extend(col)
-        
+
         fill_to_longest(final_cols)
 
         return final_cols
@@ -516,7 +516,7 @@ class Gauntlet(LayoutType):
     # 0 1 2 3
     #
     # 4 5 6 7
-    
+
     def set_options(self, options: Dict[str, Any]) -> Dict[str, Any]:
         width: int = options.pop("width", 7)
         self.width = min(max(width, 4), self.size)
@@ -529,7 +529,7 @@ class Gauntlet(LayoutType):
         for i in range(self.size - 1):
             missions[i].next.append(missions[i + 1])
         return missions
-    
+
     def get_visual_layout(self) -> List[List[int]]:
         columns = [[] for _ in range(self.width)]
         for idx in range(self.size):
@@ -562,12 +562,12 @@ class Blitz(LayoutType):
         else:
             self.width = min(self.size, width)
         return options
-    
+
     def make_slots(self, mission_factory: Callable[[], SC2MOGenMission]) -> List[SC2MOGenMission]:
         slots = [mission_factory() for _ in range(self.size)]
         for idx in range(self.width):
             slots[idx].option_entrance = True
-        
+
         # TODO: this is copied from the original mission order and works, but I'm not sure on the intent
         # middle_column = self.width // 2
         # if self.size % self.width > middle_column:
@@ -587,18 +587,18 @@ class Blitz(LayoutType):
                         slots[idx].next.append(slots[other])
                     if row == rows-1:
                         slots[idx].option_exit = True
-        
+
         return slots
-    
+
     def get_visual_layout(self) -> List[List[int]]:
         columns = [[] for _ in range(self.width)]
         for idx in range(self.size):
             columns[idx % self.width].append(idx)
-        
+
         fill_to_longest(columns)
 
         return columns
-    
+
     def idx_row(self, row: str) -> Union[Set[int], None]:
         try:
             row = int(row)
@@ -611,7 +611,7 @@ class Blitz(LayoutType):
         return {
             idx for idx in indices if idx < self.size
         }
-    
+
 def fill_to_longest(columns: List[List[int]]):
     longest = max(len(col) for col in columns)
     for idx in range(len(columns)):

--- a/worlds/sc2/mission_order/nodes.py
+++ b/worlds/sc2/mission_order/nodes.py
@@ -3,8 +3,7 @@ Contains the data structures that make up a mission order.
 Data in these structures is validated in .options.py and manipulated by .generation.py.
 """
 
-from __future__ import annotations
-from typing import Dict, Set, Callable, List, Any, Type, Optional, Union, TYPE_CHECKING
+from typing import Callable, Any, Type, TYPE_CHECKING
 from weakref import ref, ReferenceType
 from dataclasses import asdict
 from abc import ABC, abstractmethod
@@ -22,10 +21,10 @@ if TYPE_CHECKING:
     from .. import SC2World
 
 class MissionOrderNode(ABC):
-    parent: Optional[ReferenceType[MissionOrderNode]]
+    parent: ReferenceType['MissionOrderNode'] | None
     important_beat_event: bool
 
-    def get_parent(self, address_so_far: str, full_address: str) -> MissionOrderNode:
+    def get_parent(self, address_so_far: str, full_address: str) -> 'MissionOrderNode':
         if self.parent is None:
             raise ValueError(
                 f"Address \"{address_so_far}\" (from \"{full_address}\") could not find a parent object. "
@@ -34,7 +33,7 @@ class MissionOrderNode(ABC):
         return self.parent()
 
     @abstractmethod
-    def search(self, term: str) -> Union[List[MissionOrderNode], None]:
+    def search(self, term: str) -> list['MissionOrderNode'] | None:
         raise NotImplementedError
 
     @abstractmethod
@@ -42,25 +41,25 @@ class MissionOrderNode(ABC):
         raise NotImplementedError
 
     @abstractmethod
-    def get_missions(self) -> List[SC2MOGenMission]:
-        raise NotImplementedError
-    
-    @abstractmethod
-    def get_exits(self) -> List[SC2MOGenMission]:
+    def get_missions(self) -> list['SC2MOGenMission']:
         raise NotImplementedError
 
     @abstractmethod
-    def get_visual_requirement(self, start_node: MissionOrderNode) -> Union[str, SC2MOGenMission]:
+    def get_exits(self) -> list['SC2MOGenMission']:
         raise NotImplementedError
-    
+
+    @abstractmethod
+    def get_visual_requirement(self, start_node: 'MissionOrderNode') -> 'str | SC2MOGenMission':
+        raise NotImplementedError
+
     @abstractmethod
     def get_key_name(self) -> str:
         raise NotImplementedError
-    
+
     @abstractmethod
     def get_min_depth(self) -> int:
         raise NotImplementedError
-    
+
     @abstractmethod
     def get_address_to_node(self) -> str:
         raise NotImplementedError
@@ -70,17 +69,17 @@ class SC2MOGenMissionOrder(MissionOrderNode):
     """
     The top-level data structure for mission orders.
     """
-    campaigns: List[SC2MOGenCampaign]
-    sorted_missions: Dict[Difficulty, List[SC2MOGenMission]]
+    campaigns: list['SC2MOGenCampaign']
+    sorted_missions: dict[Difficulty, list['SC2MOGenMission']]
     """All mission slots in the mission order sorted by their difficulty, but not their depth."""
-    fixed_missions: List[SC2MOGenMission]
+    fixed_missions: list['SC2MOGenMission']
     """All mission slots that have a plando'd mission."""
-    items_to_lock: Dict[str, int]
-    keys_to_resolve: Dict[MissionOrderNode, List[ItemEntryRule]]
-    goal_missions: List[SC2MOGenMission]
+    items_to_lock: dict[str, int]
+    keys_to_resolve: dict[MissionOrderNode, list[ItemEntryRule]]
+    goal_missions: list['SC2MOGenMission']
     max_depth: int
 
-    def __init__(self, world: 'SC2World', data: Dict[str, Any]):
+    def __init__(self, world: 'SC2World', data: dict[str, Any]):
         self.campaigns = []
         self.sorted_missions = {diff: [] for diff in Difficulty if diff != Difficulty.RELATIVE}
         self.fixed_missions = []
@@ -112,7 +111,7 @@ class SC2MOGenMissionOrder(MissionOrderNode):
         if len(self.goal_missions) == 0:
             self.campaigns[-1].option_goal = True
             self.goal_missions.extend(mission for mission in self.campaigns[-1].exits)
-        
+
         # Apply victory cache option wherever the value has not yet been defined; must happen after goal missions are decided
         for mission in self.get_missions():
             if mission.option_victory_cache != -1:
@@ -124,7 +123,7 @@ class SC2MOGenMissionOrder(MissionOrderNode):
                 mission.option_victory_cache = world.options.victory_cache.value
 
         # Resolve names
-        used_names: Set[str] = set()
+        used_names: set[str] = set()
         for campaign in self.campaigns:
             names = [campaign.option_name] if len(campaign.option_display_name) == 0 else campaign.option_display_name
             if campaign.option_unique_name:
@@ -137,28 +136,28 @@ class SC2MOGenMissionOrder(MissionOrderNode):
                     names = [name for name in names if name not in used_names]
                 layout.display_name = world.random.choice(names)
                 used_names.add(layout.display_name)
-    
-    def get_slot_data(self) -> List[Dict[str, Any]]:
+
+    def get_slot_data(self) -> list[dict[str, Any]]:
         # [(campaign data, [(layout data, [[(mission data)]] )] )]
         return [asdict(campaign.get_slot_data()) for campaign in self.campaigns]
 
-    def search(self, term: str) -> Union[List[MissionOrderNode], None]:
+    def search(self, term: str) -> list[MissionOrderNode] | None:
         return [
             campaign.layouts[0] if campaign.option_single_layout_campaign else campaign
             for campaign in self.campaigns
             if campaign.option_name.casefold() == term.casefold()
         ]
-    
+
     def child_type_name(self) -> str:
         return "Campaign"
-    
-    def get_missions(self) -> List[SC2MOGenMission]:
+
+    def get_missions(self) -> list['SC2MOGenMission']:
         return [mission for campaign in self.campaigns for layout in campaign.layouts for mission in layout.missions]
-    
-    def get_exits(self) -> List[SC2MOGenMission]:
+
+    def get_exits(self) -> list['SC2MOGenMission']:
         return []
-    
-    def get_visual_requirement(self, _start_node: MissionOrderNode) -> Union[str, SC2MOGenMission]:
+
+    def get_visual_requirement(self, _start_node: MissionOrderNode) -> 'str | SC2MOGenMission':
         return "All Missions"
 
     def get_key_name(self) -> str:
@@ -166,16 +165,16 @@ class SC2MOGenMissionOrder(MissionOrderNode):
 
     def get_min_depth(self) -> int:
         return super().get_min_depth()  # type: ignore
-    
+
     def get_address_to_node(self):
         return self.campaigns[0].get_address_to_node() + "/.."
 
 
 class SC2MOGenCampaign(MissionOrderNode):
     option_name: str # name of this campaign
-    option_display_name: List[str]
+    option_display_name: list[str]
     option_unique_name: bool
-    option_entry_rules: List[Dict[str, Any]]
+    option_entry_rules: list[dict[str, Any]]
     option_unique_progression_track: int # progressive keys under this campaign and on this track will be changed to a unique track
     option_goal: bool # whether this campaign is required to beat the game
     # minimum difficulty of this campaign
@@ -187,15 +186,15 @@ class SC2MOGenCampaign(MissionOrderNode):
     option_single_layout_campaign: bool
 
     # layouts of this campaign in correct order
-    layouts: List[SC2MOGenLayout]
-    exits: List[SC2MOGenMission] # missions required to beat this campaign (missions marked "exit" in layouts marked "exit")
+    layouts: list['SC2MOGenLayout']
+    exits: list['SC2MOGenMission'] # missions required to beat this campaign (missions marked "exit" in layouts marked "exit")
     entry_rule: SubRuleEntryRule
     display_name: str
 
     min_depth: int
     max_depth: int
 
-    def __init__(self, world: 'SC2World', parent: ReferenceType[SC2MOGenMissionOrder], name: str, data: Dict[str, Any]):
+    def __init__(self, world: 'SC2World', parent: ReferenceType[SC2MOGenMissionOrder], name: str, data: dict[str, Any]):
         self.parent = parent
         self.important_beat_event = False
         self.option_name = name
@@ -211,45 +210,45 @@ class SC2MOGenCampaign(MissionOrderNode):
         self.exits = []
 
         for (layout_name, layout_data) in data.items():
-            if type(layout_data) == dict:
+            if isinstance(layout_data, dict):
                 layout = SC2MOGenLayout(world, ref(self), layout_name, layout_data)
                 self.layouts.append(layout)
 
                 # Collect required missions (marked layouts' exits)
                 if layout.option_exit:
                     self.exits.extend(layout.exits)
-                
+
         # If no exits are set, use the last defined layout
         if len(self.exits) == 0:
             self.layouts[-1].option_exit = True
             self.exits.extend(self.layouts[-1].exits)
-        
-    def is_beaten(self, beaten_missions: Set[SC2MOGenMission]) -> bool:
+
+    def is_beaten(self, beaten_missions: set['SC2MOGenMission']) -> bool:
         return beaten_missions.issuperset(self.exits)
 
     def is_always_unlocked(self, in_region_creation = False) -> bool:
         return self.entry_rule.is_always_fulfilled(in_region_creation)
 
-    def is_unlocked(self, beaten_missions: Set[SC2MOGenMission], in_region_creation = False) -> bool:
+    def is_unlocked(self, beaten_missions: set['SC2MOGenMission'], in_region_creation = False) -> bool:
         return self.entry_rule.is_fulfilled(beaten_missions, in_region_creation)
 
-    def search(self, term: str) -> Union[List[MissionOrderNode], None]:
+    def search(self, term: str) -> list[MissionOrderNode] | None:
         return [
             layout
             for layout in self.layouts
             if layout.option_name.casefold() == term.casefold()
         ]
-    
+
     def child_type_name(self) -> str:
         return "Layout"
 
-    def get_missions(self) -> List[SC2MOGenMission]:
+    def get_missions(self) -> list['SC2MOGenMission']:
         return [mission for layout in self.layouts for mission in layout.missions]
 
-    def get_exits(self) -> List[SC2MOGenMission]:
+    def get_exits(self) -> list['SC2MOGenMission']:
         return self.exits
-    
-    def get_visual_requirement(self, start_node: MissionOrderNode) -> Union[str, SC2MOGenMission]:
+
+    def get_visual_requirement(self, start_node: MissionOrderNode) -> 'str | SC2MOGenMission':
         visual_name = self.get_visual_name()
         # Needs special handling for double-parent, which is valid for missions but errors for campaigns
         first_parent = start_node.get_parent("", "")
@@ -260,16 +259,16 @@ class SC2MOGenCampaign(MissionOrderNode):
         ) and visual_name == "":
             return "this campaign"
         return visual_name
-    
+
     def get_visual_name(self) -> str:
         return self.display_name
-    
+
     def get_key_name(self) -> str:
         return item_names._TEMPLATE_NAMED_CAMPAIGN_KEY.format(self.get_visual_name())
-    
+
     def get_min_depth(self) -> int:
         return self.min_depth
-    
+
     def get_address_to_node(self) -> str:
         return f"{self.option_name}"
 
@@ -289,16 +288,16 @@ class SC2MOGenCampaign(MissionOrderNode):
 
 class SC2MOGenLayout(MissionOrderNode):
     option_name: str # name of this layout
-    option_display_name: List[str] # visual name of this layout
+    option_display_name: list[str] # visual name of this layout
     option_unique_name: bool
     option_type: Type[LayoutType] # type of this layout
     option_size: int # amount of missions in this layout
     option_goal: bool # whether this layout is required to beat the game
     option_exit: bool # whether this layout is required to beat its parent campaign
-    option_mission_pool: List[int] # IDs of valid missions for this layout
-    option_missions: List[Dict[str, Any]]
+    option_mission_pool: list[int] # IDs of valid missions for this layout
+    option_missions: list[dict[str, Any]]
 
-    option_entry_rules: List[Dict[str, Any]]
+    option_entry_rules: list[dict[str, Any]]
     option_unique_progression_track: int # progressive keys under this layout and on this track will be changed to a unique track
 
     # minimum difficulty of this layout
@@ -308,17 +307,17 @@ class SC2MOGenLayout(MissionOrderNode):
     # 'relative': based on the median distance of the last mission
     option_max_difficulty: Difficulty
 
-    missions: List[SC2MOGenMission]
+    missions: list['SC2MOGenMission']
     layout_type: LayoutType
-    entrances: List[SC2MOGenMission]
-    exits: List[SC2MOGenMission]
+    entrances: list['SC2MOGenMission']
+    exits: list['SC2MOGenMission']
     entry_rule: SubRuleEntryRule
     display_name: str
 
     min_depth: int
     max_depth: int
 
-    def __init__(self, world: 'SC2World', parent: ReferenceType[SC2MOGenCampaign], name: str, data: Dict):
+    def __init__(self, world: 'SC2World', parent: ReferenceType[SC2MOGenCampaign], name: str, data: dict):
         self.parent: ReferenceType[SC2MOGenCampaign] = parent
         self.important_beat_event = False
         self.option_name = name
@@ -353,8 +352,8 @@ class SC2MOGenLayout(MissionOrderNode):
 
         # Update missions with user data
         for mission_data in self.option_missions:
-            indices: Set[int] = set()
-            index_terms: List[Union[int, str]] = mission_data["index"]
+            indices: set[int] = set()
+            index_terms: list[int | str] = mission_data["index"]
             for term in index_terms:
                 result = self.resolve_index_term(term)
                 indices.update(result)
@@ -376,7 +375,7 @@ class SC2MOGenLayout(MissionOrderNode):
         for mission in self.missions:
             for next_mission in mission.next:
                 next_mission.prev.append(mission)
-        
+
         # Remove empty missions from access data
         for mission in self.missions:
             if mission.option_empty:
@@ -386,7 +385,7 @@ class SC2MOGenLayout(MissionOrderNode):
                 for prev_mission in mission.prev:
                     prev_mission.next.remove(mission)
                 mission.prev.clear()
-        
+
         # Clean up data and options
         all_empty = True
         for mission in self.missions:
@@ -418,16 +417,16 @@ class SC2MOGenLayout(MissionOrderNode):
         if all_empty:
             raise Exception(f"Layout \"{self.option_name}\" only contains empty mission slots.")
 
-    def is_beaten(self, beaten_missions: Set[SC2MOGenMission]) -> bool:
+    def is_beaten(self, beaten_missions: set['SC2MOGenMission']) -> bool:
         return beaten_missions.issuperset(self.exits)
 
     def is_always_unlocked(self, in_region_creation = False) -> bool:
         return self.entry_rule.is_always_fulfilled(in_region_creation)
-    
-    def is_unlocked(self, beaten_missions: Set[SC2MOGenMission], in_region_creation = False) -> bool:
+
+    def is_unlocked(self, beaten_missions: set['SC2MOGenMission'], in_region_creation = False) -> bool:
         return self.entry_rule.is_fulfilled(beaten_missions, in_region_creation)
 
-    def resolve_index_term(self, term: Union[str, int], *, ignore_out_of_bounds: bool = True, reject_none: bool = True) -> Union[Set[int], None]:
+    def resolve_index_term(self, term: str | int, *, ignore_out_of_bounds: bool = True, reject_none: bool = True) -> set[int] | None:
         try:
             result = {int(term)}
         except ValueError:
@@ -452,38 +451,38 @@ class SC2MOGenLayout(MissionOrderNode):
             parent = self.parent
         return parent()
 
-    def search(self, term: str) -> Union[List[MissionOrderNode], None]:
+    def search(self, term: str) -> list[MissionOrderNode] | None:
         indices = self.resolve_index_term(term, reject_none=False)
         if indices is None:
             # Let the address parser handle the fail case
             return []
         missions = [self.missions[index] for index in sorted(indices)]
         return missions
-    
+
     def child_type_name(self) -> str:
         return "Mission"
 
-    def get_missions(self) -> List[SC2MOGenMission]:
+    def get_missions(self) -> list['SC2MOGenMission']:
         return [mission for mission in self.missions]
 
-    def get_exits(self) -> List[SC2MOGenMission]:
+    def get_exits(self) -> list['SC2MOGenMission']:
         return self.exits
-    
-    def get_visual_requirement(self, start_node: MissionOrderNode) -> Union[str, SC2MOGenMission]:
+
+    def get_visual_requirement(self, start_node: MissionOrderNode) -> 'str | SC2MOGenMission':
         visual_name = self.get_visual_name()
         if start_node.get_parent("", "") is self and visual_name == "":
             return "this questline"
         return visual_name
-    
+
     def get_visual_name(self) -> str:
         return self.display_name
-    
+
     def get_key_name(self) -> str:
         return item_names._TEMPLATE_NAMED_LAYOUT_KEY.format(self.get_visual_name(), self.parent().get_visual_name())
-    
+
     def get_min_depth(self) -> int:
         return self.min_depth
-    
+
     def get_address_to_node(self) -> str:
         campaign = self.parent()
         if campaign.option_single_layout_campaign:
@@ -516,12 +515,12 @@ class SC2MOGenMission(MissionOrderNode):
     option_entrance: bool  # whether this mission is unlocked when the layout is unlocked
     option_exit: bool  # whether this mission is required to beat its parent layout
     option_empty: bool  # whether this slot contains a mission at all
-    option_next: Union[None, List[Union[int, str]]]  # indices of internally connected missions
-    option_entry_rules: List[Dict[str, Any]]
+    option_next: list[int | str] | None  # indices of internally connected missions
+    option_entry_rules: list[dict[str, Any]]
     option_difficulty: Difficulty  # difficulty pool this mission pulls from
-    option_mission_pool: Set[int]  # Allowed mission IDs for this slot
+    option_mission_pool: set[int]  # Allowed mission IDs for this slot
     option_victory_cache: int  # Number of victory cache locations tied to the mission name
-    option_heroes: Optional[List[str]]  # Exact heroes assigned to this slot, or None to use normal hero presence
+    option_heroes: list[str] | None  # Exact heroes assigned to this slot, or None to use normal hero presence
 
     entry_rule: SubRuleEntryRule
     min_depth: int # Smallest amount of missions to beat before this slot is accessible
@@ -529,10 +528,10 @@ class SC2MOGenMission(MissionOrderNode):
     mission: SC2Mission
     region: Region
 
-    next: List[SC2MOGenMission]
-    prev: List[SC2MOGenMission]
+    next: list['SC2MOGenMission']
+    prev: list['SC2MOGenMission']
 
-    def __init__(self, parent: ReferenceType[SC2MOGenLayout], parent_mission_pool: Set[int]):
+    def __init__(self, parent: ReferenceType[SC2MOGenLayout], parent_mission_pool: set[int]) -> None:
         self.parent: ReferenceType[SC2MOGenLayout] = parent
         self.important_beat_event = False
         self.option_mission_pool = parent_mission_pool
@@ -549,7 +548,7 @@ class SC2MOGenMission(MissionOrderNode):
         self.option_victory_cache = -1
         self.option_heroes = None
 
-    def update_with_data(self, data: Dict):
+    def update_with_data(self, data: dict) -> None:
         self.option_goal = data.get("goal", self.option_goal)
         self.option_entrance = data.get("entrance", self.option_entrance)
         self.option_exit = data.get("exit", self.option_exit)
@@ -560,40 +559,40 @@ class SC2MOGenMission(MissionOrderNode):
         self.option_mission_pool = data.get("mission_pool", self.option_mission_pool)
         self.option_victory_cache = data.get("victory_cache", -1)
         self.option_heroes = data.get("heroes", self.option_heroes)
-    
+
     def is_always_unlocked(self, in_region_creation = False) -> bool:
         return self.entry_rule.is_always_fulfilled(in_region_creation)
-    
-    def is_unlocked(self, beaten_missions: Set[SC2MOGenMission], in_region_creation = False) -> bool:
+
+    def is_unlocked(self, beaten_missions: set['SC2MOGenMission'], in_region_creation = False) -> bool:
         return self.entry_rule.is_fulfilled(beaten_missions, in_region_creation)
-    
+
     def beat_item(self) -> str:
         return f"Beat {self.mission.mission_name}"
-    
+
     def beat_rule(self, player) -> Callable[[CollectionState], bool]:
         return lambda state: state.has(self.beat_item(), player)
 
-    def search(self, term: str) -> Union[List[MissionOrderNode], None]:
+    def search(self, term: str) -> list[MissionOrderNode] | None:
         return None
-    
+
     def child_type_name(self) -> str:
         return ""
 
-    def get_missions(self) -> List[SC2MOGenMission]:
+    def get_missions(self) -> list['SC2MOGenMission']:
         return [self]
 
-    def get_exits(self) -> List[SC2MOGenMission]:
+    def get_exits(self) -> list['SC2MOGenMission']:
         return [self]
-    
-    def get_visual_requirement(self, _start_node: MissionOrderNode) -> Union[str, SC2MOGenMission]:
+
+    def get_visual_requirement(self, _start_node: MissionOrderNode) -> 'str | SC2MOGenMission':
         return self
-    
+
     def get_key_name(self) -> str:
         return item_names._TEMPLATE_MISSION_KEY.format(self.mission.mission_name)
-    
+
     def get_min_depth(self) -> int:
         return self.min_depth
-    
+
     def get_address_to_node(self) -> str:
         layout = self.parent()
         assert layout is not None

--- a/worlds/sc2/mission_order/options.py
+++ b/worlds/sc2/mission_order/options.py
@@ -7,7 +7,7 @@ import random
 
 from Options import OptionDict, Visibility
 from schema import Schema, Optional, And, Or
-from typing import Any, Union
+from typing import Any, Iterable
 import copy
 
 from ..mission_tables import lookup_name_to_mission
@@ -36,12 +36,20 @@ HERO_OPTION_VALUES = {
 
 STR_OPTION_VALUES: dict[str, dict[str, Any]] = {
     "type": {
-        "column": Column.__name__, "grid": Grid.__name__, "hopscotch": Hopscotch.__name__, "gauntlet": Gauntlet.__name__, "blitz": Blitz.__name__,
+        "column": Column.__name__,
+        "grid": Grid.__name__,
+        "hopscotch": Hopscotch.__name__,
+        "gauntlet": Gauntlet.__name__,
+        "blitz": Blitz.__name__,
         "canvas": Canvas.__name__,
     },
     "difficulty": {
-        "relative": Difficulty.RELATIVE.value, "starter": Difficulty.STARTER.value, "easy": Difficulty.EASY.value,
-        "medium": Difficulty.MEDIUM.value, "hard": Difficulty.HARD.value, "very hard": Difficulty.VERY_HARD.value
+        "relative": Difficulty.RELATIVE.value,
+        "starter": Difficulty.STARTER.value,
+        "easy": Difficulty.EASY.value,
+        "medium": Difficulty.MEDIUM.value,
+        "hard": Difficulty.HARD.value,
+        "very hard": Difficulty.VERY_HARD.value
     },
     "preset": {
         "none": lambda _: {},
@@ -335,8 +343,8 @@ def _resolve_string_option_single(option: str, option_value: str) -> Any:
     return STR_OPTION_VALUES[option][formatted_value]
 
 
-def _resolve_string_option(option: str, option_value: Union[list[str], str]) -> Any:
-    if type(option_value) == list:
+def _resolve_string_option(option: str, option_value: list[str] | str) -> Any:
+    if isinstance(option_value, list):
         return [_resolve_string_option_single(option, val) for val in option_value]
     else:
         return _resolve_string_option_single(option, option_value)
@@ -390,9 +398,9 @@ def _resolve_entry_rule(option_value: dict[str, Any]) -> dict[str, Any]:
     return resolved
 
 
-def _resolve_potential_range(option_value: Union[Any, str]) -> Union[Any, int]:
+def _resolve_potential_range(option_value: Any | str) -> Any | int:
     # An option value may be a range
-    if type(option_value) == str and option_value.startswith("random-range-"):
+    if isinstance(option_value, str) and option_value.startswith("random-range-"):
         resolved = _custom_range(option_value)
         return resolved
     else:
@@ -402,11 +410,11 @@ def _resolve_potential_range(option_value: Union[Any, str]) -> Union[Any, int]:
         return option_value
 
 
-def _resolve_mission_pool(option_value: Union[str, list[str]]) -> set[int]:
-    if type(option_value) == str:
+def _resolve_mission_pool(option_value: str | list[str]) -> set[int]:
+    if isinstance(option_value, str):
         pool = _get_target_missions(option_value)
     else:
-        pool: set[int] = set()
+        pool = set()
         for line in option_value:
             if line.startswith("~"):
                 if len(pool) == 0:
@@ -444,7 +452,7 @@ def _get_target_missions(term: str) -> set[int]:
 
 
 def _resolve_heroes(option_value: str | list[str]) -> list[str]:
-    if type(option_value) == str:
+    if isinstance(option_value, str):
         heroes = [option_value]
     else:
         heroes = option_value
@@ -488,7 +496,7 @@ def _triangular(lower: int, end: int, tri: int | None = None) -> int:
 # Version of options.Sc2ItemDict.verify without World
 def _resolve_item_names(value: dict[str, int]) -> dict[str, int]:
     new_value: dict[str, int] = {}
-    case_insensitive_group_mapping = {
+    case_insensitive_group_mapping: dict[str, Iterable[str]] = {
         group_name.casefold(): group_value for group_name, group_value in item_name_groups.items()
     }
     case_insensitive_group_mapping.update({item.casefold(): {item} for item in item_table})

--- a/worlds/sc2/mission_order/presets_scripted.py
+++ b/worlds/sc2/mission_order/presets_scripted.py
@@ -1,11 +1,16 @@
-from typing import Any
+from typing import Any, TYPE_CHECKING
 import copy
+
+if TYPE_CHECKING:
+    from .types import CampaignDict, LayoutDict
+
 
 def _required_option(option: str, options: dict[str, Any]) -> Any:
     """Returns the option value, or raises an error if the option is not present."""
     if option not in options:
         raise KeyError(f"Campaign preset is missing required option \"{option}\".")
     return options.pop(option)
+
 
 def _validate_option(option: str, options: dict[str, str], default: str, valid_values: list[str]) -> str:
     """Returns the option value if it is present and valid, the default if it is not present, or raises an error if it is present but not valid."""
@@ -14,7 +19,8 @@ def _validate_option(option: str, options: dict[str, str], default: str, valid_v
         raise ValueError(f"Preset option \"{option}\" received unknown value \"{result}\".")
     return result
 
-def make_golden_path(options: dict[str, Any]) -> dict[str, Any]:
+
+def make_golden_path(options: dict[str, Any]) -> 'CampaignDict':
     chain_name_options = [
         'Mar Sara', 'Agria', 'Redstone', 'Meinhoff', 'Haven', 'Tarsonis', 'Valhalla', 'Char',
         'Umoja', 'Kaldir', 'Zerus', 'Skygeirr Station', 'Dominion Space', 'Korhal',
@@ -79,7 +85,7 @@ def make_golden_path(options: dict[str, Any]) -> dict[str, Any]:
     campaign.add_mission(0, current_required_missions, is_final = True)
 
     # Create mission order preset out of campaign
-    layout_base = {
+    layout_base: 'LayoutDict' = {
         "type": "column",
         "display_name": chain_name_options,
         "unique_name": True,
@@ -90,7 +96,7 @@ def make_golden_path(options: dict[str, Any]) -> dict[str, Any]:
         layout_base["entry_rules"] = [{ "items": { "Key": 1 }}]
     elif keys_option == "progressive_layouts":
         layout_base["entry_rules"] = [{ "items": { "Progressive Key": 0 }}]
-    preset = {
+    preset: 'CampaignDict' = {
         str(chain): copy.deepcopy(layout_base) for chain in range(len(campaign.chain_lengths))
     }
     preset["0"]["exit"] = True

--- a/worlds/sc2/mission_order/presets_scripted.py
+++ b/worlds/sc2/mission_order/presets_scripted.py
@@ -1,26 +1,28 @@
-from typing import Dict, Any, List
+from typing import Any
 import copy
 
-def _required_option(option: str, options: Dict[str, Any]) -> Any:
+def _required_option(option: str, options: dict[str, Any]) -> Any:
     """Returns the option value, or raises an error if the option is not present."""
     if option not in options:
         raise KeyError(f"Campaign preset is missing required option \"{option}\".")
     return options.pop(option)
 
-def _validate_option(option: str, options: Dict[str, str], default: str, valid_values: List[str]) -> str:
+def _validate_option(option: str, options: dict[str, str], default: str, valid_values: list[str]) -> str:
     """Returns the option value if it is present and valid, the default if it is not present, or raises an error if it is present but not valid."""
     result = options.pop(option, default)
     if result not in valid_values:
         raise ValueError(f"Preset option \"{option}\" received unknown value \"{result}\".")
     return result
 
-def make_golden_path(options: Dict[str, Any]) -> Dict[str, Any]:
-    chain_name_options = ['Mar Sara', 'Agria', 'Redstone', 'Meinhoff', 'Haven', 'Tarsonis', 'Valhalla', 'Char',
-                          'Umoja', 'Kaldir', 'Zerus', 'Skygeirr Station', 'Dominion Space', 'Korhal',
-                          'Aiur', 'Glacius', 'Shakuras', 'Ulnar', 'Slayn',
-                          'Antiga', 'Braxis', 'Chau Sara', 'Moria', 'Tyrador', 'Xil', 'Zhakul',
-                          'Azeroth', 'Crouton', 'Draenor', 'Sanctuary']
-    
+def make_golden_path(options: dict[str, Any]) -> dict[str, Any]:
+    chain_name_options = [
+        'Mar Sara', 'Agria', 'Redstone', 'Meinhoff', 'Haven', 'Tarsonis', 'Valhalla', 'Char',
+        'Umoja', 'Kaldir', 'Zerus', 'Skygeirr Station', 'Dominion Space', 'Korhal',
+        'Aiur', 'Glacius', 'Shakuras', 'Ulnar', 'Slayn',
+        'Antiga', 'Braxis', 'Chau Sara', 'Moria', 'Tyrador', 'Xil', 'Zhakul',
+        'Azeroth', 'Crouton', 'Draenor', 'Sanctuary'
+    ]
+
     size = max(_required_option("size", options), 4)
     keys_option_values = ["none", "layouts", "missions", "progressive_layouts", "progressive_missions", "progressive_per_layout"]
     keys_option = _validate_option("keys", options, "none", keys_option_values)
@@ -39,11 +41,11 @@ def make_golden_path(options: Dict[str, Any]) -> Dict[str, Any]:
             self.padding = 0
             self.missions_remaining = missions_remaining
             self.mission_counter = 1
-        
+
         def add_mission(self, chain: int, required_missions: int = 0, *, is_final: bool = False):
             if self.missions_remaining == 0 and not is_final:
                 return
-            
+
             self.mission_counter += 1
             self.chain_lengths[chain] += 1
             self.missions_remaining -= 1
@@ -55,7 +57,7 @@ def make_golden_path(options: Dict[str, Any]) -> Dict[str, Any]:
         def add_chain(self):
             self.chain_lengths.append(0)
             self.chain_padding.append(self.padding)
-    
+
     campaign = Campaign(size - 2)
     current_required_missions = 0
     main_chain_length = 0

--- a/worlds/sc2/mission_order/presets_static.py
+++ b/worlds/sc2/mission_order/presets_static.py
@@ -1,10 +1,15 @@
-from typing import Dict, Any, Callable, List, Tuple
+from typing import Any, Callable, TYPE_CHECKING
 import copy
 
 from ..mission_groups import MissionGroupNames
 from ..mission_tables import SC2Mission, SC2Campaign
 
-preset_mini_wol_with_prophecy = {
+
+if TYPE_CHECKING:
+    from .types import CampaignDict, EntryRuleDict
+
+
+preset_mini_wol_with_prophecy: 'CampaignDict' = {
     "global": {
         "type": "column",
         "mission_pool": [
@@ -94,7 +99,7 @@ preset_mini_prophecy["Prophecy"]["type"] = "gauntlet"
 preset_mini_prophecy["Prophecy"]["display_name"] = ""
 preset_mini_prophecy["Prophecy"]["missions"].append({ "index": "entrances", "entry_rules": [] })
 
-preset_mini_hots = {
+preset_mini_hots: 'CampaignDict' = {
     "global": {
         "type": "column",
         "mission_pool": [
@@ -171,7 +176,7 @@ preset_mini_hots = {
     }
 }
 
-preset_mini_lotv_prologue = {
+preset_mini_lotv_prologue: 'CampaignDict' = {
     "min_difficulty": "easy",
     "Prologue": {
         "display_name": "",
@@ -187,7 +192,7 @@ preset_mini_lotv_prologue = {
     }
 }
 
-preset_mini_lotv = {
+preset_mini_lotv: 'CampaignDict' = {
     "global": {
         "type": "column",
         "mission_pool": [
@@ -266,7 +271,7 @@ preset_mini_lotv = {
     }
 }
 
-preset_mini_lotv_epilogue = {
+preset_mini_lotv_epilogue: 'CampaignDict' = {
     "min_difficulty": "very hard",
     "Epilogue": {
         "display_name": "",
@@ -282,7 +287,7 @@ preset_mini_lotv_epilogue = {
     }
 }
 
-preset_mini_nco = {
+preset_mini_nco: 'CampaignDict' = {
     "min_difficulty": "easy",
     "global": {
         "type": "column",
@@ -319,7 +324,7 @@ preset_mini_nco = {
     },
 }
 
-preset_wol_with_prophecy = {
+preset_wol_with_prophecy: 'CampaignDict' = {
     "global": {
         "type": "column",
         "mission_pool": [
@@ -448,7 +453,7 @@ preset_prophecy["Prophecy"]["type"] = "gauntlet"
 preset_prophecy["Prophecy"]["display_name"] = ""
 preset_prophecy["Prophecy"]["missions"].append({ "index": "entrances", "entry_rules": [] })
 
-preset_hots = {
+preset_hots: 'CampaignDict' = {
     "global": {
         "type": "column",
         "mission_pool": [
@@ -497,7 +502,7 @@ preset_hots = {
             {
                 "rules": [
                     { "scope": "../Kaldir" },
-                    { "scope": "../Char" }
+                    { "scope": "../Char" },
                 ],
                 "amount": 1
             },
@@ -550,7 +555,7 @@ preset_hots = {
     }
 }
 
-preset_lotv_prologue = {
+preset_lotv_prologue: 'CampaignDict' = {
     "min_difficulty": "easy",
     "Prologue": {
         "display_name": "",
@@ -569,7 +574,7 @@ preset_lotv_prologue = {
     }
 }
 
-preset_lotv = {
+preset_lotv: 'CampaignDict' = {
     "global": {
         "type": "column",
         "mission_pool": [
@@ -695,7 +700,7 @@ preset_lotv = {
     }
 }
 
-preset_lotv_epilogue = {
+preset_lotv_epilogue: 'CampaignDict' = {
     "min_difficulty": "very hard",
     "Epilogue": {
         "display_name": "",
@@ -714,7 +719,7 @@ preset_lotv_epilogue = {
     }
 }
 
-preset_nco = {
+preset_nco: 'CampaignDict' = {
     "min_difficulty": "easy",
     "global": {
         "type": "column",
@@ -760,7 +765,7 @@ preset_nco = {
     },
 }
 
-def _build_static_preset(preset: Dict[str, Any], options: Dict[str, Any]) -> Dict[str, Any]:
+def _build_static_preset(preset: 'CampaignDict', options: dict[str, Any]) -> dict[str, Any]:
     # Raceswap shuffling
     raceswaps = options.pop("shuffle_raceswaps", False)
     if not isinstance(raceswaps, bool):
@@ -774,14 +779,15 @@ def _build_static_preset(preset: Dict[str, Any], options: Dict[str, Any]) -> Dic
         for layout in preset.values():
             if type(layout) == dict:
                 # Currently mission pools in layouts are always ["X campaign missions", "~ raceswap missions"]
-                layout_mission_pool: List[str] = layout.get("mission_pool", None)
+                layout_mission_pool: list[str] | None = layout.get("mission_pool", None)
                 if layout_mission_pool is not None:
                     layout_mission_pool.pop()
                     layout["mission_pool"] = layout_mission_pool
                 if "missions" in layout:
                     for slot in layout["missions"]:
                         # Currently mission pools in slots are always strings
-                        slot_mission_pool: str = slot.get("mission_pool", None)
+                        slot_mission_pool = slot.get("mission_pool", None)
+                        assert not isinstance(slot_mission_pool, (list, set))
                         # Identify raceswappable missions by their race in brackets
                         if slot_mission_pool is not None and slot_mission_pool[-1] == ")":
                             mission_name = slot_mission_pool[:slot_mission_pool.rfind("(")]
@@ -812,7 +818,7 @@ def _build_static_preset(preset: Dict[str, Any], options: Dict[str, Any]) -> Dic
             f"Preset option \"missions\" received unknown value \"{missions}\".\n"
             "Valid values are: random, vanilla, vanilla_shuffled"
         )
-    
+
     # Key rule selection
     keys = options.pop("keys", "none")
     if keys == "layouts":
@@ -872,16 +878,16 @@ def _build_static_preset(preset: Dict[str, Any], options: Dict[str, Any]) -> Dic
             f"Preset option \"keys\" received unknown value \"{keys}\".\n"
             "Valid values are: none, missions, layouts, progressive_missions, progressive_layouts, progressive_per_layout"
         )
-    
+
     return preset
 
-def _remove_key_rules(entry_rules: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+def _remove_key_rules(entry_rules: list['EntryRuleDict']) -> list['EntryRuleDict']:
     return [rule for rule in entry_rules if not ("items" in rule and "Key" in rule["items"])]
 
-def _make_key_rules_progressive(entry_rules: List[Dict[str, Any]], track: int) -> List[Dict[str, Any]]:
+def _make_key_rules_progressive(entry_rules: list['EntryRuleDict'], track: int) -> list['EntryRuleDict']:
     for rule in entry_rules:
         if "items" in rule and "Key" in rule["items"]:
-            new_items: Dict[str, Any] = {}
+            new_items: dict[str, Any] = {}
             for (item, amount) in rule["items"].items():
                 if item == "Key":
                     new_items["Progressive Key"] = track
@@ -890,11 +896,11 @@ def _make_key_rules_progressive(entry_rules: List[Dict[str, Any]], track: int) -
             rule["items"] = new_items
     return entry_rules
 
-def static_preset(preset: Dict[str, Any]) -> Callable[[Dict[str, Any]], Dict[str, Any]]:
+def static_preset(preset: dict[str, Any]) -> Callable[[dict[str, Any]], 'CampaignDict']:
     return lambda options: _build_static_preset(copy.deepcopy(preset), options)
 
-def get_used_layout_names() -> Dict[SC2Campaign, Tuple[int, List[str]]]:
-    campaign_to_preset: Dict[SC2Campaign, Dict[str, Any]] = {
+def get_used_layout_names() -> dict[SC2Campaign, tuple[int, list[str]]]:
+    campaign_to_preset: dict[SC2Campaign, 'CampaignDict'] = {
         SC2Campaign.WOL: preset_wol_with_prophecy,
         SC2Campaign.PROPHECY: preset_prophecy,
         SC2Campaign.HOTS: preset_hots,
@@ -903,7 +909,7 @@ def get_used_layout_names() -> Dict[SC2Campaign, Tuple[int, List[str]]]:
         SC2Campaign.EPILOGUE: preset_lotv_epilogue,
         SC2Campaign.NCO: preset_nco
     }
-    campaign_to_layout_names: Dict[SC2Campaign, Tuple[int, List[str]]] = { SC2Campaign.GLOBAL: (0, []) }
+    campaign_to_layout_names: dict[SC2Campaign, tuple[int, list[str]]] = { SC2Campaign.GLOBAL: (0, []) }
     for campaign in SC2Campaign:
         if campaign == SC2Campaign.GLOBAL:
             continue

--- a/worlds/sc2/mission_order/types.py
+++ b/worlds/sc2/mission_order/types.py
@@ -1,0 +1,69 @@
+"""
+Types used throughout the mission order package.
+"""
+
+from typing import TypedDict, Literal, NotRequired, Required, final
+
+
+@final
+class SubRuleEntryRuleDict(TypedDict):
+    rules: list['EntryRuleDict']
+    amount: NotRequired[int]
+
+
+@final
+class MissionCountEntryRuleDict(TypedDict):
+    scope: str
+    amount: int
+
+
+@final
+class BeatMissionsEntryRuleDict(TypedDict):
+    scope: list[str] | str
+
+
+@final
+class ItemsEntryRuleDict(TypedDict):
+    items: dict[str, int]
+
+
+EntryRuleDict = SubRuleEntryRuleDict | MissionCountEntryRuleDict | BeatMissionsEntryRuleDict | ItemsEntryRuleDict
+DifficultyType = Literal["relative", "starter", "easy", "medium", "hard", "very hard"]
+
+
+class MissionSlotDict(TypedDict, total=False):
+    index: Required[int | str | list[str | int]]
+    entrance: bool
+    exit: bool
+    goal: bool
+    empty: bool
+    next: list[int | str]
+    entry_rules: list[EntryRuleDict]
+    mission_pool: set[str] | list[str] | str
+    difficulty: DifficultyType
+    victory_cache: int
+    heroes: list[str]
+
+
+class LayoutDict(TypedDict, total=False):
+    # Naming
+    display_name: str | list[str]
+    unique_name: bool
+    # Layout Type
+    type: Literal["column", "grid", "hopscotch", "gauntlet", "blitz", "canvas"]
+    size: int
+    # Links
+    exit: bool
+    goal: bool
+    entry_rules: list[EntryRuleDict]
+    unique_progression_track: int
+    # Mission pool
+    mission_pool: list[str]
+    min_difficulty: DifficultyType
+    max_difficulty: DifficultyType
+    # missions
+    missions: list[MissionSlotDict]
+
+
+# Note(mm): extra_items added in 3.15 to express the layout name keys, but that's not available to AP yet.
+CampaignDict = dict[str, LayoutDict]


### PR DESCRIPTION
## What is this fixing or adding?
I had to touch the mission_order package a bit as part of the logic PR #70, and the constant disco lights whenever I ran mypy were bugging me. This doesn't resolve everything (that's for one of the _next_ big reworks, for option processing/error handling in mission order generation), but it resolves a lot and should make the future rework easier.

Behaviour should be the same, this mostly changes type annotations:
* Removing a lot of those outdated `typing.{Dict, Set, List, Tuple}` references in favour of `dict`, `set`, `list`, `tuple`
* Updated many `type(value) == <type>` checks to `isinstance(value, <type>)` for proper type narrowing
* Added typed dicts in a new types.py file to track the types of keys in the option as much as possible.
  * This mostly impacted the typing of the presets
  * This should have no runtime cost as it's never imported at runtime
  * Note `CampaignDict` doesn't fully capture everything; right now the actual type is a blend of preset string keys and other, arbitrary strings mapping to a different type. There's no way to represent that in Python <3.15 unfortunately, though [PEP 0728](https://peps.python.org/pep-0728/) adds the necessary feature in 3.15 so there's a light at the end of the tunnel

## How was this tested?
Ran mypy. Ran all unit tests

## If this makes graphical changes, please attach screenshots.
None.